### PR TITLE
Revert previous unit test fix due to hang

### DIFF
--- a/t/0100-sysio-gotcha.t
+++ b/t/0100-sysio-gotcha.t
@@ -5,4 +5,4 @@
 #
 . $(dirname $0)/sharness.d/00-test-env.sh
 . $(dirname $0)/sharness.d/01-unifyfs-settings.sh
-$JOB_RUN_COMMAND $UNIFYFS_BUILD_DIR/t/sys/sysio-gotcha.t
+$UNIFYFS_BUILD_DIR/t/sys/sysio-gotcha.t

--- a/t/0200-stdio-gotcha.t
+++ b/t/0200-stdio-gotcha.t
@@ -5,4 +5,4 @@
 #
 . $(dirname $0)/sharness.d/00-test-env.sh
 . $(dirname $0)/sharness.d/01-unifyfs-settings.sh
-$JOB_RUN_COMMAND $UNIFYFS_BUILD_DIR/t/std/stdio-gotcha.t
+$UNIFYFS_BUILD_DIR/t/std/stdio-gotcha.t

--- a/t/0500-sysio-static.t
+++ b/t/0500-sysio-static.t
@@ -5,4 +5,4 @@
 #
 . $(dirname $0)/sharness.d/00-test-env.sh
 . $(dirname $0)/sharness.d/01-unifyfs-settings.sh
-$JOB_RUN_COMMAND $UNIFYFS_BUILD_DIR/t/sys/sysio-static.t
+$UNIFYFS_BUILD_DIR/t/sys/sysio-static.t

--- a/t/0600-stdio-static.t
+++ b/t/0600-stdio-static.t
@@ -5,4 +5,4 @@
 #
 . $(dirname $0)/sharness.d/00-test-env.sh
 . $(dirname $0)/sharness.d/01-unifyfs-settings.sh
-$JOB_RUN_COMMAND $UNIFYFS_BUILD_DIR/t/std/stdio-static.t
+$UNIFYFS_BUILD_DIR/t/std/stdio-static.t

--- a/t/9005-unifyfs-unmount.t
+++ b/t/9005-unifyfs-unmount.t
@@ -5,4 +5,4 @@
 #
 . $(dirname $0)/sharness.d/00-test-env.sh
 . $(dirname $0)/sharness.d/01-unifyfs-settings.sh
-$JOB_RUN_COMMAND $UNIFYFS_BUILD_DIR/t/unifyfs_unmount.t
+$UNIFYFS_BUILD_DIR/t/unifyfs_unmount.t

--- a/t/9100-metadata-api.t
+++ b/t/9100-metadata-api.t
@@ -7,4 +7,4 @@ test_description="Test Metadata API"
 # and UnifyFS runtime settings.
 #
 . $(dirname $0)/sharness.d/00-test-env.sh
-$JOB_RUN_COMMAND $UNIFYFS_BUILD_DIR/t/server/metadata.t
+$UNIFYFS_BUILD_DIR/t/server/metadata.t


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
This reverts (#350) back to having both the server used for unit testing and the unit tests themselves to all be run on the same node where `make check` is executed. Makes it so an allocation is not required for running the unit tests and will allow them to be run by GitLab.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Running the tests with an MPI launcher works fine in most cases, but breaks in a certain LSF `bsub` implementation. This is the case where the tests are run from a launch node and to be executed on a compute node. This is the case that is used by GitLab's batch runners. The unit testing suite is set up to launch `unifyfs` on the current node (launch node) so when the suites are run by an MPI launcher, the server cannot be found and the tests bail out.

This cannot be resolved by simply running the server on the compute node from a launch node as the TAP harness used by UnifyFS (automakes `tap-driver.sh`) has an problem where it will hang as it waits for any background processes started by a test (`unifyfsd` in this case) to finish running before moving on. This is why [0001-setup.t](https://github.com/LLNL/UnifyFS/blob/dev/t/0001-setup.t) was originally set up as a makeshift test and not a real Sharness test.

However, this should be fine since the unit tests all only use a single process, so there shouldn't be a need to run them with an MPI launcher. It appears that the only thing MPI is needed for in the unit test suites is the arguments for `unifyfs_mount()`.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Ran unit tests on a launch node, on an allocation that uses a launch node and compute node, and an allocation that only uses a compute node.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.