### PR TITLE
remove deprecated unifyfs.debug setting

### DIFF
--- a/extras/unifyfs.conf.in
+++ b/extras/unifyfs.conf.in
@@ -10,7 +10,6 @@
 [unifyfs]
 # consistency = "LAMINATED" ; NONE | LAMINATED | POSIX
 # daemonize = on            ; servers will become daemons
-debug = on                  ; enable debug output (default: off)
 # mountpoint = "/unifyfs"   ; mountpoint (i.e., prefix path)
 
 # SECTION: client settings
@@ -39,4 +38,3 @@ chunk_mem = 67108864 ; segment size for data chunks (default: 256 MiB)
 # data_dir = "/mnt/ssd" ; directory path for data spillover
 # meta_dir = "/mnt/ssd" ; directory path for metadata spillover
 size = 268435456        ; data spillover max size (default: 1 GiB)
-


### PR DESCRIPTION
### Description
The template for `/etc/unifyfs/unifyfs.conf` still contained a line for
`unifyfs.debug`, which is a deprecated config setting.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
