### PR TITLE
docs: dropping dotkit

### DIFF
--- a/docs/build-intercept.rst
+++ b/docs/build-intercept.rst
@@ -29,11 +29,10 @@ Building with Spack
 ********************
 
 These instructions assume that you do not already have a module system installed
-such as LMod, Dotkit, or Environment Modules. If your system already has Dotkit
-or LMod installed then installing the environment-modules package with Spack
+such as LMod or Environment Modules. If your system already has
+LMod installed then installing the environment-modules package with Spack
 is unnecessary (so you can safely skip that step).
 
-If you use Dotkit then replace ``spack load`` with ``spack use``.
 First, install Spack if you don't already have it:
 
 .. code-block:: Bash
@@ -107,8 +106,6 @@ Build the Dependencies with Spack
 
 Once Spack is installed on your system (see :ref:`above <build-label>`), you
 can install just the dependencies for an easier manual installation of UnifyFS.
-
-If you use Dotkit then replace ``spack load`` with ``spack use``.
 
 .. code-block:: Bash
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
I believe Spack has dropped Dotkit support, which is likely only really used at LLNL anyway.  This drops references to Dotkit in our documentation.

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.