### PR TITLE
Add Travis-CI style and build check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: c
+sudo: required
+before_install:
+    # The default environment variable $CC is known to interfere with
+    # MPI projects.
+    - test -n $CC && unset CC
+    - sudo apt-get -qq update
+    - sudo apt-get install --yes -qq build-essential autoconf libtool
+    - sudo apt-get install --yes -qq libleveldb1 libleveldb-dev
+    - sudo apt-get install --yes -qq libopenmpi-dev openmpi-bin
+script:
+    - sh autogen.sh && ./configure && make
+    - make checkstyle

--- a/scripts/checkpatch.sh
+++ b/scripts/checkpatch.sh
@@ -20,8 +20,6 @@ checkpatch_ignore+=",CODE_INDENT"       # Don't require tabs for indentation
 checkpatch_ignore+=",MISSING_SIGN_OFF"  # No Signed-off-by: in commit msg
 checkpatch_ignore+=",FILE_PATH_CHANGES" # Don't nag about updating MAINTAINERS
 
-# Allow spaces for indentation.
-# Don't require Signed-off-by: in commit message.
 checkpatch_cmd+=" --ignore $checkpatch_ignore"
 
 # Suppress summary warning about white space errors.
@@ -32,12 +30,12 @@ checkpatch_cmd+=" --no-tree"
 
 #
 # Check the tip of the current branch by if no argument is given.
-# Otherwise check the given git revision, e.g. to check the previous
-# commit:
+# Otherwise check the given git revision, e.g. to check the all
+# patches ahead of origin/dev:
 #
-#    ./checkpatch.sh HEAD^
+#    ./checkpatch.sh origin/dev..HEAD
 #
-revisions=${1:-HEAD}
+revisions=${1:-"HEAD^..HEAD"}
 
 #
 # If we're reading from a pipe then pass input directly into
@@ -46,7 +44,7 @@ revisions=${1:-HEAD}
 if [ ! -t 0 ] ; then
     show_patch_cmd="cat"
 else
-    show_patch_cmd="git show $revisions"
+    show_patch_cmd="git format-patch -k --stdout $revisions"
 fi
 
 $show_patch_cmd | $checkpatch_cmd


### PR DESCRIPTION
### Description

Add a skeleton .travis.yml file that runs the code style
checker and builds the project. This can be later extended to
run a test suite. A UnifyCR project maintainer just needs to
log in to http://travis-ci.org and enable testing for the
LLNL/UnifyCR repo. (Once the repo is made public, that is.
While LLNL/UnifyCR is still private we would have to use
http://travis-ci.com instead.)

Update checkpatch.sh to use 'git format-patch' instead of
'git show' to produce patches for checkpatch.pl. The output
of format-patch is more in line with what checkpatch.pl expects.
In particular, commit messages are not indented and it allows
one to check a whole patch stack by specifying a revision range,
e.g.: ./scripts/checkpatch.sh origin/dev..HEAD

Remove redundant comment in checkpatch.sh.

### Motivation and Context

Automated testing is great!
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
I tested it against my private fork. The build will fail until we merge
the build system updates in #10.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted.
