### PR TITLE
Add autoconf check for openssl/md5.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -42,6 +42,8 @@ AC_CHECK_HEADERS([fcntl.h limits.h stdlib.h string.h sys/socket.h sys/time.h])
 AC_CHECK_HEADERS([unistd.h arpa/inet.h inttypes.h netdb.h netinet/in.h])
 AC_CHECK_HEADERS([stddef.h stdint.h strings.h syslog.h])
 AC_CHECK_HEADERS([inttypes.h wchar.h wctype.h])
+AC_CHECK_HEADER([openssl/md5.h], [], [AC_MSG_FAILURE([
+        *** openssl/md5.h missing, openssl-devel package required])])
 
 # Checks for library functions.
 AC_FUNC_MALLOC


### PR DESCRIPTION
### Description
The header openssl/md5.h is required by client/src/unifycr.c. Add
an autoconf check to make configure fail if it's not present.

### Motivation and Context
More robust configure time checking for dependencies.

Fixes #24

### How Has This Been Tested?

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
