### PR TITLE
setbuf should return void

### DIFF
--- a/client/src/unifycr-stdio.h
+++ b/client/src/unifycr-stdio.h
@@ -52,7 +52,7 @@ UNIFYCR_DECL(fclose, int, (FILE *stream));
 UNIFYCR_DECL(fflush, int, (FILE *stream));
 UNIFYCR_DECL(fopen, FILE*, (const char *path, const char *mode));
 UNIFYCR_DECL(freopen, FILE*, (const char *path, const char *mode, FILE *stream));
-UNIFYCR_DECL(setbuf, void*, (FILE *stream, char* buf));
+UNIFYCR_DECL(setbuf, void, (FILE *stream, char* buf));
 UNIFYCR_DECL(setvbuf, int, (FILE *stream, char* buf, int type, size_t size));
 
 UNIFYCR_DECL(fprintf,  int, (FILE* stream, const char* format, ...));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Declaration for setbuf was specifying a return type of void* instead of void.

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
