### PR TITLE
Implement fread(), add more read/write test cases

### DIFF
--- a/client/src/unifyfs-stdio.c
+++ b/client/src/unifyfs-stdio.c
@@ -513,6 +513,7 @@ static int unifyfs_stream_read(
         /* ERROR: invalid file descriptor */
         s->err = 1;
         errno = EBADF;
+        LOGDBG("Invalid file descriptor");
         return UNIFYFS_ERROR_BADF;
     }
 
@@ -520,6 +521,8 @@ static int unifyfs_stream_read(
     if (!filedesc->read) {
         s->err = 1;
         errno = EBADF;
+        LOGDBG("Stream not open for reading");
+
         return UNIFYFS_ERROR_BADF;
     }
 
@@ -531,12 +534,14 @@ static int unifyfs_stream_read(
             /* ERROR: failed to associate buffer */
             s->err = 1;
             errno = unifyfs_err_map_to_errno(setvbuf_rc);
+            LOGDBG("Couldn't setvbuf");
             return setvbuf_rc;
         }
     }
 
     /* don't attempt read if end-of-file indicator is set */
     if (s->eof) {
+        LOGDBG("Stop read, at EOF");
         return UNIFYFS_FAILURE;
     }
 
@@ -594,17 +599,20 @@ static int unifyfs_stream_read(
 
             /* read data from file into buffer */
             size_t bufcount;
-            int read_rc = unifyfs_fd_read(s->fd, current, s->buf, s->bufsize, &bufcount);
-            if (read_rc != UNIFYFS_SUCCESS) {
-                /* ERROR: read error, set error indicator and errno */
+            size_t read_rc = unifyfs_fd_read(s->fd, current, s->buf,
+                s->bufsize);
+            if (read_rc  == -1) {
+                /*
+                 * ERROR: read error, set error indicator. errno is already set
+                 * by unifyfs_fd_read()
+                 */
                 s->err = 1;
-                errno = unifyfs_err_map_to_errno(read_rc);
                 return read_rc;
             }
 
             /* record new buffer range within file */
             s->bufpos  = current;
-            s->buflen  = bufcount;
+            s->buflen  = read_rc;
 
             /* set end-of-file flag if our read was short */
             if (bufcount < s->bufsize) {
@@ -669,6 +677,7 @@ static int unifyfs_stream_write(
     unifyfs_fd_t* filedesc = unifyfs_get_filedesc_from_fd(s->fd);
     if (filedesc == NULL) {
         /* ERROR: invalid file descriptor */
+        LOGDBG("Bad file descriptor");
         s->err = 1;
         errno = EBADF;
         return UNIFYFS_ERROR_BADF;
@@ -676,6 +685,7 @@ static int unifyfs_stream_write(
 
     /* bail with error if stream not open for writing */
     if (!filedesc->write) {
+        LOGDBG("Stream not open for writing");
         s->err = 1;
         errno = EBADF;
         return UNIFYFS_ERROR_BADF;
@@ -2256,17 +2266,16 @@ static int __srefill(unifyfs_stream_t* stream)
 
         /* read data from file into buffer */
         size_t bufcount;
-        int read_rc = unifyfs_fd_read(s->fd, current, s->buf, s->bufsize, &bufcount);
-        if (read_rc != UNIFYFS_SUCCESS) {
-            /* ERROR: read error, set error indicator and errno */
+        size_t read_rc = unifyfs_fd_read(s->fd, current, s->buf, s->bufsize);
+        if (read_rc < 0) {
+            /* ERROR: read error, set error indicator */
             s->err = 1;
-            errno = unifyfs_err_map_to_errno(read_rc);
             return 1;
         }
 
         /* record new buffer range within file */
         s->bufpos = current;
-        s->buflen = bufcount;
+        s->buflen = read_rc;
     }
 
     /* determine number of bytes to copy from stream buffer */

--- a/client/src/unifyfs-sysio.h
+++ b/client/src/unifyfs-sysio.h
@@ -103,12 +103,12 @@ UNIFYFS_DECL(close, int, (int fd));
 UNIFYFS_DECL(lio_listio, int, (int mode, struct aiocb* const aiocb_list[],
                                int nitems, struct sigevent* sevp));
 
-/* read count bytes info buf from file starting at offset pos,
- * returns number of bytes actually read in retcount,
- * retcount will be less than count only if an error occurs
- * or end of file is reached */
-int unifyfs_fd_read(int fd, off_t pos, void* buf, size_t count,
-                    size_t* retcount);
+/*
+ * Read 'count' bytes info 'buf' from file starting at offset 'pos'.
+ * Returns number of bytes actually read, or -1 on error, in which
+ * case errno will be set.
+ */
+size_t unifyfs_fd_read(int fd, off_t pos, void* buf, size_t count);
 
 /* write count bytes from buf into file starting at offset pos,
  * allocates new bytes and updates file size as necessary,

--- a/client/src/unifyfs.c
+++ b/client/src/unifyfs.c
@@ -1035,33 +1035,6 @@ int unifyfs_fid_create_directory(const char* path)
     return UNIFYFS_SUCCESS;
 }
 
-/* read count bytes from file starting from pos and store into buf,
- * all bytes are assumed to exist, so checks on file size should be
- * done before calling this routine */
-int unifyfs_fid_read(int fid, off_t pos, void* buf, size_t count)
-{
-    int rc;
-
-    /* short-circuit a 0-byte read */
-    if (count == 0) {
-        return UNIFYFS_SUCCESS;
-    }
-
-    /* get meta for this file id */
-    unifyfs_filemeta_t* meta = unifyfs_get_meta_from_fid(fid);
-
-    /* determine storage type to read file data */
-    if (meta->storage == FILE_STORAGE_FIXED_CHUNK) {
-        /* file stored in fixed-size chunks */
-        rc = unifyfs_fid_store_fixed_read(fid, meta, pos, buf, count);
-    } else {
-        /* unknown storage type */
-        rc = (int)UNIFYFS_ERROR_IO;
-    }
-
-    return rc;
-}
-
 /* write count bytes from buf into file starting at offset pos,
  * all bytes are assumed to be allocated to file, so file should
  * be extended before calling this routine */
@@ -1290,8 +1263,9 @@ int unifyfs_fid_open(const char* path, int flags, mode_t mode, int* outfid,
      */
     if (gfattr.is_laminated &&
         ((flags & (O_CREAT | O_TRUNC | O_APPEND | O_WRONLY)) ||
-         (mode & 0222))) {
-            LOGDBG("Can't open with a writable flag on laminated file.");
+         ((mode & 0222) && (flags != O_RDONLY)))) {
+            LOGDBG("Can't open %s with a writable flag on laminated file.",
+                path);
             return EROFS;
     }
 

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -97,7 +97,9 @@ sys_sysio_gotcha_t_SOURCES = sys/sysio_suite.h \
                              sys/creat64.c \
                              sys/mkdir-rmdir.c \
                              sys/open.c \
-                             sys/open64.c
+                             sys/open64.c \
+                             sys/write-read.c
+
 sys_sysio_gotcha_t_CPPFLAGS = $(test_cppflags)
 sys_sysio_gotcha_t_LDADD = $(test_ldadd)
 sys_sysio_gotcha_t_LDFLAGS = $(AM_LDFLAGS)
@@ -108,21 +110,29 @@ sys_sysio_static_t_SOURCES = sys/sysio_suite.h \
                              sys/creat64.c \
                              sys/mkdir-rmdir.c \
                              sys/open.c \
-                             sys/open64.c
+                             sys/open64.c \
+                             sys/write-read.c
+
 sys_sysio_static_t_CPPFLAGS = $(test_cppflags)
 sys_sysio_static_t_LDADD = $(test_static_ldadd)
 sys_sysio_static_t_LDFLAGS = $(test_static_ldflags)
 
 std_stdio_gotcha_t_SOURCES = std/stdio_suite.h \
                              std/stdio_suite.c \
-                             std/fopen-fclose.c
+                             std/fopen-fclose.c \
+                             std/fwrite-fread.c \
+                             std/fflush.c
+
 std_stdio_gotcha_t_CPPFLAGS = $(test_cppflags)
 std_stdio_gotcha_t_LDADD = $(test_ldadd)
 std_stdio_gotcha_t_LDFLAGS = $(AM_LDFLAGS)
 
 std_stdio_static_t_SOURCES = std/stdio_suite.h \
                              std/stdio_suite.c \
-                             std/fopen-fclose.c
+                             std/fopen-fclose.c \
+                             std/fwrite-fread.c \
+                             std/fflush.c
+
 std_stdio_static_t_CPPFLAGS = $(test_cppflags)
 std_stdio_static_t_LDADD = $(test_static_ldadd)
 std_stdio_static_t_LDFLAGS = $(test_static_ldflags)

--- a/t/std/fflush.c
+++ b/t/std/fflush.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2019, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2018, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyFS.
+ * For details, see https://github.com/LLNL/UnifyFS.
+ * Please read https://github.com/LLNL/UnifyFS/LICENSE for full license text.
+ */
+
+ /*
+  * Test fflush().  Currently this test is skipped until #374 is addressed.
+  */
+#include <fcntl.h>
+#include <string.h>
+#include <errno.h>
+#include <linux/limits.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include "t/lib/tap.h"
+#include "t/lib/testutil.h"
+
+int fflush_test(char* unifyfs_root)
+{
+    char path[64];
+    char buf[64] = {0};
+    FILE* fp = NULL;
+    int rc;
+
+    /* Generate a random file name in the mountpoint path to test on */
+    testutil_rand_path(path, sizeof(path), unifyfs_root);
+    skip(1, 9, "remove when fflush() sync extents (issue #374)");
+
+    /* Write "hello world" to a file */
+    fp = fopen(path, "w");
+    ok(fp != NULL, "%s: fopen(%s): %s", __FILE__, path, strerror(errno));
+
+    rc = fwrite("hello world", 12, 1, fp);
+    ok(rc == 1, "%s: fwrite(\"hello world\"): %s", __FILE__, strerror(errno));
+
+    /* Flush the extents */
+    rc = fflush(fp);
+    ok(rc == 0, "%s: fflush() (rc=%d): %s", __FILE__, rc, strerror(errno));
+
+    rc = fclose(fp);
+    ok(rc == 0, "%s: fclose() (rc=%d): %s", __FILE__, rc, strerror(errno));
+
+    /* Laminate */
+    rc = chmod(path, 0444);
+    ok(rc == 0, "%s: chmod(0444) (rc=%d): %s", __FILE__, strerror(errno));
+
+    /* Read it back */
+    fp = fopen(path, "r");
+    ok(fp != NULL, "%s: fopen(%s): %s", __FILE__, path, strerror(errno));
+
+    rc = fread(buf, 12, 1, fp);
+    ok(rc == 1, "%s: fread() buf[]=\"%s\", (rc %d): %s", __FILE__, buf, rc,
+        strerror(errno));
+    is(buf, "hello world", "%s: saw \"hello world\"", __FILE__);
+
+    rc = fclose(fp);
+    ok(rc == 0, "%s: fclose() (rc=%d): %s", __FILE__, rc, strerror(errno));
+
+    end_skip;
+
+    return 0;
+}

--- a/t/std/fwrite-fread.c
+++ b/t/std/fwrite-fread.c
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2019, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2018, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyFS.
+ * For details, see https://github.com/LLNL/UnifyFS.
+ * Please read https://github.com/LLNL/UnifyFS/LICENSE for full license text.
+ */
+
+ /*
+  * Test fwrite/fread/fseek/fgets/rewind/ftell/feof/chmod
+  */
+#include <fcntl.h>
+#include <string.h>
+#include <errno.h>
+#include <linux/limits.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include "t/lib/tap.h"
+#include "t/lib/testutil.h"
+
+int fwrite_fread_test(char* unifyfs_root)
+{
+    char path[64];
+    char buf[64] = {0};
+    FILE* fp = NULL;
+    int rc;
+    char* tmp;
+
+    errno = 0;
+
+    testutil_rand_path(path, sizeof(path), unifyfs_root);
+
+    /* Write "hello world" to a file */
+    fp = fopen(path, "w");
+    ok(fp != NULL, "%s: fopen(%s): %s", __FILE__, path, strerror(errno));
+
+    rc = fwrite("hello world", 12, 1, fp);
+    ok(rc == 1, "%s: fwrite(\"hello world\"): %s", __FILE__, strerror(errno));
+
+    rc = fclose(fp);
+    ok(rc == 0, "%s: fclose() (rc=%d): %s", __FILE__, rc, strerror(errno));
+
+    /* Sync extents */
+    int fd;
+    fd = open(path, O_RDWR);
+    rc = fsync(fd);
+    ok(rc == 0, "%s: fsync() (rc=%d): %s", __FILE__, rc, strerror(errno));
+    close(fd);
+
+    /* Laminate */
+    rc = chmod(path, 0444);
+    ok(rc == 0, "%s: chmod(0444) (rc=%d): %s", __FILE__, strerror(errno));
+
+    /* Read it back */
+    fp = fopen(path, "r");
+    ok(fp != NULL, "%s: fopen(%s): %s", __FILE__, path, strerror(errno));
+
+    rc = fread(buf, 12, 1, fp);
+    ok(rc == 1, "%s: fread() buf[]=\"%s\", (rc %d): %s", __FILE__, buf, rc,
+        strerror(errno));
+    is(buf, "hello world", "%s: saw \"hello world\"", __FILE__);
+
+    fseek(fp, 6, SEEK_SET);
+    rc = ftell(fp);
+    ok(rc == 6, "%s: fseek() (rc %d): %s", __FILE__, rc, strerror(errno));
+
+    rc = fread(buf, 6, 1, fp);
+    ok(rc == 1, "%s: fread() at offset 6 buf[]=\"%s\", (rc %d): %s", __FILE__,
+        buf, rc, strerror(errno));
+    is(buf, "world", "%s: saw \"world\"", __FILE__);
+
+    rewind(fp);
+    rc = fread(buf, 12, 1, fp);
+    ok(rc == 1, "%s: fread() after rewind() buf[]=\"%s\", (rc %d): %s",
+        __FILE__, buf, rc, strerror(errno));
+    is(buf, "hello world", "%s: saw \"hello world\"", __FILE__);
+
+    rewind(fp);
+    memset(buf, 0, sizeof(buf));
+    tmp = fgets(buf, 12, fp);
+    ok(tmp == buf, "%s: fgets() after rewind() buf[]=\"%s\": %s", __FILE__, buf,
+        strerror(errno));
+    is(buf, "hello world", "%s: saw \"hello world\"", __FILE__);
+
+    rewind(fp);
+    memset(buf, 0, sizeof(buf));
+    tmp = fgets(buf, 6, fp);
+    ok(tmp == buf, "%s: fgets() with size = 6 after rewind() buf[]=\"%s\": %s",
+        __FILE__, buf, strerror(errno));
+    is(buf, "hello", "%s: saw \"hello\"", __FILE__);
+
+    rewind(fp);
+    rc = fread(buf, sizeof(buf), 1, fp);
+    ok(rc != 1, "%s: fread() past end of file (rc %d): %s", __FILE__, rc,
+        strerror(errno));
+
+    rc = feof(fp);
+    ok(rc != 0, "%s: feof() past end of file (rc %d): %s", __FILE__, rc,
+        strerror(errno));
+
+    rc = fclose(fp);
+    ok(rc == 0, "%s: fclose() (rc=%d): %s", __FILE__, rc, strerror(errno));
+
+    return 0;
+}

--- a/t/std/stdio_suite.c
+++ b/t/std/stdio_suite.c
@@ -70,6 +70,8 @@ int main(int argc, char* argv[])
      * failures to start passing. */
 
     fopen_fclose_test(unifyfs_root);
+    fwrite_fread_test(unifyfs_root);
+    fflush_test(unifyfs_root);
 
     MPI_Finalize();
 

--- a/t/std/stdio_suite.h
+++ b/t/std/stdio_suite.h
@@ -32,5 +32,7 @@
 
 /* Tests for UNIFYFS_WRAP(fopen) and UNIFYFS_WRAP(fclose) */
 int fopen_fclose_test(char* unifyfs_root);
+int fwrite_fread_test(char* unifyfs_root);
+int fflush_test(char* unifyfs_root);
 
 #endif /* STDIO_SUITE_H */

--- a/t/sys/sysio_suite.c
+++ b/t/sys/sysio_suite.c
@@ -81,6 +81,8 @@ int main(int argc, char* argv[])
 
     open64_test(unifyfs_root);
 
+    write_read_test(unifyfs_root);
+
     MPI_Finalize();
 
     done_testing();

--- a/t/sys/sysio_suite.h
+++ b/t/sys/sysio_suite.h
@@ -45,4 +45,6 @@ int open_test(char* unifyfs_root);
 /* Tests for UNIFYFS_WRAP(open64) */
 int open64_test(char* unifyfs_root);
 
+int write_read_test(char* unifyfs_root);
+
 #endif /* SYSIO_SUITE_H */

--- a/t/sys/write-read.c
+++ b/t/sys/write-read.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2019, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2018, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyFS.
+ * For details, see https://github.com/LLNL/UnifyFS.
+ * Please read https://github.com/LLNL/UnifyFS/LICENSE for full license text.
+ */
+
+ /*
+  * Test write/read/lseek/fsync/stat/chmod
+  */
+#include <fcntl.h>
+#include <string.h>
+#include <errno.h>
+#include <linux/limits.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include "t/lib/tap.h"
+#include "t/lib/testutil.h"
+
+int write_read_test(char* unifyfs_root)
+{
+    char path[64];
+    int rc;
+    struct stat sb;
+    int fd;
+
+    testutil_rand_path(path, sizeof(path), unifyfs_root);
+
+    /* Write to the file */
+    fd = open(path, O_WRONLY | O_CREAT, 0222);
+    ok(fd != -1, "%s: open(%s) (fd=%d): %s", __FILE__, path, fd,
+        strerror(errno));
+
+    rc = write(fd, "hello world", 12);
+    ok(rc == 12, "%s: write() (rc=%d): %s", __FILE__, rc, strerror(errno));
+
+    /* Test writing to a different offset */
+    rc = lseek(fd, 6, SEEK_SET);
+    ok(rc == 6, "%s: lseek() (rc=%d): %s", __FILE__, rc, strerror(errno));
+
+    rc = write(fd, "universe", 9);
+    ok(rc == 9, "%s: write() (rc=%d): %s", __FILE__, rc, strerror(errno));
+
+    /* Filesize should be zero, since we're not-laminated */
+    rc = stat(path, &sb);
+    ok(rc == 0, "%s: stat() on non-synced & non-laminated file (rc %d): %s",
+        __FILE__, rc, strerror(errno));
+    ok(sb.st_size == 0, "%s: file size %ld == 0", __FILE__, sb.st_size);
+
+    rc = fsync(fd);
+    ok(rc == 0, "%s: fsync() (rc=%d): %s", __FILE__, rc, strerror(errno));
+    close(fd);
+
+    /* Size should still be zero, despite syncing, since it's not-laminated */
+    ok(rc == 0, "%s: stat() on synced & non-laminated file (rc %d): %s",
+        __FILE__, rc, strerror(errno));
+    ok(sb.st_size == 0, "%s: file size %ld == 0", __FILE__, sb.st_size);
+
+    /* Laminate */
+    rc = chmod(path, 0444);
+    ok(rc == 0, "%s: chmod(0444) (rc=%d): %s", __FILE__, rc, strerror(errno));
+
+    /* Verify we're getting the correct file size */
+    rc = stat(path, &sb);
+    ok(rc == 0, "%s: stat() (rc %d): %s", __FILE__, rc, strerror(errno));
+    ok(sb.st_size == 15, "%s: file size %ld == 15", __FILE__, sb.st_size);
+
+    return 0;
+}


### PR DESCRIPTION
### Description
- Implement `fread()` for the `FILE_STORAGE_LOGIO` case

- Add a test case for `fread()`/`fwrite()`.  It also tests some other stream IO calls like fseek()/rewind()/fgets().
 
- Add a test case for `read()`/`write()`/`lseek().

- Add a test case for `fflush()` for #374.  It's currently set to "skip" while we decide what the `fflush()` behaviour should be.

- Add additional `LOGDBG()` logging

These test cases will clear the way for fixing the various file size bugs.  I didn't want to include the file size changes in this PR, since it's already a really big patch.

### Motivation and Context
- Make `fread()` work
- Add test cases.
- Fixes #367 

### How Has This Been Tested?
Added test cases

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
