### PR TITLE
Fix up docs/Makefile issues

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -9,11 +9,13 @@ BUILDDIR      = _build
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
-    $(error The '$(SPHINXBUILD)' command was not found. Make sure you have 
-Sphinx installed, then set the SPHINXBUILD environment variable to point to the 
-full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the 
-directory with the executable to your PATH. If you don\'t have Sphinx 
-installed, grab it from http://sphinx-doc.org/)
+    $(info The '$(SPHINXBUILD)' command was not found. Make sure you have)
+    $(info Sphinx installed, then set the SPHINXBUILD environment variable)
+    $(info to point to the full path of the '$(SPHINXBUILD)' executable.)
+    $(info Alternatively you can add the directory with the executable to)
+    $(info your PATH. If you don\'t have Sphinx installed, grab it from)
+    $(info http://sphinx-doc.org/)
+    $(error missing '$(SPHINXBUILD)')
 endif
 
 # Internal variables.
@@ -40,7 +42,7 @@ help:
 	@echo "  latex      to make LaTeX files, you can set PAPER=a4 or " \
               "PAPER=letter"
 	@echo "  latexpdf   to make LaTeX files and run them through pdflatex"
-	@echo "  latexpdfja to make LaTeX files and run them through " \   
+	@echo "  latexpdfja to make LaTeX files and run them through " \
 	      "platex/dvipdfmx"
 	@echo "  text       to make text files"
 	@echo "  man        to make manual pages"


### PR DESCRIPTION
### Description

Line-wrapping of an error message introduced a syntax error for the
$(error) function which doesn't handle multi-line input:

 Makefile:12: *** unterminated call to function 'error': missing ')'. Stop.

Fix this by making multiple calls to the $(info) function to display
the formatted error message.

Trailing whitespace after an escape character caused the string
on the next line to be interpreted as a shell command, which
caused this 'make help' error:

 "platex/dvipdfmx"
 /bin/sh: 1: platex/dvipdfmx: not found
 Makefile:33: recipe for target 'help' failed
 make: *** [help] Error 127

### Motivation and Context
fix documentation build issue
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
manually

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted.
