### PR TITLE
Fix file descriptor returned by fileno wrapper

### DIFF
--- a/client/src/unifyfs-stdio.c
+++ b/client/src/unifyfs-stdio.c
@@ -1764,6 +1764,7 @@ void UNIFYFS_WRAP(clearerr)(FILE* stream)
 
 int UNIFYFS_WRAP(fileno)(FILE* stream)
 {
+    int ret;
     /* check whether we should intercept this stream */
     if (unifyfs_intercept_stream(stream)) {
         /* lookup stream */
@@ -1776,11 +1777,13 @@ int UNIFYFS_WRAP(fileno)(FILE* stream)
             return -1;
         }
 
-        /* return file descriptor associated with stream */
-        return fd;
+        /* return file descriptor associated with stream but don't conflict
+         * with active system fds that range from 0 - (fd_limit) */
+        ret = fd + unifyfs_fd_limit;
+        return ret;
     } else {
         MAP_OR_FAIL(fileno);
-        int ret = UNIFYFS_REAL(fileno)(stream);
+        ret = UNIFYFS_REAL(fileno)(stream);
         return ret;
     }
 }


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
When asking for a file descriptor associated with a file stream, our `fileno()` wrapper doesn't adjust for potential fds on the system. Thus, when determining if UnifyFS should intercept an I/O call associated with the fd in `unifyfs_intercept_fd()`:
https://github.com/LLNL/UnifyFS/blob/9b9a831767df80ba0efeee9936d86e5d3439e80b/client/src/unifyfs.c#L448-L450
UnifyFS sees the fd as a real descriptor and lets the call pass through to `UNIFYFS_REAL(fileno)`.

This updates our fileno wrapper to adjust for the file descriptor limit of the active system.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
One of a few bugs ran in to while attempting to integrate UnifyFS with VeloC.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Using the VeloC `heatdis_file` example, editing it to use UnifyFS, and adding a call to `fileno()` and `fchmod()` in order to laminate a file.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.