### PR TITLE
Fix wrong style error for unwrapped commit message

### DIFF
--- a/scripts/checkpatch.sh
+++ b/scripts/checkpatch.sh
@@ -44,7 +44,7 @@ revisions=${1:-"HEAD^..HEAD"}
 if [ ! -t 0 ] ; then
     show_patch_cmd="cat"
 else
-    show_patch_cmd="git format-patch -k --stdout $revisions"
+    show_patch_cmd="git format-patch -p -k --stdout $revisions"
 fi
 
 $show_patch_cmd | $checkpatch_cmd


### PR DESCRIPTION
### Description

The checkpatch.sh style checker incorrectly flags
commit description lines that are too long. The default
'git format-patch' output includes diff stats that
checkpatch.pl is interpreting as part of the commit
message. Add the 'git format-patch -p' option to
generate plain diffs without diff stats.

<!--- Provide a general summary of your changes in the Title above -->


<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
False style warnings are no fun.

### How Has This Been Tested?
Manually.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
