### PR TITLE
avoid conflicts on runstate file

### DIFF
--- a/common/src/unifycr_configurator.h
+++ b/common/src/unifycr_configurator.h
@@ -80,7 +80,7 @@
     UNIFYCR_CFG(meta, db_path, STRING, META_DEFAULT_DB_PATH, "metadata database path", NULL) \
     UNIFYCR_CFG(meta, server_ratio, INT, META_DEFAULT_SERVER_RATIO, "metadata server ratio", NULL) \
     UNIFYCR_CFG(meta, range_size, INT, META_DEFAULT_RANGE_SZ, "metadata range size", NULL) \
-    UNIFYCR_CFG_CLI(runstate, dir, STRING, RUNDIR/unifycr, "runstate file directory", configurator_directory_check, 'R', "specify full path to directory to contain runstate file") \
+    UNIFYCR_CFG_CLI(runstate, dir, STRING, RUNDIR, "runstate file directory", configurator_directory_check, 'R', "specify full path to directory to contain server runstate file") \
     UNIFYCR_CFG(shmem, chunk_bits, INT, UNIFYCR_CHUNK_BITS, "shared memory data chunk size in bits (i.e., size=2^bits)", NULL) \
     UNIFYCR_CFG(shmem, chunk_mem, INT, UNIFYCR_CHUNK_MEM, "shared memory segment size for data chunks", NULL) \
     UNIFYCR_CFG(shmem, recv_size, INT, UNIFYCR_SHMEM_RECV_SIZE, "shared memory segment size in bytes for receiving data from delegators", NULL) \

--- a/common/src/unifycr_runstate.c
+++ b/common/src/unifycr_runstate.c
@@ -14,6 +14,7 @@ int unifycr_read_runstate(unifycr_cfg_t *cfg,
 {
     int rc = (int)UNIFYCR_SUCCESS;
     int have_path = 0;
+    int uid = (int)getuid();
     char runstate_fname[UNIFYCR_MAX_FILENAME] = {0};
 #ifdef HAVE_PMIX_H
     char *pmix_path = NULL;
@@ -43,7 +44,7 @@ int unifycr_read_runstate(unifycr_cfg_t *cfg,
                 return (int)UNIFYCR_ERROR_APPCONFIG;
             }
             snprintf(runstate_fname, sizeof(runstate_fname),
-                     "%s/%s", cfg->runstate_dir, runstate_file);
+                     "%s/%s.%d", cfg->runstate_dir, runstate_file, uid);
         }
     } else {
         snprintf(runstate_fname, sizeof(runstate_fname),
@@ -63,6 +64,7 @@ int unifycr_read_runstate(unifycr_cfg_t *cfg,
 int unifycr_write_runstate(unifycr_cfg_t *cfg)
 {
     int rc = (int)UNIFYCR_SUCCESS;
+    int uid = (int)getuid();
     FILE *runstate_fp = NULL;
     char runstate_fname[UNIFYCR_MAX_FILENAME] = {0};
 
@@ -72,7 +74,7 @@ int unifycr_write_runstate(unifycr_cfg_t *cfg)
     }
 
     snprintf(runstate_fname, sizeof(runstate_fname),
-             "%s/%s", cfg->runstate_dir, runstate_file);
+             "%s/%s.%d", cfg->runstate_dir, runstate_file, uid);
 
     runstate_fp = fopen(runstate_fname, "w");
     if (runstate_fp == NULL) {

--- a/t/0001-setup.t
+++ b/t/0001-setup.t
@@ -42,7 +42,7 @@ unifycrd_start_daemon
 # Make sure the unifycrd process starts.
 #
 if ! process_is_running unifycrd 5 ; then
-    echo not ok 1 - unifycrd running
+    echo not ok 1 - unifycrd started
     exit 1
 fi
 
@@ -58,8 +58,9 @@ fi
 #
 # Make sure unifycrd successfully generated client runstate file
 #
-if ! test -f $UNIFYCR_META_DB_PATH/unifycr-runstate.conf ; then
-    echo not ok 1 - unifycrd running
+uid=$(id -u)
+if ! test -f $UNIFYCR_META_DB_PATH/unifycr-runstate.conf.$uid ; then
+    echo not ok 1 - unifycrd runstate
     exit 1
 fi
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description

The former method of appending "unifycr" to the configured runstate directory
could lead to directory ownership conflicts. We now use the user's numeric id
in the runstate file name to avoid conflicts. 

The new default runstate file path will be `/var/tmp/unifycr-runstate.conf.<uid>`

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
