### PR TITLE
Add laminate to write example for file size check

### DIFF
--- a/examples/src/write.c
+++ b/examples/src/write.c
@@ -190,6 +190,13 @@ int main(int argc, char* argv[])
     test_barrier(cfg);
     test_print_verbose_once(cfg, "DEBUG: finished sync");
 
+    if ((test_config.rank == 0) ||
+        (IO_PATTERN_NN == test_config.io_pattern)) {
+        /* laminate by removing write bits */
+        chmod(target_file, 0400);
+    }
+    test_print_verbose_once(cfg, "DEBUG: finished lamination");
+
     // post-write cleanup
     free(wr_buf);
     free(reqs);


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Recent changes to how the file size is calculated (#352) make stat return a size of 0 until the file is laminated. This was causing an error in the write example when file size was checked:

```
[0] ERROR - file size check failed - actual size is 0 B, expected 268435456 B
```

Laminating the file in the write example allows for the size to be correct when stat is called.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Error was causing integration tests to fail.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
* Running write example(s) before and after change.
* Running integration tests

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)