### PR TITLE
server: allocate buffer to return key/value pairs in get_file_extents

### DIFF
--- a/server/src/unifyfs_cmd_handler.c
+++ b/server/src/unifyfs_cmd_handler.c
@@ -483,7 +483,7 @@ static void unifyfs_filesize_rpc(hg_handle_t handle)
 
     /* read data for a single read request from client,
      * returns data to client through shared memory */
-    size_t filesize;
+    size_t filesize = 0;
     int ret = rm_cmd_filesize(in.app_id, in.local_rank_idx,
                               in.gfid, &filesize);
 

--- a/server/src/unifyfs_metadata.c
+++ b/server/src/unifyfs_metadata.c
@@ -388,47 +388,75 @@ int unifyfs_get_file_extents(int num_keys, unifyfs_key_t** keys,
      * key-value pairs within the range of the key tuple.
      * We need to re-evaluate this function to use different key-value stores.
      */
-
-    int i;
     int rc = UNIFYFS_SUCCESS;
-    int tot_num = 0;
 
-    unifyfs_key_t* tmp_key;
-    unifyfs_val_t* tmp_val;
-    unifyfs_keyval_t* kviter = *keyvals;
+    /* initialize output values */
+    *num_values = 0;
+    *keyvals = NULL;
 
     md->primary_index = unifyfs_indexes[0];
-    bgrm = mdhimBGet(md, md->primary_index, (void**)keys,
-                     key_lens, num_keys, MDHIM_RANGE_BGET);
 
-    while (bgrm) {
-        bgrmp = bgrm;
-        if (bgrmp->error < 0) {
-            // TODO: need better error handling
-            rc = (int)UNIFYFS_ERROR_MDHIM;
-            return rc;
+    /* execute range query */
+    struct mdhim_bgetrm_t* bkvlist = mdhimBGet(md, md->primary_index,
+        (void**)keys, key_lens, num_keys, MDHIM_RANGE_BGET);
+
+    /* iterate over each item in list, check for errors
+     * and sum up total number of key/value pairs we got back */
+    size_t tot_num = 0;
+    struct mdhim_bgetrm_t* ptr = bkvlist;
+    while (ptr) {
+        /* check that we don't have an error condition */
+        if (ptr->error < 0) {
+            /* hit an error */
+            LOGERR("MDHIM Range Query error");
+            return (int)UNIFYFS_ERROR_MDHIM;
         }
 
-        if (tot_num < MAX_META_PER_SEND) {
-            for (i = 0; i < bgrmp->num_keys; i++) {
-                tmp_key = (unifyfs_key_t*)bgrmp->keys[i];
-                tmp_val = (unifyfs_val_t*)bgrmp->values[i];
-                memcpy(&(kviter->key), tmp_key, sizeof(unifyfs_key_t));
-                memcpy(&(kviter->val), tmp_val, sizeof(unifyfs_val_t));
-                kviter++;
-                tot_num++;
-                if (MAX_META_PER_SEND == tot_num) {
-                    LOGERR("Error: maximum number of values!");
-                    rc = UNIFYFS_FAILURE;
-                    break;
-                }
-            }
-        }
-        bgrm = bgrmp->next;
-        mdhim_full_release_msg(bgrmp);
+        /* total up number of key/values returned */
+        tot_num += (size_t) ptr->num_keys;
+
+        /* get pointer to next item in the list */
+        ptr = ptr->next;
     }
 
+    /* allocate memory to copy key/value data */
+    unifyfs_keyval_t* kvs = (unifyfs_keyval_t*) calloc(
+        tot_num, sizeof(unifyfs_keyval_t));
+    if (NULL == kvs) {
+        LOGERR("failed to allocate keyvals");
+        return (int)UNIFYFS_ERROR_MDHIM;
+    }
+
+    /* iterate over list and copy each key/value into output array */
+    ptr = bkvlist;
+    unifyfs_keyval_t* kviter = kvs;
+    while (ptr) {
+        /* iterate over key/value in list element */
+        int i;
+        for (i = 0; i < ptr->num_keys; i++) {
+            /* get pointer to current key and value */
+            unifyfs_key_t* tmp_key = (unifyfs_key_t*)ptr->keys[i];
+            unifyfs_val_t* tmp_val = (unifyfs_val_t*)ptr->values[i];
+
+            /* copy contents over to output array */
+            memcpy(&(kviter->key), tmp_key, sizeof(unifyfs_key_t));
+            memcpy(&(kviter->val), tmp_val, sizeof(unifyfs_val_t));
+
+            /* bump up to next element in output array */
+            kviter++;
+        }
+
+        /* get pointer to next item in the list */
+        struct mdhim_bgetrm_t* next = ptr->next;
+
+        /* release resources for the curren item */
+        mdhim_full_release_msg(ptr);
+        ptr = next;
+    }
+
+    /* set output values */
     *num_values = tot_num;
+    *keyvals = kvs;
 
     return rc;
 }

--- a/server/src/unifyfs_request_manager.c
+++ b/server/src/unifyfs_request_manager.c
@@ -478,14 +478,16 @@ int rm_cmd_filesize(
     int gfid,      /* global file id of read request */
     size_t* outsize) /* output file size */
 {
+    /* initialize output file size to something deterministic,
+     * in case we drop out with an error */
+    *outsize = 0;
+
     /* set offset and length to request *all* key/value pairs
      * for this file */
     size_t offset = 0;
 
     /* want to pick the highest integer offset value a file
      * could have here */
-    // TODO: would like to unsed max for unsigned long, but
-    // that fails to return any keys for some reason
     size_t length = (SIZE_MAX >> 1) - 1;
 
     /* get the locations of all the read requests from the
@@ -500,27 +502,17 @@ int rm_cmd_filesize(
     key2.fid    = gfid;
     key2.offset = offset + length - 1;
 
-    unifyfs_keyval_t* keyvals;
+    /* set up input params to specify range lookup */
     unifyfs_key_t* unifyfs_keys[2] = {&key1, &key2};
     int key_lens[2] = {sizeof(unifyfs_key_t), sizeof(unifyfs_key_t)};
 
     /* look up all entries in this range */
     int num_vals = 0;
-    keyvals = (unifyfs_keyval_t*) calloc(UNIFYFS_MAX_SPLIT_CNT,
-                                         sizeof(unifyfs_keyval_t));
-    if (NULL == keyvals) {
-        LOGERR("failed to allocate keyvals");
-        return UNIFYFS_ERROR_NOMEM;
-    }
-
+    unifyfs_keyval_t* keyvals = NULL;
     int rc = unifyfs_get_file_extents(2, unifyfs_keys, key_lens,
                                       &num_vals, &keyvals);
-    /* TODO: if there are file extents not accounted for we should
-     * either return 0 for that date (holes) or EOF if reading past
-     * the end of the file */
     if (UNIFYFS_SUCCESS != rc) {
-        // we need to let the client know that there was an error
-        free(keyvals);
+        /* failed to look up extents, bail with error */
         return UNIFYFS_FAILURE;
     }
 
@@ -541,8 +533,11 @@ int rm_cmd_filesize(
         }
     }
 
-    // cleanup
-    free(keyvals);
+    /* free off key/value buffer returned from get_file_extents */
+    if (NULL != keyvals) {
+        free(keyvals);
+        keyvals = NULL;
+    }
 
     *outsize = filesize;
     return rc;
@@ -552,17 +547,24 @@ int create_gfid_chunk_reads(reqmgr_thrd_t* thrd_ctrl,
                             int gfid, int app_id, int client_id,
                             int num_keys, unifyfs_key_t** keys, int* keylens)
 {
-    // TODO: might want to get this from a memory pool
-    unifyfs_keyval_t* keyvals = calloc(UNIFYFS_MAX_SPLIT_CNT,
-                                       sizeof(unifyfs_keyval_t));
-    if (NULL == keyvals) {
-        LOGERR("failed to allocate keyvals");
+    /* lookup all key/value pairs for given range */
+    int num_vals = 0;
+    unifyfs_keyval_t* keyvals = NULL;
+    int rc = unifyfs_get_file_extents(num_keys, keys, keylens,
+                                      &num_vals, &keyvals);
+
+    /* this is to maintain limits imposed in previous code
+     * that would throw fatal errors */
+    if (num_vals >= UNIFYFS_MAX_SPLIT_CNT ||
+        num_vals >= MAX_META_PER_SEND) {
+        LOGERR("too many key/values returned in range lookup");
+        if (NULL != keyvals) {
+            free(keyvals);
+            keyvals = NULL;
+        }
         return UNIFYFS_ERROR_NOMEM;
     }
 
-    int num_vals = 0;
-    int rc = unifyfs_get_file_extents(num_keys, keys, keylens,
-                                      &num_vals, &keyvals);
     /* TODO: if there are file extents not accounted for we should
      * either return 0 for that data (holes) or EOF if reading past
      * the end of the file */
@@ -575,13 +577,14 @@ int create_gfid_chunk_reads(reqmgr_thrd_t* thrd_ctrl,
             qsort(keyvals, (size_t)num_vals, sizeof(unifyfs_keyval_t),
                   compare_kv_gfid_rank);
         }
+
         server_read_req_t* rdreq = reserve_read_req(thrd_ctrl);
         if (NULL == rdreq) {
             rc = UNIFYFS_FAILURE;
         } else {
-            rdreq->app_id = app_id;
-            rdreq->client_id = client_id;
-            rdreq->extent.gfid = gfid;
+            rdreq->app_id         = app_id;
+            rdreq->client_id      = client_id;
+            rdreq->extent.gfid    = gfid;
             rdreq->extent.errcode = EINPROGRESS;
             rc = create_chunk_requests(thrd_ctrl, rdreq,
                                        num_vals, keyvals);
@@ -591,8 +594,11 @@ int create_gfid_chunk_reads(reqmgr_thrd_t* thrd_ctrl,
         }
     }
 
-    // cleanup
-    free(keyvals);
+    /* free off key/value buffer returned from get_file_extents */
+    if (NULL != keyvals) {
+        free(keyvals);
+        keyvals = NULL;
+    }
 
     return rc;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The get_file_extents function in the server would throw an error if 4096 or more key/values are returned from a range lookup.  This changes the routines to support an arbitrary number of key/values.

### Description
<!--- Describe your changes in detail -->
It now allocates memory to hold the returned key/value pairs, which it returns to the caller.  The caller is responsible for freeing that buffer.

The function that reads data after doing this lookup would have errored out in the case that the number of returned keys is greater than either MAX_META_PER_SEND or UNIFYFS_MAX_SPLIT_CNT.  A check was added to keep that behavior.

Fixes: https://github.com/LLNL/UnifyFS/issues/365 (for now)

There will likely be problems once we have so many key/values returned that we exceed internal MDHIM limits.  An alternative would be to query the file size in regions or perhaps through recursive doubling and binary search.

I think we may ultimately want to have writers update the file size on fsync, and to do that in a scalable way, we may want to process these updates through a tree across the servers or something like that to distribute the load.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.