### PR TITLE
Fix minor checkpatch issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ before_install:
     - sudo apt-get install --yes -qq libopenmpi-dev openmpi-bin
 script:
     - sh autogen.sh && ./configure && make
-    - make checkstyle
+    - ./scripts/checkpatch.sh

--- a/scripts/checkpatch.sh
+++ b/scripts/checkpatch.sh
@@ -17,8 +17,9 @@ checkpatch_cmd=$basedir/linux_kernel_checkpatch/checkpatch.pl
 #
 checkpatch_ignore="LEADING_SPACE"       # Allow spaces for indentation
 checkpatch_ignore+=",CODE_INDENT"       # Don't require tabs for indentation
-checkpatch_ignore+=",MISSING_SIGN_OFF"  # No Signed-off-by: in commit msg
+checkpatch_ignore+=",MISSING_SIGN_OFF"  # Signed-off-by: line is optional
 checkpatch_ignore+=",FILE_PATH_CHANGES" # Don't nag about updating MAINTAINERS
+checkpatch_ignore+=",CONST_STRUCT"      # Don't nag about const structs
 
 checkpatch_cmd+=" --ignore $checkpatch_ignore"
 


### PR DESCRIPTION
### Description
- Have travis-ci run ./scripts/checkpatch.sh directly instead
  of 'make checkpatch' so the style-checker can still run if
  the configure script fails to generate a Makefile.

- Add CONST_STRUCT to the checkpatch.pl message-type ignore list.
  Those checks are specific to the Linux kernel and will cause false
  style warnings for UnifyCR.

- Revise Signed-off-by: comment for clarity.

<!--- Provide a general summary of your changes in the Title above -->


<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
