### PR TITLE
Build system fixes for leveldb support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -138,7 +138,11 @@ AC_CHECK_HEADERS(mntent.h sys/mount.h)
 
 # check leveldb
 PKG_CHECK_MODULES([LEVELDB], [leveldb], ,
-                  AC_MSG_ERROR(['leveldb is required to build unifycr.']))
+    AC_CHECK_LIB([leveldb], [leveldb_create_default_env],
+        [AC_SUBST([LEVELDB_LIBS], [-lleveldb])
+         AC_SUBST([LEVELDB_CFLAGS], [-I/usr/include/leveldb])
+        ],
+        AC_MSG_ERROR(['leveldb is required to build unifycr.'])))
 
 # libc functions wrapped by unifycr
 

--- a/server/src/Makefile.am
+++ b/server/src/Makefile.am
@@ -12,8 +12,8 @@ unifycrd_SOURCES = arraylist.c \
 
 unifycrd_LDFLAGS = -static
 
-unifycrd_LDADD = -lpthread -lm -lstdc++ -lrt \
-                 $(top_srcdir)/meta/src/libmdhim.a \
+unifycrd_LDADD = $(top_srcdir)/meta/src/libmdhim.a \
+                 -lpthread -lm -lstdc++ -lrt \
                  $(LEVELDB_LIBS)
 
 noinst_HEADERS = arraylist.h \


### PR DESCRIPTION
### Description

These updates allow UnifyCR to build on Ubuntu 14.04 and
16.04 with the vendor-provided leveldb libraries. This
will be helpful for automated testing under Travis-CI.

- Update the autoconf check to fall back to AC_CHECK_LIB
  if PKG_CHECK_MODULES doesn't find the packaged version
  of leveldb. This is needed for packages that don't
  provide a pkgconfig file, as is the case for Ubuntu.
  AC_CHECK_LIB tests whether a library is available by
  trying to link a test program that calls a given
  function.

- Specify libraries in the proper order when linking
  unifycrd. System libraries such as -lm should follow
  everything else on the link line. Without this, I was
  getting the error:
  undefined reference to symbol 'trunc@@GLIBC_2.2.5'

### Motivation and Context

* Improve portability.
* Enable automated testing with Travis-CI.

### How Has This Been Tested?

Tested by hand on my Ubuntu 16.04 desktop and in the Ubuntu 14.04
instance provided by Travis CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted.
