### PR TITLE
Use spack for leveldb and gotcha in travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,25 @@
 language: c
 sudo: required
+
 before_install:
-    # The default environment variable $CC is known to interfere with
-    # MPI projects.
-    - test -n $CC && unset CC
-    - sudo apt-get -qq update
-    - sudo apt-get install --yes -qq build-essential autoconf libtool
-    - sudo apt-get install --yes -qq libleveldb1 libleveldb-dev
-    - sudo apt-get install --yes -qq libopenmpi-dev openmpi-bin
+  # The default environment variable $CC is known to interfere with
+  # MPI projects.
+  - test -n $CC && unset CC
+  - sudo apt-get -qq update
+  - sudo apt-get install --yes -qq build-essential autoconf libtool
+  - sudo apt-get install --yes -qq libopenmpi-dev openmpi-bin
+  - (cd $HOME/spack; git describe) || git clone https://github.com/spack/spack $HOME/spack
+  - $HOME/spack/bin/spack install leveldb
+  - $HOME/spack/bin/spack install gotcha
+  - $HOME/spack/bin/spack install environment-modules
+
+cache:
+  directories:
+    - $HOME/spack
+
 script:
-    - sh autogen.sh && ./configure && make
-    - ./scripts/checkpatch.sh
+  - . $HOME/spack/share/spack/setup-env.sh
+  - spack load environment-modules
+  - source <(spack module loads gotcha leveldb)
+  - sh autogen.sh && ./configure && make
+  - ./scripts/checkpatch.sh


### PR DESCRIPTION
### Description

Install spack package manager and use it to install leveldb and
gotcha library dependencies. Add options to .travis.yml to cache
the spack directory. The first build will take ~20 minutes to
build leveldb and gotcha, but subsequent build will reuse the
build results.

Decrease indentation width from 4 to 2 spaces in .travis.yml.

<!--- Provide a general summary of your changes in the Title above -->

<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
