### PR TITLE
Fix size bugs, add lamination with chmod/fchmod, misc fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,22 +65,9 @@ t/sys/.dirstamp
 
 # test files
 client/unifyfs-runtime-config.h
-examples/src/app-btio-gotcha
-examples/src/app-btio-static
-examples/src/app-mpiio-gotcha
-examples/src/app-mpiio-static
-examples/src/sysio-read-gotcha
-examples/src/sysio-read-static
-examples/src/app-tileio-gotcha
-examples/src/app-tileio-static
-examples/src/sysio-write-gotcha
-examples/src/sysio-write-static
-examples/src/sysio-writeread-gotcha
-examples/src/sysio-writeread-static
-examples/src/sysio-writeread2-gotcha
-examples/src/sysio-writeread2-static
-examples/src/app-hdf5-create-gotcha
-examples/src/app-hdf5-writeread-gotcha
+examples/src/*-gotcha
+examples/src/*-posix
+examples/src/*-static
 t/sys/open.t
 t/test-results/
 t/unifyfs_unmount.t

--- a/client/check_fns/unifyfs_list.txt
+++ b/client/check_fns/unifyfs_list.txt
@@ -1,4 +1,6 @@
 int UNIFYFS_WRAP(access)(const char *path, int mode)
+int UNIFYFS_WRAP(chmod)(const char *path, mode_t mode)
+int UNIFYFS_WRAP(fchmod)(int fd, mode_t mode)
 int UNIFYFS_WRAP(mkdir)(const char *path, mode_t mode)
 int UNIFYFS_WRAP(rmdir)(const char *path)
 int UNIFYFS_WRAP(rename)(const char *oldpath, const char *newpath)

--- a/client/src/gotcha_map_unifyfs_list.h
+++ b/client/src/gotcha_map_unifyfs_list.h
@@ -4,6 +4,8 @@
 #include <stdio.h>
 
 UNIFYFS_DEF(access, int, (const char* path, int mode));
+UNIFYFS_DEF(chmod, int, (const char* path, mode_t mode));
+UNIFYFS_DEF(fchmod, int, (int fd, mode_t mode));
 UNIFYFS_DEF(mkdir, int, (const char* path, mode_t mode));
 UNIFYFS_DEF(rmdir, int, (const char* path));
 UNIFYFS_DEF(rename, int, (const char* oldpath, const char* newpath));
@@ -106,6 +108,8 @@ UNIFYFS_DEF(ungetwc, wint_t, (wint_t c, FILE* stream));
 
 struct gotcha_binding_t wrap_unifyfs_list[] = {
     { "access", UNIFYFS_WRAP(access), &UNIFYFS_REAL(access) },
+    { "chmod", UNIFYFS_WRAP(chmod), &UNIFYFS_REAL(chmod) },
+    { "fchmod", UNIFYFS_WRAP(fchmod), &UNIFYFS_REAL(fchmod) },
     { "mkdir", UNIFYFS_WRAP(mkdir), &UNIFYFS_REAL(mkdir) },
     { "rmdir", UNIFYFS_WRAP(rmdir), &UNIFYFS_REAL(rmdir) },
     { "rename", UNIFYFS_WRAP(rename), &UNIFYFS_REAL(rename) },

--- a/client/src/margo_client.c
+++ b/client/src/margo_client.c
@@ -266,6 +266,7 @@ int invoke_client_metaset_rpc(unifyfs_file_attr_t* f_meta)
     in.atime    = f_meta->atime;
     in.mtime    = f_meta->mtime;
     in.ctime    = f_meta->ctime;
+    in.is_laminated = f_meta->is_laminated;
 
     LOGDBG("invoking the metaset rpc function in client");
     hret = margo_forward(handle, &in);
@@ -326,6 +327,7 @@ int invoke_client_metaget_rpc(int gfid,
         file_meta->atime = out.atime;
         file_meta->mtime = out.mtime;
         file_meta->ctime = out.ctime;
+        file_meta->is_laminated = out.is_laminated;
     }
 
     margo_free_output(handle, &out);

--- a/client/src/unifyfs-dirops.c
+++ b/client/src/unifyfs-dirops.c
@@ -127,7 +127,7 @@ DIR* UNIFYFS_WRAP(opendir)(const char* name)
          * global metadb. is it safe to invalidate the local entry and
          * re-populate with the global data?
          */
-        if (!meta->is_dir) {
+        if (!unifyfs_fid_is_dir(fid)) {
             errno = EIO;
             return NULL;
         }
@@ -146,7 +146,7 @@ DIR* UNIFYFS_WRAP(opendir)(const char* name)
         }
 
         meta = unifyfs_get_meta_from_fid(fid);
-        meta->is_dir   = 1;
+        meta->mode = (meta->mode & ~S_IFREG) | S_IFDIR; /* set as directory */
         meta->size     = sb.st_size;
         meta->chunks   = sb.st_blocks;
         meta->log_size = 0;

--- a/client/src/unifyfs-internal.h
+++ b/client/src/unifyfs-internal.h
@@ -269,7 +269,6 @@ typedef struct {
 typedef struct {
     off_t size;                      /* current file size */
     off_t log_size;                  /* real size of the file for logio*/
-    int is_dir;                      /* is this file a directory */
     pthread_spinlock_t fspinlock;    /* file lock variable */
     enum flock_enum flock_status;    /* file lock status */
 
@@ -279,6 +278,10 @@ typedef struct {
 
     off_t chunks;                   /* number of chunks allocated to file */
     off_t chunkmeta_idx;            /* starting index in unifyfs_chunkmeta */
+    int is_laminated;               /* Is this file laminated */
+    uint32_t mode;                  /* st_mode bits.  This has file
+                                     * permission info and will tell you if this
+                                     * is a regular file or directory. */
 } unifyfs_filemeta_t;
 
 /* struct used to map a full path to its local file id,
@@ -467,6 +470,9 @@ unifyfs_fd_t* unifyfs_get_filedesc_from_fd(int fd);
  * otherwise return NULL */
 unifyfs_filemeta_t* unifyfs_get_meta_from_fid(int fid);
 
+/* Given a fid, return the path.  */
+const char* unifyfs_path_from_fid(int fid);
+
 /* given an UNIFYFS error code, return corresponding errno code */
 int unifyfs_err_map_to_errno(int rc);
 
@@ -550,8 +556,7 @@ int unifyfs_fid_unlink(int fid);
 
 int unifyfs_generate_gfid(const char* path);
 
-int unifyfs_set_global_file_meta(const char* path, int fid, int gfid,
-                                 int isdir);
+int unifyfs_set_global_file_meta(int fid, int gfid);
 
 int unifyfs_get_global_file_meta(int fid, int gfid,
                                  unifyfs_file_attr_t* gfattr);

--- a/client/src/unifyfs-stdio.c
+++ b/client/src/unifyfs-stdio.c
@@ -266,10 +266,11 @@ static int unifyfs_fopen_parse_mode(
     return UNIFYFS_SUCCESS;
 }
 
-/* calls unifyfs_fid_open to open specified file in mode according to
- * fopen mode semantics, initializes outstream and returns
- * UNIFYFS_SUCCESS if successful, returns some other UNIFYFS error
- * otherwise */
+/*
+ * Calls unifyfs_fid_open() to open specified file in mode according to
+ * fopen mode semantics, initializes outstream and returns UNIFYFS_SUCCESS if
+ * successful.  Returns some other UNIFYFS/errno error otherwise.
+ */
 static int unifyfs_fopen(
     const char* path,
     const char* mode,

--- a/client/src/unifyfs-stdio.h
+++ b/client/src/unifyfs-stdio.h
@@ -104,4 +104,7 @@ UNIFYFS_DECL(getwc,     wint_t, (FILE* stream));
 UNIFYFS_DECL(putwc,     wint_t, (wchar_t c, FILE* stream));
 UNIFYFS_DECL(ungetwc,   wint_t, (wint_t c, FILE* stream));
 
+UNIFYFS_DECL(chmod,     int, (const char* path, mode_t mode));
+UNIFYFS_DECL(fchmod,    int, (int fd, mode_t mode));
+
 #endif /* UNIFYFS_STDIO_H */

--- a/common/src/err_enumerator.h
+++ b/common/src/err_enumerator.h
@@ -21,6 +21,7 @@
 
 #ifndef _UNIFYFS_ERROR_ENUMERATOR_H_
 #define _UNIFYFS_ERROR_ENUMERATOR_H_
+#include <errno.h>
 
 /**
  * @brief enumerator list expanded many times with varied ENUMITEM() definitions
@@ -91,6 +92,11 @@
 extern "C" {
 #endif
 
+/* #define __ELASTERROR if our errno.h doesn't define it for us */
+#ifndef __ELASTERROR
+#define __ELASTERROR    2000
+#endif
+
 /**
  * @brief enum for error codes
  */
@@ -98,6 +104,8 @@ typedef enum {
     UNIFYFS_INVALID_ERROR = -2,
     UNIFYFS_FAILURE = -1,
     UNIFYFS_SUCCESS = 0,
+    /* Start our error numbers after the standard errno.h ones */
+    UNIFRFS_START_OF_ERRORS = __ELASTERROR,
 #define ENUMITEM(name, desc)                    \
         UNIFYFS_ERROR_ ## name,
     UNIFYFS_ERROR_ENUMERATOR

--- a/common/src/unifyfs_client_rpcs.h
+++ b/common/src/unifyfs_client_rpcs.h
@@ -69,7 +69,8 @@ MERCURY_GEN_PROC(unifyfs_metaset_in_t,
                  ((uint64_t)(size))
                  ((sys_timespec_t)(atime))
                  ((sys_timespec_t)(mtime))
-                 ((sys_timespec_t)(ctime)))
+                 ((sys_timespec_t)(ctime))
+                 ((uint32_t)(is_laminated)))
 MERCURY_GEN_PROC(unifyfs_metaset_out_t, ((int32_t)(ret)))
 DECLARE_MARGO_RPC_HANDLER(unifyfs_metaset_rpc)
 
@@ -90,7 +91,8 @@ MERCURY_GEN_PROC(unifyfs_metaget_out_t,
                  ((uint64_t)(size))
                  ((sys_timespec_t)(atime))
                  ((sys_timespec_t)(mtime))
-                 ((sys_timespec_t)(ctime)))
+                 ((sys_timespec_t)(ctime))
+                 ((uint32_t)(is_laminated)))
 DECLARE_MARGO_RPC_HANDLER(unifyfs_metaget_rpc)
 
 /* unifyfs_fsync_rpc (client => server)

--- a/configure.ac
+++ b/configure.ac
@@ -194,6 +194,8 @@ AM_CONDITIONAL([HAVE_HDF5], [test x$with_hdf5 = xyes])
 # libc functions wrapped by unifyfs
 
 CP_WRAPPERS+="-Wl,-wrap,access"
+CP_WRAPPERS+=",-wrap,chmod"
+CP_WRAPPERS+=",-wrap,fchmod"
 CP_WRAPPERS+=",-wrap,lio_listio"
 CP_WRAPPERS+=",-wrap,mkdir"
 CP_WRAPPERS+=",-wrap,rmdir"

--- a/examples/src/Makefile.am
+++ b/examples/src/Makefile.am
@@ -13,7 +13,9 @@ libexec_PROGRAMS = \
   app-mpiio-gotcha app-mpiio-static \
   app-btio-gotcha app-btio-static \
   app-tileio-gotcha app-tileio-static \
-  transfer-gotcha transfer-static
+  transfer-gotcha transfer-static \
+  size-gotcha size-static \
+  chmod-gotcha chmod-static
 
 if HAVE_FORTRAN
 libexec_PROGRAMS += \
@@ -258,4 +260,23 @@ transfer_static_CPPFLAGS = $(test_cppflags)
 transfer_static_LDADD    = $(test_static_ldadd)
 transfer_static_LDFLAGS  = $(test_static_ldflags)
 
+size_gotcha_SOURCES  = size.c testutil.c
+size_gotcha_CPPFLAGS = $(test_cppflags)
+size_gotcha_LDADD    = $(test_gotcha_ldadd)
+size_gotcha_LDFLAGS  = $(test_gotcha_ldflags)
+
+size_static_SOURCES  = size.c testutil.c
+size_static_CPPFLAGS = $(test_cppflags)
+size_static_LDADD    = $(test_static_ldadd)
+size_static_LDFLAGS  = $(test_static_ldflags)
+
+chmod_gotcha_SOURCES  = chmod.c testutil.c
+chmod_gotcha_CPPFLAGS = $(test_cppflags)
+chmod_gotcha_LDADD    = $(test_gotcha_ldadd)
+chmod_gotcha_LDFLAGS  = $(test_gotcha_ldflags)
+
+chmod_static_SOURCES  = chmod.c testutil.c
+chmod_static_CPPFLAGS = $(test_cppflags)
+chmod_static_LDADD    = $(test_static_ldadd)
+chmod_static_LDFLAGS  = $(test_static_ldflags)
 

--- a/examples/src/chmod.c
+++ b/examples/src/chmod.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2019, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2019, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyFS.
+ * For details, see https://github.com/LLNL/UnifyFS.
+ * Please read https://github.com/LLNL/UnifyFS/LICENSE for full license text.
+ *
+ * Test chmod() and fchmod()
+ *
+ * Test description:
+ * 1. Make an empty file.
+ * 2. Try setting all the permission bits
+ * 3. Verify you see the bits in stat()
+ * 4. Use chmod() to remove the write bits to laminate it
+ * 5. Check file is laminated after
+ * 6. Make another empty file
+ * 7. Laminate it using fchmod()
+ * 8. Check file is laminated after
+ */
+#include "testutil.h"
+
+int do_test(test_cfg* cfg)
+{
+    char* file;
+    int rank = cfg->rank;
+    int fd;
+
+    file = mktemp_cmd(cfg, "/unifyfs");
+    assert(file);
+
+    test_print(cfg, "Create empty file %s", file);
+    test_print(cfg, "Before lamination stat() is:");
+    stat_cmd(cfg, file);
+
+    test_print(cfg, "Try setting all the bits.  stat() is:");
+    chmod(file, 0777);
+    stat_cmd(cfg, file);
+
+    if (rank == cfg->n_ranks - 1) {
+        test_print(cfg, "I'm the last rank, so I'll laminate the file");
+
+        sync_cmd(cfg, file);
+        /* laminate by setting permissions to read-only */
+        chmod(file, 0444);
+
+        test_print(cfg, "After lamination stat() is:");
+        stat_cmd(cfg, file);
+    }
+    free(file);
+
+    /* Do the same thing as before, but use fchmod() */
+    file = mktemp_cmd(cfg, "/unifyfs");
+    test_print(cfg, "Create empty file %s", file);
+    test_print(cfg, "Before lamination stat() is:");
+    stat_cmd(cfg, file);
+    if (rank == cfg->n_ranks - 1) {
+        test_print(cfg, "I'm the last rank, so I'll fchmod laminate the file");
+
+        fd = open(file, O_RDWR);
+        /* laminate by removing write bits */
+        fchmod(fd, 0444);   /* set to read-only */
+        close(fd);
+
+        test_print(cfg, "After lamination stat() is:");
+        stat_cmd(cfg, file);
+        test_print(cfg, "Verifying that writes to the laminated file fail");
+        dd_cmd(cfg, "/dev/zero", file, 1024, 1, 0);
+    }
+    free(file);
+}
+
+int main(int argc, char* argv[])
+{
+    test_cfg test_config;
+    test_cfg* cfg = &test_config;
+    int rc;
+
+    rc = test_init(argc, argv, cfg);
+    if (rc) {
+        test_print(cfg, "ERROR - Test %s initialization failed!", argv[0]);
+        fflush(NULL);
+        return rc;
+    }
+    do_test(cfg);
+
+    test_fini(cfg);
+
+    return 0;
+}

--- a/examples/src/size.c
+++ b/examples/src/size.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2019, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2019, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyFS.
+ * For details, see https://github.com/LLNL/UnifyFS.
+ * Please read https://github.com/LLNL/UnifyFS/LICENSE for full license text.
+ *
+ * Test file size functions
+ *
+ * Test description:
+ * 1. For each rank, write 1KB at a 1KB * rank offset.
+ * 2. Check the file size.  It should be 0 since it hasn't been laminated.
+ * 3. Have the last rank laminate the file.
+ * 4. Check the file size again.  It should be the real, laminated, file size.
+ */
+#include "testutil.h"
+
+int do_test(test_cfg* cfg)
+{
+    char* file;
+    int rank = cfg->rank;
+
+    file = mktemp_cmd(cfg, "/unifyfs");
+    assert(file);
+
+    test_print(cfg, "I'm writing 1KB to %s at my offset at %ld",
+        file, rank * 1024);
+
+    dd_cmd(cfg, "/dev/zero", file, 1024, 1, rank);
+
+    test_print(cfg, "Stating the file");
+    stat_cmd(cfg, file);
+    test_print(cfg, "After writing, file size is %lu, apparent-size %lu",
+        du_cmd(cfg, file, 0),
+        du_cmd(cfg, file, 1));
+
+    /* sync our extents */
+    sync_cmd(cfg, file);
+
+    /* Wait for everyone to finish writing */
+    test_barrier(cfg);
+
+    if (rank == cfg->n_ranks - 1) {
+        test_print(cfg, "I'm the last rank, so I'll laminate the file");
+
+        /* laminate by removing write bits */
+        chmod(file, 0444);  /* set to read-only */
+
+        test_print(cfg, "After lamination, file size is %lu",
+            du_cmd(cfg, file, 0));
+        test_print(cfg, "Stating the file");
+        stat_cmd(cfg, file);
+    }
+    free(file);
+}
+
+int main(int argc, char* argv[])
+{
+    test_cfg test_config;
+    test_cfg* cfg = &test_config;
+    int rc;
+
+    rc = test_init(argc, argv, cfg);
+    if (rc) {
+        test_print(cfg, "ERROR - Test %s initialization failed!", argv[0]);
+        fflush(NULL);
+        return rc;
+    }
+    do_test(cfg);
+
+    test_fini(cfg);
+
+    return 0;
+}

--- a/examples/src/testutil.c
+++ b/examples/src/testutil.c
@@ -1,0 +1,348 @@
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <sys/sysmacros.h>
+#include <unistd.h>
+#include <errno.h>
+#include <stdarg.h>
+#include <ctype.h>
+#include "testutil.h"
+
+/* Clone of the apsrintf().  See the standard asprintf() man page for details */
+static int asprintf(char** strp, const char* fmt, ...)
+{
+    /*
+     * This code is taken from the vmalloc(3) man page and modified slightly.
+     */
+    int n;
+    int size = 100;     /* Guess we need no more than 100 bytes */
+    char* p;
+    char* np;
+    va_list ap;
+
+    p = malloc(size);
+    if (p == NULL) {
+        *strp = NULL;
+        return -ENOMEM;
+    }
+
+    while (1) {
+        /* Try to print in the allocated space */
+
+        va_start(ap, fmt);
+        n = vsnprintf(p, size, fmt, ap);
+        va_end(ap);
+
+        /* Check error code */
+
+        if (n < 0) {
+            *strp = NULL;
+            return -1;
+        }
+
+        /* If that worked, return the string */
+        if (n < size) {
+            *strp = p;
+            return n;
+        }
+
+        /* Else try again with more space */
+
+        size = n + 1;       /* Precisely what is needed */
+
+        np = realloc(p, size);
+        if (np == NULL) {
+            *strp = NULL;
+            free(p);
+            return -ENOMEM;
+        } else {
+            p = np;
+        }
+    }
+}
+
+
+/******************************************************************************
+ * Below are some standard unix commands replicated in C.  These were included
+ * to make testing easier, since you can really do a lot with just a handful
+ * of commands.  All these are named 'unix name'_cmd() to differentiate the
+ * command from the system calls by the same name (like "stat").
+ *****************************************************************************/
+
+/*
+ * C clone of 'dd'.  All semantics are the same.
+ * Return 0 on success, errno otherwise.
+ */
+int dd_cmd(test_cfg* cfg, char* infile, char* outfile, unsigned long bs,
+    unsigned long count, unsigned long seek)
+{
+    FILE* infp;
+    FILE* outfp;
+    char* buf;
+    size_t rc;
+    int i;
+    infp = fopen(infile, "r");
+    if (!infp) {
+        test_print(cfg, "Error opening infile");
+        return errno;
+    }
+    outfp = fopen(outfile, "w");
+    if (!outfp) {
+        test_print(cfg, "Error opening outfile");
+        return errno;
+    }
+    buf = calloc(sizeof(*buf), bs);
+    assert(buf);
+
+    rc = fseek(outfp, seek * bs, SEEK_SET);
+    if (rc) {
+        test_print(cfg, "Error seeking outfile");
+        return errno;
+    }
+
+    for (i = 0; i < count; i++) {
+        if (feof(infp)) {
+            break;
+        }
+        rc = fread(buf, bs, 1, infp);
+        if (ferror(infp)) {
+            test_print(cfg, "Error reading infile");
+            return errno;
+        }
+        rc = fwrite(buf, rc * bs, 1, outfp);
+        if (ferror(outfp)) {
+            test_print(cfg, "Error writing outfile");
+            return errno;
+        }
+    }
+    free(buf);
+    fclose(infp);
+    fclose(outfp);
+    return 0;
+}
+
+/*
+ * C clone of the 'test' command.  Only supports file checks like
+ * "test -f $file" or "test -d $dir" for now.
+ */
+int test_cmd(char* expression, char* path)
+{
+    struct stat sb;
+    int ret;
+
+    ret = stat(path, &sb);
+    /*
+     * We're stat'ing a file/dir which may or may not exist.  Clear errno so
+     * that we don't pollute future test_print() calls with bogus errors.
+     */
+    errno = 0;
+    if (ret) {
+        return 0;
+    }
+
+    ret = 0;
+    switch (sb.st_mode & S_IFMT) {
+    case S_IFREG:
+        if (strcmp(expression, "-f") == 0) {
+            ret = 1;
+        }
+        break;
+    case S_IFDIR:
+        if (strcmp(expression, "-d") == 0) {
+            ret = 1;
+        }
+        break;
+    default:
+        break;
+    }
+    return ret;
+}
+
+/*
+ * C clone of 'mktemp'.  tmpdir is the directory to create the file in.
+ *
+ * Makes the file with zero length and returns the filename.  The filename
+ * is malloc'd so it must be freed when finished.
+ */
+char* mktemp_cmd(test_cfg* cfg, char* tmpdir)
+{
+    char* tmpfile = NULL;
+    int i;
+    char letters[11];
+    char r;
+    char* job_id;
+    if (!tmpdir) {
+        tmpdir = "/tmp";
+    }
+
+    if (!test_cmd("-d", tmpdir)) {
+        test_print(cfg, "%s dir does not exists", tmpdir);
+        return NULL;
+    }
+
+    /* If we can get our job ID, use it to seed our RNG. Else use our app_id */
+    job_id = getenv("LSB_JOBID");
+    if (job_id) {
+        srand(atol(job_id));
+    } else {
+        srand(cfg->app_id);
+    }
+
+    do {
+        /*
+         * The normal mktemp creates filenames like /tmp/tmp.qTHxL7SLGx. Let's
+         * try to replicate that.
+         */
+        i = 0;
+        do {
+            /*
+             * First make our qTHxL7SLGx string.  Pick random characters that
+             * are alphanumeric.
+             */
+            r = rand() % 123;   /* Ignore anything past char 122 ('z') */
+            if (isalnum(r)) {
+                letters[i] = r;
+                i++;
+            }
+        } while (i < 10);
+        letters[10] = '\0';
+
+        asprintf(&tmpfile, "%s/tmp.%s", tmpdir, letters);
+        if (!tmpfile) {
+            return NULL;
+        }
+
+    /* Loop until we've generated a filename that doesn't already exist */
+    } while (test_cmd("-f", tmpfile));
+
+    /*
+     * Success, we've generated a tmpfile name that doesn't already exist.
+     * Make an empty file (use bs=1 to follow normal dd semantics).
+     */
+    test_print(cfg, "File doesn't exist, create it");
+    if (dd_cmd(cfg, "/dev/zero", tmpfile, 1, 0, 0) != 0) {
+        return NULL;
+    }
+
+    return tmpfile;
+}
+
+/* C clone of 'du'.  Returns the logical file size unless apparent_size = 1,
+ * in which case it returns the apparent size (aka the "log size" in UnifyFS
+ * speak). Otherwise, return a negative number on error.
+ */
+long du_cmd(test_cfg* cfg, char* filename, int apparent_size)
+{
+    struct stat sb;
+    if (stat(filename, &sb) == -1) {
+        test_print(cfg, "Error stat");
+        return -1;
+    }
+
+    if (apparent_size) {
+        return sb.st_blksize * sb.st_blocks;
+    } else {
+        return sb.st_size;
+    }
+}
+
+/*  C clone of 'sync [filename]' */
+int sync_cmd(test_cfg* cfg, char* filename)
+{
+    int fd;
+    fd = open(filename, O_RDWR);
+    if (fd < 0) {
+        test_print(cfg, "Error opening file");
+        return errno;
+    }
+    if (fsync(fd) != 0) {
+        test_print(cfg, "Error syncing file");
+        return errno;
+    }
+    close(fd);
+}
+
+/* C clone of 'stat' */
+int stat_cmd(test_cfg* cfg, char* filename)
+{
+    struct stat sb;
+    int rc;
+    const char* typestr;
+    char* tmp;
+
+    rc = stat(filename, &sb);
+    if (rc) {
+        test_print(cfg, "Error stating %s: %s", filename, strerror(rc));
+        return rc;
+    }
+
+    switch (sb.st_mode & S_IFMT) {
+    case S_IFREG:
+        typestr = "regular file";
+        break;
+    case S_IFDIR:
+        typestr = "directory";
+        break;
+    case S_IFCHR:
+        typestr = "character device";
+        break;
+    case S_IFBLK:
+        typestr = "block device";
+        break;
+    case S_IFLNK:
+        typestr = "symbolic (soft) link";
+        break;
+    case S_IFIFO:
+        typestr = "FIFO or pipe";
+        break;
+    case S_IFSOCK:
+        typestr = "socket";
+        break;
+    default:
+        typestr = "unknown file type?";
+        break;
+    }
+
+    /* Do some work to get the ':' in the right place */
+    asprintf(&tmp, "%s:", filename);
+    test_print(cfg, "%-26s%s", tmp, typestr);
+    free(tmp);
+
+    test_print(cfg, "Device containing i-node: major=%ld   minor=%ld",
+           (long) major(sb.st_dev), (long) minor(sb.st_dev));
+
+    test_print(cfg, "I-node number:            %ld", (long) sb.st_ino);
+
+    test_print(cfg, "Mode:                     %lo",
+           (unsigned long) sb.st_mode);
+
+    if (sb.st_mode & (S_ISUID | S_ISGID | S_ISVTX)) {
+        test_print(cfg, "    special bits set:     %s%s%s",
+               (sb.st_mode & S_ISUID) ? "set-UID " : "",
+               (sb.st_mode & S_ISGID) ? "set-GID " : "",
+               (sb.st_mode & S_ISVTX) ? "sticky " : "");
+    }
+
+    test_print(cfg, "Number of (hard) links:   %ld", (long) sb.st_nlink);
+
+    test_print(cfg, "Ownership:                UID=%ld   GID=%ld",
+           (long) sb.st_uid, (long) sb.st_gid);
+
+    if (S_ISCHR(sb.st_mode) || S_ISBLK(sb.st_mode)) {
+        test_print(cfg, "Device number (st_rdev):  major=%ld; minor=%ld",
+               (long) major(sb.st_rdev), (long) minor(sb.st_rdev));
+    }
+
+    test_print(cfg, "File size:                %lld bytes",
+        (long long) sb.st_size);
+    test_print(cfg, "Optimal I/O block size:   %ld bytes",
+        (long) sb.st_blksize);
+    test_print(cfg, "Blocks allocated:         %lld", (long long) sb.st_blocks);
+    test_print(cfg, "Last file access:         %s", ctime(&sb.st_atime));
+    test_print(cfg, "Last file modification:   %s", ctime(&sb.st_mtime));
+    test_print(cfg, "Last status change:       %s", ctime(&sb.st_ctime));
+}

--- a/examples/src/testutil.h
+++ b/examples/src/testutil.h
@@ -240,6 +240,7 @@ static inline
 void test_print(test_cfg* cfg, const char* fmt, ...)
 {
     int err = errno;
+    char buf[1024];
 
     assert(NULL != cfg);
 
@@ -247,14 +248,19 @@ void test_print(test_cfg* cfg, const char* fmt, ...)
 
     va_list args;
     va_start(args, fmt);
-    vfprintf(stdout, fmt, args);
+    vsprintf(buf, fmt, args);
+    printf("%s", buf);
     va_end(args);
 
     if (err) {
         printf(" (errno=%d, %s)", err, strerror(err));
     }
 
-    printf("\n");
+    /* Add in a '\n' if the line didn't end with one */
+    if (buf[strlen(buf) - 1] != '\n') {
+        printf("\n");
+    }
+
     fflush(stdout);
 }
 
@@ -768,7 +774,7 @@ double test_reduce_double_min(test_cfg* cfg, double local_val)
 }
 
 /* ---------- Program Utilities ---------- */
-
+static
 int test_access_to_mmap_prot(int access)
 {
     switch (access) {
@@ -784,6 +790,7 @@ int test_access_to_mmap_prot(int access)
     return PROT_NONE;
 }
 
+static
 const char* test_access_to_stdio_mode(int access)
 {
     switch (access) {
@@ -1063,5 +1070,16 @@ void test_fini(test_cfg* cfg)
 
     memset(cfg, 0, sizeof(test_cfg));
 }
+
+/*
+ * Various C equivalents of bash commands (dd, test, mktemp, du, stat, ...)
+ */
+int dd_cmd(test_cfg* cfg, char* infile, char* outfile, unsigned long bs,
+    unsigned long count, unsigned long seek);
+int test_cmd(char* expression, char* path);
+char* mktemp_cmd(test_cfg* cfg, char* tmpdir);
+long du_cmd(test_cfg* cfg, char* filename, int apparent_size);
+int sync_cmd(test_cfg* cfg, char* filename);
+int stat_cmd(test_cfg* cfg, char* filename);
 
 #endif /* UNIFYFS_TEST_UTIL_H */

--- a/server/src/unifyfs_cmd_handler.c
+++ b/server/src/unifyfs_cmd_handler.c
@@ -391,6 +391,7 @@ static void unifyfs_metaget_rpc(hg_handle_t handle)
     out.mtime = attr_val.mtime;
     out.ctime = attr_val.ctime;
     out.filename = attr_val.filename;
+    out.is_laminated = attr_val.is_laminated;
     out.ret = ret;
 
     /* send output back to caller */
@@ -424,6 +425,7 @@ static void unifyfs_metaset_rpc(hg_handle_t handle)
     fattr.atime = in.atime;
     fattr.mtime = in.mtime;
     fattr.ctime = in.ctime;
+    fattr.is_laminated = in.is_laminated;
 
     int ret = unifyfs_set_file_attribute(&fattr);
 

--- a/server/src/unifyfs_request_manager.c
+++ b/server/src/unifyfs_request_manager.c
@@ -713,7 +713,7 @@ int rm_cmd_filesize(
     int key_lens[2] = {sizeof(unifyfs_key_t), sizeof(unifyfs_key_t)};
 
     /* look up all entries in this range */
-    int num_vals;
+    int num_vals = 0;
     keyvals = (unifyfs_keyval_t*) calloc(UNIFYFS_MAX_SPLIT_CNT,
                                          sizeof(unifyfs_keyval_t));
     int rc = unifyfs_get_file_extents(2, unifyfs_keys, key_lens,
@@ -721,7 +721,7 @@ int rm_cmd_filesize(
     /* TODO: if there are file extents not accounted for we should
      * either return 0 for that date (holes) or EOF if reading past
      * the end of the file */
-    if (UNIFYFS_SUCCESS != rc || num_vals == 0) {
+    if (UNIFYFS_SUCCESS != rc) {
         // we need to let the client know that there was an error
         free(keyvals);
         return UNIFYFS_FAILURE;


### PR DESCRIPTION
### Description
This patch does a number of things:

- Wrap `chmod()` and `fchmod()` functions.

- Add in functionality to laminate files via clearing the write bits in chmod.  Add `is_laminated` file meta attribute.  A file that is not laminated will show 0 hard links (`stat.st_nlink`), whereas a laminated file will show 1.  This makes it easy to see if a file is laminated with `stat()`.

- Report final file size and apparent size in `stat()` if file is laminated.   If file is not laminated, return a zero file size.

- Correctly gitignore the gotcha,posix,static files in examples/src/

- Add `size.c` and `chmod.c` test cases.  Add utility functions to `testutil.c`.

- Start `UNIFYFS_ERROR_ENUMERATOR` error numbers after the standard `errno.h` ones.

- Allow for zero length files.

### Motivation and Context
- Provide a way to laminate files
- Make sure size is correctly reported after lamination

### How Has This Been Tested?
Added `chmod.c` and `size.c` test cases

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
