### PR TITLE
Remove old FILE_STORAGE_FIXED_CHUNK code

### DIFF
--- a/client/src/unifyfs-fixed.c
+++ b/client/src/unifyfs-fixed.c
@@ -625,10 +625,7 @@ int unifyfs_fid_store_fixed_write(int fid, unifyfs_filemeta_t* meta, off_t pos,
     int chunk_id;
     off_t chunk_offset;
 
-    if (meta->storage == FILE_STORAGE_FIXED_CHUNK) {
-        chunk_id = pos >> unifyfs_chunk_bits;
-        chunk_offset = pos & unifyfs_chunk_mask;
-    } else if (meta->storage == FILE_STORAGE_LOGIO) {
+    if (meta->storage == FILE_STORAGE_LOGIO) {
         chunk_id = meta->log_size >> unifyfs_chunk_bits;
         chunk_offset = meta->log_size & unifyfs_chunk_mask;
     } else {
@@ -639,9 +636,7 @@ int unifyfs_fid_store_fixed_write(int fid, unifyfs_filemeta_t* meta, off_t pos,
     size_t remaining = unifyfs_chunk_size - chunk_offset;
     if (count <= remaining) {
         /* all bytes for this write fit within the current chunk */
-        if (meta->storage == FILE_STORAGE_FIXED_CHUNK) {
-            rc = unifyfs_chunk_write(meta, chunk_id, chunk_offset, buf, count);
-        } else if (meta->storage == FILE_STORAGE_LOGIO) {
+        if (meta->storage == FILE_STORAGE_LOGIO) {
             rc = unifyfs_logio_chunk_write(fid, pos, meta, chunk_id, chunk_offset,
                                            buf, count);
         } else {
@@ -650,10 +645,7 @@ int unifyfs_fid_store_fixed_write(int fid, unifyfs_filemeta_t* meta, off_t pos,
     } else {
         /* otherwise, fill up the remainder of the current chunk */
         char* ptr = (char*) buf;
-        if (meta->storage == FILE_STORAGE_FIXED_CHUNK) {
-            rc = unifyfs_chunk_write(meta, chunk_id,
-                chunk_offset, (void*)ptr, remaining);
-        } else if (meta->storage == FILE_STORAGE_LOGIO) {
+        if (meta->storage == FILE_STORAGE_LOGIO) {
             rc = unifyfs_logio_chunk_write(fid, pos, meta, chunk_id,
                 chunk_offset, (void*)ptr, remaining);
         } else {
@@ -677,9 +669,7 @@ int unifyfs_fid_store_fixed_write(int fid, unifyfs_filemeta_t* meta, off_t pos,
             }
 
             /* write data */
-            if (meta->storage == FILE_STORAGE_FIXED_CHUNK) {
-                rc = unifyfs_chunk_write(meta, chunk_id, 0, (void*)ptr, num);
-            } else if (meta->storage == FILE_STORAGE_LOGIO) {
+            if (meta->storage == FILE_STORAGE_LOGIO) {
                 rc = unifyfs_logio_chunk_write(fid, pos, meta, chunk_id, 0,
                                                (void*)ptr, num);
             } else {

--- a/client/src/unifyfs-internal.h
+++ b/client/src/unifyfs-internal.h
@@ -252,10 +252,7 @@ enum flock_enum {
     SH_LOCKED
 };
 
-/* TODO: make this an enum */
-#define FILE_STORAGE_NULL        0
-#define FILE_STORAGE_FIXED_CHUNK 1
-#define FILE_STORAGE_LOGIO       2
+enum {FILE_STORAGE_NULL = 0, FILE_STORAGE_LOGIO};
 
 /* TODO: make this an enum */
 #define CHUNK_LOCATION_NULL      0

--- a/client/src/unifyfs.c
+++ b/client/src/unifyfs.c
@@ -1073,8 +1073,7 @@ int unifyfs_fid_write(int fid, off_t pos, const void* buf, size_t count)
     unifyfs_filemeta_t* meta = unifyfs_get_meta_from_fid(fid);
 
     /* determine storage type to write file data */
-    if (meta->storage == FILE_STORAGE_FIXED_CHUNK ||
-        meta->storage == FILE_STORAGE_LOGIO) {
+    if (meta->storage == FILE_STORAGE_LOGIO) {
         /* file stored in fixed-size chunks */
         rc = unifyfs_fid_store_fixed_write(fid, meta, pos, buf, count);
     } else {
@@ -1141,21 +1140,12 @@ int unifyfs_fid_extend(int fid, off_t length)
     unifyfs_filemeta_t* meta = unifyfs_get_meta_from_fid(fid);
 
     /* determine file storage type */
-    if (meta->storage == FILE_STORAGE_FIXED_CHUNK ||
-        meta->storage == FILE_STORAGE_LOGIO) {
+    if (meta->storage == FILE_STORAGE_LOGIO) {
         /* file stored in fixed-size chunks */
         rc = unifyfs_fid_store_fixed_extend(fid, meta, length);
     } else {
         /* unknown storage type */
         rc = (int)UNIFYFS_ERROR_IO;
-    }
-
-    /* TODO: move this statement elsewhere */
-    /* increase file size up to length */
-    if (meta->storage == FILE_STORAGE_FIXED_CHUNK) {
-        if (length > meta->local_size) {
-            meta->local_size = length;
-        }
     }
 
     return rc;
@@ -1164,21 +1154,9 @@ int unifyfs_fid_extend(int fid, off_t length)
 /* if length is less than reserved space, give back space down to length */
 int unifyfs_fid_shrink(int fid, off_t length)
 {
-    int rc;
+    /* TODO: implement this function */
 
-    /* get meta data for this file */
-    unifyfs_filemeta_t* meta = unifyfs_get_meta_from_fid(fid);
-
-    /* determine file storage type */
-    if (meta->storage == FILE_STORAGE_FIXED_CHUNK) {
-        /* file stored in fixed-size chunks */
-        rc = unifyfs_fid_store_fixed_shrink(fid, meta, length);
-    } else {
-        /* unknown storage type */
-        rc = (int)UNIFYFS_ERROR_IO;
-    }
-
-    return rc;
+    return UNIFYFS_ERROR_IO;
 }
 
 /* truncate file id to given length, frees resources if length is


### PR DESCRIPTION
### Description
Remove all references to the old FILE_STORAGE_FIXED_CHUNK code.  We use the FILE_STORAGE_LOGIO codepath exclusively now.

Note: This depends on #377, so I've included that commit here to make Travis happy.
### Motivation and Context
Code cleanup

### How Has This Been Tested?
Passed `make check` tests

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
