### PR TITLE
mentioned -f flag for unifyfsd in config intro

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -14,6 +14,12 @@ certain settings have command line options. When defined via multiple methods,
 the command line options have the highest priority, followed by environment
 variables, and finally config file options from ``unifyfs.conf``.
 
+If you're testing or developing on Unify on a system where you don't have
+install access to /etc/, you can specify a different location for the
+unifyfs.conf file using the -f command-line option to unifyfsd (see below).
+There is a sample unifyfs.conf file package for this purpose in the UnifyFS
+source repository in the directory "extras".
+
 The unified method for providing configuration control is adapted from
 CONFIGURATOR_. Configuration settings are grouped within named sections, and
 each setting consists of a key-value pair with one of the following types:


### PR DESCRIPTION
Add a paragraph to the intro in the configuration documentation to
specifically call out that the configuration file location for
unifyfsd can be overridden by the -f command-line flag.  This is
mostly for people testing or developing on a system where they
don't have root access and so can't put the configuration file
in the default location in /etc/.

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If someone needs to use a configuration file on a system they don't have root access to, this provides that specifically in the introduction to the configuration doc section.  
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Just a text change in the doc source.  Tested with the syntax check script.  
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the UnifyFS code style requirements.
- [ x] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x ] All commit messages are properly formatted.
