### PR TITLE
autoconf: generate version from most recent tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ before_cache:
   - rm -f $HOME/spack/opt/spack/.spack-db/prefix_lock
 
 script:
+  # Force git to update the shallow clone and include tags so git-describe works
+  - git fetch --unshallow --tags
   - sh autogen.sh && ./configure && make
   - make distcheck
   - ./scripts/checkpatch.sh || test "$TEST_CHECKPATCH_ALLOW_FAILURE" = yes

--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,10 @@ dnl This file is a part of UnifyCR. Please see LICENSE for the license
 dnl information.
 dnl Process this file with autoconf to produce a configure script.
 
-AC_INIT([unifycr], [0.1.0], [unifycr@llnl.gov])
+AC_INIT([unifycr],
+        m4_esyscmd([git describe --always |
+                   awk '/.*/{sub(/^v/,""); printf "%s",$1; exit}']),
+        [unifycr@llnl.gov])
 AC_CONFIG_SRCDIR([configure.ac])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])


### PR DESCRIPTION
Update the AC_INIT macro to generate a version string based on the most
recent annotated tag using 'git describe'. The practical consequence of
this is that version portion of 'make dist' tarball names will reflect the
git commit that the tarball is based on. This also has the advantage of
not needing to update configure.ac every time we tag a release.

If the most recent tag points to the most recent commit, then only the
version number is shown. Otherwise, the version number is suffixed with the
number of additional commits on top of the tag object and the abbreviated
object name of the most recent commit.

For example, the distribution tarball for tag v0.1.0 would be named
unifycr-0.1.0.tar.gz, whereas a distribution tarball from a later untagged
commit might be named something like unifycr-0.1.0-88-gc1de261.tar.gz.