### PR TITLE
remove creation of nojekyll file

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -64,7 +64,6 @@ clean:
 .PHONY: html
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
-	touch $(BUILDDIR)/html/.nojekyll
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 


### PR DESCRIPTION
A .nojekyll file was being created in each html build to bypass Jekyll processing by Github Pages, which is unnecessary when using Sphinx. 

### Description
I removed the .nojekyll file creation for html builds in the Makefile in the docs directory. 

### Motivation and Context
We are converting to readthedocs so creating a .nojekyll file to bypass Github Pages processing is unnecessary.

### How Has This Been Tested?
Can still successfully build html pages in the _build directory generated by Sphinx. 

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation (a change to man pages or other documentation)

### Checklist:
- [X] My code follows the UnifyCR code style requirements.
- [X] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.