### PR TITLE
Allow style checker to pass on do-while loop

### DIFF
--- a/scripts/linux_kernel_checkpatch/checkpatch.pl
+++ b/scripts/linux_kernel_checkpatch/checkpatch.pl
@@ -5211,6 +5211,12 @@ sub process {
 				$allowed = 0;
 			}
 
+			# Allow while conditional that comes at end of a do-while loop
+			if ($cond =~ /^(\}\swhile)/) {
+				#print "APW: ALLOWED: cond<$cond>\n";
+				$allowed = 1;
+			}
+
 			# Allow any conditional directives
 			if ($line =~ /^(.*#)/) {
 				#print "APW: ALLOWED: pre<$1>\n";


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
@MichaelBrim discovered the style checker currently fails on a do-while loop, thinking it is the beginning of a single statement block that is missing brackets.

```
WARNING: braces {} are necessary for single statement blocks
#5233: FILE: server/src/unifycr_service_manager.c:209:
+} while (0)
 
```

This creates an allowance for that condition.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fix style checker.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Modified a file by adding some while and do-while loops. Ran checkpatch.sh before and after this change. After change, no longer failed on do-while and still fails on while loop w/out brackets.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.