### PR TITLE
Fix unit tests MPI launcher bug

### DIFF
--- a/t/0100-sysio-gotcha.t
+++ b/t/0100-sysio-gotcha.t
@@ -5,4 +5,4 @@
 #
 . $(dirname $0)/sharness.d/00-test-env.sh
 . $(dirname $0)/sharness.d/01-unifyfs-settings.sh
-$UNIFYFS_BUILD_DIR/t/sys/sysio-gotcha.t
+$JOB_RUN_COMMAND $UNIFYFS_BUILD_DIR/t/sys/sysio-gotcha.t

--- a/t/0200-stdio-gotcha.t
+++ b/t/0200-stdio-gotcha.t
@@ -5,4 +5,4 @@
 #
 . $(dirname $0)/sharness.d/00-test-env.sh
 . $(dirname $0)/sharness.d/01-unifyfs-settings.sh
-$UNIFYFS_BUILD_DIR/t/std/stdio-gotcha.t
+$JOB_RUN_COMMAND $UNIFYFS_BUILD_DIR/t/std/stdio-gotcha.t

--- a/t/0500-sysio-static.t
+++ b/t/0500-sysio-static.t
@@ -5,4 +5,4 @@
 #
 . $(dirname $0)/sharness.d/00-test-env.sh
 . $(dirname $0)/sharness.d/01-unifyfs-settings.sh
-$UNIFYFS_BUILD_DIR/t/sys/sysio-static.t
+$JOB_RUN_COMMAND $UNIFYFS_BUILD_DIR/t/sys/sysio-static.t

--- a/t/0600-stdio-static.t
+++ b/t/0600-stdio-static.t
@@ -5,4 +5,4 @@
 #
 . $(dirname $0)/sharness.d/00-test-env.sh
 . $(dirname $0)/sharness.d/01-unifyfs-settings.sh
-$UNIFYFS_BUILD_DIR/t/std/stdio-static.t
+$JOB_RUN_COMMAND $UNIFYFS_BUILD_DIR/t/std/stdio-static.t

--- a/t/9005-unifyfs-unmount.t
+++ b/t/9005-unifyfs-unmount.t
@@ -5,4 +5,4 @@
 #
 . $(dirname $0)/sharness.d/00-test-env.sh
 . $(dirname $0)/sharness.d/01-unifyfs-settings.sh
-$UNIFYFS_BUILD_DIR/t/unifyfs_unmount.t
+$JOB_RUN_COMMAND $UNIFYFS_BUILD_DIR/t/unifyfs_unmount.t

--- a/t/9100-metadata-api.t
+++ b/t/9100-metadata-api.t
@@ -7,4 +7,4 @@ test_description="Test Metadata API"
 # and UnifyFS runtime settings.
 #
 . $(dirname $0)/sharness.d/00-test-env.sh
-$JOB_RUN_COMMAND -n 1 $UNIFYFS_BUILD_DIR/t/server/metadata.t
+$JOB_RUN_COMMAND $UNIFYFS_BUILD_DIR/t/server/metadata.t

--- a/t/sharness.d/00-test-env.sh
+++ b/t/sharness.d/00-test-env.sh
@@ -22,7 +22,9 @@ export UNIFYFS_TEST_RUN_SCRIPT=$UNIFYFS_BUILD_DIR/t/test_run_env.sh
 #
 # Find MPI job launcher.
 #
-if test -n "$(which srun 2>/dev/null)"; then
+if test -n "$(which jsrun 2>/dev/null)"; then
+    JOB_RUN_COMMAND="jsrun -r1 -n1"
+elif test -n "$(which srun 2>/dev/null)"; then
     JOB_RUN_COMMAND="srun -n1 -N1"
 elif test -n "$(which mpirun 2>/dev/null)"; then
     JOB_RUN_COMMAND="mpirun -wd $UNIFYFS_BUILD_DIR -np 1"

--- a/t/std/stdio_suite.c
+++ b/t/std/stdio_suite.c
@@ -71,9 +71,9 @@ int main(int argc, char* argv[])
 
     fopen_fclose_test(unifyfs_root);
 
-    done_testing();
-
     MPI_Finalize();
+
+    done_testing();
 
     return 0;
 }

--- a/t/sys/sysio_suite.c
+++ b/t/sys/sysio_suite.c
@@ -81,9 +81,9 @@ int main(int argc, char* argv[])
 
     open64_test(unifyfs_root);
 
-    done_testing();
-
     MPI_Finalize();
+
+    done_testing();
 
     return 0;
 }

--- a/t/unifyfs_unmount.c
+++ b/t/unifyfs_unmount.c
@@ -28,9 +28,9 @@ int main(int argc, char* argv[])
     rc = unifyfs_unmount();
     ok(rc == 0, "unifyfs_unmount succeeds (rc=%d)", rc);
 
-    done_testing();
-
     MPI_Finalize();
+
+    done_testing();
 
     return 0;
 }


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Unit tests were set up to be run with MPI and a `JOB_RUN_COMMAND` envar set up to launch them with the proper MPI launcher, but the command wasn't being used. Tests were still passing since they were set up to run with a single process, which is what MPI defaults to when nothing is given.

This adds `jsrun` to the MPI launchers and adds `$JOB_RUN_COMMAND` to the unit testing suites. Moves `MPI_Finalize()` to being called before `done_testing()`, otherwise an MPI error occurs.

Thanks @boehms for catching this.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Ran the unit tests on multiple architectures with different MPI libraries.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyCR code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.