### PR TITLE
Add lua plugin for SLURM integration

### DIFF
--- a/util/plugins/slurm/README.md
+++ b/util/plugins/slurm/README.md
@@ -1,0 +1,26 @@
+### Integration with SLURM Resource Manager
+
+To enable job-level integration of UnifyCR, where the UnifyCR daemon
+is automatically launched on each node during job startup and
+terminate once the job completes, a SPANK lua plugin must be added
+to SLURM. Typically, these SPANK lua plugins are installed in
+`/etc/slurm/lua.d` Consult with your SLURM system administrator for
+more precise location information, and to make the changes described below.
+
+We provide a lua plugin that launches and terminates a UnifyCR daemon
+(i.e., `unifycrd`) on a node.
+
+Integration of the lua plugin requires placing unifycr.lua in
+`/etc/slurm/lua.`, which in most cases cannot be written to
+without root access. The SLURM lua plugin supports a new "unifycr"
+job allocation flag. Users may specify the allocation flag as an
+option to the `srun` command:
+```shell
+[prompt]$ srun -N1 -n2 --unifycr <other srun options> ./jobscript
+```
+Alternatively, the job script may contain the flag as an `#SBATCH`
+directive:
+```shell
+#! /bin/bash
+#SBATCH --unifycr
+```

--- a/util/plugins/slurm/unifycr.lua
+++ b/util/plugins/slurm/unifycr.lua
@@ -29,12 +29,12 @@ function slurm_spank_init (spank)
 end
 
 local function start_unifycr ()
-    local status = os.execute("unifycrd &")
+    local status = os.execute("/g/g0/sikich1/UnifyCR/install/bin/unifycrd &")
         return status == 0 and SPANK.SUCCESS or SPANK.FAILURE
 end
 
 local function stop_unifycr ()
-    local status = os.execute("pkill unifycrd")
+    local status = os.execute("pkill /g/g0/sikich1/UnifyCR/install/bin/unifycrd")
         return status == 0 and SPANK.SUCCESS or SPANK.FAILURE
 end
 
@@ -55,7 +55,7 @@ function slurm_spank_task_exit (spank)
 
         if spank.context == "remote" then
                 if unifycr_enabled then
-                        return stopt_unifycr ()
+                        return stop_unifycr ()
                 else
                         return SPANK.SUCCESS
                 end

--- a/util/plugins/slurm/unifycr.lua
+++ b/util/plugins/slurm/unifycr.lua
@@ -1,0 +1,65 @@
+--
+--   UnifyCR option to start unifycr daemon from within SLURM
+
+--
+--  If user requested --unifycr unifycr == true
+--
+unifycr_enabled = nil
+
+function opt_handler (val, optarg, isremote)
+    unifycr_enabled = true
+    return SPANK.SUCCESS
+end
+
+function slurm_spank_init (spank)
+    --
+    -- Register --unifycr option
+    --
+    local enable_unifycr_opt = {
+       name =    "unifycr",
+       usage =   "start and stop unifycr daemon " ..
+                 "on nodes of job before and after job runs",
+           cb =      "opt_handler"
+    }
+        local rc, err = spank:register_option (enable_unifycr_opt)
+        if not rc then
+            return SPANK.log_error ("Failed to register option")
+        end
+        return SPANK.SUCCESS
+end
+
+local function start_unifycr ()
+    local status = os.execute("unifycrd &")
+        return status == 0 and SPANK.SUCCESS or SPANK.FAILURE
+end
+
+local function stop_unifycr ()
+    local status = os.execute("pkill unifycrd")
+        return status == 0 and SPANK.SUCCESS or SPANK.FAILURE
+end
+
+function slurm_spank_task_init (spank)
+
+        if spank.context == "remote" then
+                if unifycr_enabled then
+                        return start_unifycr ()
+                else
+                        return SPANK.SUCCESS
+                end
+        end
+
+        return SPANK.SUCCESS
+end
+
+function slurm_spank_task_exit (spank)
+
+        if spank.context == "remote" then
+                if unifycr_enabled then
+                        return stopt_unifycr ()
+                else
+                        return SPANK.SUCCESS
+                end
+        end
+
+        return SPANK.SUCCESS
+end


### PR DESCRIPTION
A SLURM SPANK lua plugin that adds an option to
SLURM called unifycr. Using this option starts
and stops the unifycr daemon as the user at job
startup and termination.

This also makes the assumption currently that 'unifycrd' is installed in a default system path. The SPANK functions such as task_init and task_exit only run as the user running the job in a remote context.

Plugin still needs to be tested (in progress). 