### PR TITLE
Clean up and portability

### DIFF
--- a/client/src/Makefile.am
+++ b/client/src/Makefile.am
@@ -1,11 +1,14 @@
-lib_LTLIBRARIES = libunifyfs.la libunifyfs_gotcha.la
+lib_LTLIBRARIES = libunifyfs.la
+libunifyfsdir = $(includedir)
+
+if HAVE_GOTCHA
+lib_LTLIBRARIES += libunifyfs_gotcha.la
+libunifyfs_gotchadir = $(includedir)
+endif
 
 if HAVE_FORTRAN
 lib_LTLIBRARIES += libunifyfsf.la
 endif
-
-libunifyfsdir = $(includedir)
-libunifyfs_gotchadir = $(includedir)
 
 AM_CFLAGS = -Wall -Wno-strict-aliasing
 
@@ -36,7 +39,11 @@ CLIENT_COMMON_LIBADD = \
   $(top_builddir)/common/src/libunifyfs_common.la \
   $(MARGO_LIBS) \
   $(FLATCC_LIBS) \
-  -lcrypto -lrt -lpthread
+  -lpthread
+
+if !HAVE_MACOS
+  CLIENT_COMMON_LIBADD += -lcrypto -lrt
+endif
 
 CLIENT_COMMON_SOURCES = \
   margo_client.c \
@@ -69,11 +76,15 @@ libunifyfs_la_CFLAGS   = $(CLIENT_COMMON_CFLAGS)
 libunifyfs_la_LDFLAGS  = $(CLIENT_COMMON_LDFLAGS)
 libunifyfs_la_LIBADD   = $(CLIENT_COMMON_LIBADD)
 
+if HAVE_GOTCHA
+
 libunifyfs_gotcha_la_SOURCES  = $(CLIENT_COMMON_SOURCES) gotcha_map_unifyfs_list.h
 libunifyfs_gotcha_la_CPPFLAGS = $(CLIENT_COMMON_CPPFLAGS) -DUNIFYFS_GOTCHA
 libunifyfs_gotcha_la_CFLAGS   = $(CLIENT_COMMON_CFLAGS) $(GOTCHA_CFLAGS)
 libunifyfs_gotcha_la_LDFLAGS  = $(CLIENT_COMMON_LDFLAGS) $(GOTCHA_LDFLAGS)
 libunifyfs_gotcha_la_LIBADD   = $(CLIENT_COMMON_LIBADD) -lgotcha
+
+endif
 
 if HAVE_FORTRAN
 

--- a/client/src/unifyfs-internal.h
+++ b/client/src/unifyfs-internal.h
@@ -265,11 +265,16 @@ typedef struct {
 } unifyfs_chunkmeta_t;
 
 typedef struct {
+
     off_t global_size;               /* Global size of the file */
     off_t local_size;                /* Local size of the file */
     off_t log_size;                  /* Log size.  This is the sum of all the
                                       * write counts. */
+#if defined(__APPLE__) || defined(__OSX__)
+    pthread_mutex_t fspinlock;    /* file lock variable */
+#else
     pthread_spinlock_t fspinlock;    /* file lock variable */
+#endif
     enum flock_enum flock_status;    /* file lock status */
 
     int storage;                     /* FILE_STORAGE type */
@@ -404,7 +409,7 @@ extern void* free_chunk_stack;
 extern void* free_spillchunk_stack;
 extern char* unifyfs_chunks;
 extern unifyfs_chunkmeta_t* unifyfs_chunkmetas;
-int unifyfs_spilloverblock;
+extern int unifyfs_spilloverblock;
 
 /* -------------------------------
  * Common functions

--- a/client/src/unifyfs-stdio.c
+++ b/client/src/unifyfs-stdio.c
@@ -1426,7 +1426,11 @@ int UNIFYFS_WRAP(fprintf)(FILE* stream, const char* format, ...)
 }
 
 /* need to declare this before calling it */
-static int __svfscanf(unifyfs_stream_t* fp, const char* fmt0, va_list ap);
+#if defined(__APPLE__) || defined(__OSX__)
+    //static int __svfscanf(unifyfs_stream_t* fp, const char* fmt0, __gnuc_va_list ap) __scanflike(2, 0);
+#else
+    static int __svfscanf(unifyfs_stream_t* fp, const char* fmt0, va_list ap);
+#endif
 
 int UNIFYFS_WRAP(vfscanf)(FILE* stream, const char* format, va_list ap)
 {
@@ -2564,6 +2568,7 @@ ok:
     return (p - buf);
 }
 
+#if !defined(__APPLE__) && !defined(__OSX__)
 /*
  * __svfscanf - non-MT-safe version of __vfscanf
  */
@@ -2947,7 +2952,7 @@ input_failure:
 match_failure:
     return (nassigned);
 }
-
+#endif
 /*
  * Fill in the given table from the scanset at the given format
  * (just after `[').  Return a pointer to the character past the

--- a/client/src/unifyfs.c
+++ b/client/src/unifyfs.c
@@ -46,7 +46,17 @@
 
 #include <time.h>
 #include <mpi.h>
-#include <openssl/md5.h>
+
+#if defined(__APPLE__) || defined (__OSX__)
+    #include <CommonCrypto/CommonDigest.h>
+    #define MD5 CC_MD5
+    #define MD5_CTX CC_MD5_CTX
+    #define MD5_Init CC_MD5_Init
+    #define MD5_Update CC_MD5_Update
+    #define MD5_Final CC_MD5_Final
+#else
+    #include <openssl/md5.h>
+#endif
 
 #ifdef HAVE_LIBNUMA
 #include <numa.h>
@@ -980,7 +990,11 @@ int unifyfs_fid_create_file(const char* path)
     meta->mode = UNIFYFS_STAT_DEFAULT_FILE_MODE;
 
     /* PTHREAD_PROCESS_SHARED allows Process-Shared Synchronization*/
+#if defined(__APPLE__) || defined(__OSX__)
+    pthread_mutex_init(&meta->fspinlock, NULL);
+#else
     pthread_spin_init(&meta->fspinlock, PTHREAD_PROCESS_SHARED);
+#endif
 
     return fid;
 }

--- a/client/unifyfs-config.in
+++ b/client/unifyfs-config.in
@@ -12,8 +12,11 @@ UNIFYFS_LIB_PATH="@unifyfs_lib_path@"
 UNIFYFS_LD_FLAGS="@LDFLAGS@"
 
 PRE_LD_FLAGS="-L$UNIFYFS_LIB_PATH $UNIFYFS_LD_FLAGS -lz $CP_WRAPPERS"
-POST_LD_FLAGS="$UNIFYFS_LIB_PATH/libunifyfs.a -lcrypto -lm -lrt -lpthread"
+POST_LD_FLAGS="$UNIFYFS_LIB_PATH/libunifyfs.a -lm -lpthread"
 
+if !HAVE_MACOS
+  POST_LD_FLAGS += -lcrypto -lrt
+endif
 
 usage="\
 Usage: unifyfs-config [--pre-ld-flags] [--post-ld-flags]"

--- a/common/src/Makefile.am
+++ b/common/src/Makefile.am
@@ -63,6 +63,10 @@ libunifyfs_common_la_LDFLAGS = \
   -version-info $(LIBUNIFYFS_LT_VERSION)
 
 libunifyfs_common_la_LIBADD = \
-  $(OPT_LIBS) -lm -lrt
+  $(OPT_LIBS) -lm
+
+if !HAVE_MACOS
+  libunifyfs_common_la_LIBADD += -lrt
+endif
 
 AM_CFLAGS = -Wall -Wno-strict-aliasing

--- a/common/src/unifyfs_keyval.c
+++ b/common/src/unifyfs_keyval.c
@@ -33,11 +33,11 @@
 #include <sys/stat.h>
 
 // UnifyFS keys
-const char* key_runstate           = "unifyfs.runstate";
-const char* key_unifyfsd_socket    = "unifyfsd.socket";
-const char* key_unifyfsd_margo_shm = "unifyfsd.margo-shm";
-const char* key_unifyfsd_margo_svr = "unifyfsd.margo-svr";
-const char* key_unifyfsd_pmi_rank  = "unifyfsd.pmi-rank";
+const char * const key_runstate           = "unifyfs.runstate";
+const char * const key_unifyfsd_socket    = "unifyfsd.socket";
+const char * const key_unifyfsd_margo_shm = "unifyfsd.margo-shm";
+const char * const key_unifyfsd_margo_svr = "unifyfsd.margo-svr";
+const char * const key_unifyfsd_pmi_rank  = "unifyfsd.pmi-rank";
 
 // key-value store state
 static int kv_initialized; // = 0

--- a/common/src/unifyfs_keyval.h
+++ b/common/src/unifyfs_keyval.h
@@ -22,11 +22,11 @@ extern "C" {
 #endif
 
 // keys we use
-const char* key_runstate;           // path to runstate file
-const char* key_unifyfsd_socket;    // server domain socket path
-const char* key_unifyfsd_margo_shm; // client-server margo address
-const char* key_unifyfsd_margo_svr; // server-server margo address
-const char* key_unifyfsd_pmi_rank;  // server-server pmi rank
+extern const char * const key_runstate;           // path to runstate file
+extern const char * const key_unifyfsd_socket;    // server domain socket path
+extern const char * const key_unifyfsd_margo_shm; // client-server margo address
+extern const char * const key_unifyfsd_margo_svr; // server-server margo address
+extern const char * const key_unifyfsd_pmi_rank;  // server-server pmi rank
 
 // initialize key-value store
 int unifyfs_keyval_init(unifyfs_cfg_t* cfg,

--- a/configure.ac
+++ b/configure.ac
@@ -24,8 +24,6 @@ AC_PROG_CPP
 AC_PROG_INSTALL
 AC_PROG_LN_S
 AC_PROG_MAKE_SET
-AC_PROG_RANLIB
-
 
 # fortran support
 AC_ARG_ENABLE([fortran],
@@ -66,8 +64,21 @@ AC_CHECK_HEADERS([fcntl.h limits.h stdlib.h string.h sys/socket.h sys/time.h])
 AC_CHECK_HEADERS([unistd.h arpa/inet.h inttypes.h netdb.h netinet/in.h])
 AC_CHECK_HEADERS([stddef.h stdint.h libgen.h strings.h syslog.h])
 AC_CHECK_HEADERS([inttypes.h wchar.h wctype.h])
-AC_CHECK_HEADER([openssl/md5.h], [], [AC_MSG_FAILURE([
-        *** openssl/md5.h missing, openssl-devel package required])])
+
+
+case $host in
+    *darwin* )
+        dnl newer versions of OSX do not ship headers for OpenSSL
+        dnl we can use CommonCrypto instead
+        AM_CONDITIONAL([HAVE_MACOS], [true])
+        AC_CHECK_HEADER([CommonCrypto/CommonDigest.h], [], [AC_MSG_FAILURE([
+        *** Cant find CommonCrypto api])])
+    ;;
+    *)
+        AC_CHECK_HEADER([openssl/md5.h], [], [AC_MSG_FAILURE([
+            *** openssl/md5.h missing, openssl-devel package required])])
+    ;;
+esac
 
 # Checks for library functions.
 AC_FUNC_MALLOC
@@ -143,6 +154,27 @@ AC_ARG_ENABLE(st-dev-workaround,
 fi]
 ,)
 
+# look for MPI and set flags
+LX_FIND_MPI
+if test "x$enable_fortran" = "xyes"; then
+AC_LANG_PUSH([Fortran])
+LX_FIND_MPI
+AC_LANG_POP
+fi
+
+if test "$have_C_mpi" != "yes" ; then
+    AC_MSG_ERROR(["Couldn't find MPI"])
+fi
+
+# look for leveldb library, sets LEVELDB_CFLAGS/LDFLAGS/LIBS
+UNIFYFS_AC_LEVELDB
+
+# look for gotcha library, sets GOTCHA_INCLUDE, GOTCHA_LIB
+UNIFYFS_AC_GOTCHA
+
+UNIFYFS_AC_MARGO
+UNIFYFS_AC_FLATCC
+
 # checks to see how we can print 64 bit values on this architecture
 gt_INTTYPES_PRI
 
@@ -166,27 +198,6 @@ AC_TRY_COMPILE(
 
 AC_CHECK_HEADERS(mntent.h sys/mount.h)
 
-# look for MPI and set flags
-LX_FIND_MPI
-if test "x$enable_fortran" = "xyes"; then
-AC_LANG_PUSH([Fortran])
-LX_FIND_MPI
-AC_LANG_POP
-fi
-
-if test "$have_C_mpi" != "yes" ; then
-    AC_MSG_ERROR(["Couldn't find MPI"])
-fi
-
-# look for leveldb library, sets LEVELDB_CFLAGS/LDFLAGS/LIBS
-UNIFYFS_AC_LEVELDB
-
-# look for gotcha library, sets GOTCHA_INCLUDE, GOTCHA_LIB
-UNIFYFS_AC_GOTCHA
-
-UNIFYFS_AC_MARGO
-UNIFYFS_AC_FLATCC
-
 # HDF found?
 AX_LIB_HDF5
 AM_CONDITIONAL([HAVE_HDF5], [test x$with_hdf5 = xyes])
@@ -196,7 +207,9 @@ AM_CONDITIONAL([HAVE_HDF5], [test x$with_hdf5 = xyes])
 CP_WRAPPERS+="-Wl,-wrap,access"
 CP_WRAPPERS+=",-wrap,chmod"
 CP_WRAPPERS+=",-wrap,fchmod"
-CP_WRAPPERS+=",-wrap,lio_listio"
+AC_CHECK_FUNCS(lio_listio,[
+    CP_WRAPPERS+=",-wrap,lio_listio"
+], [])
 CP_WRAPPERS+=",-wrap,mkdir"
 CP_WRAPPERS+=",-wrap,rmdir"
 CP_WRAPPERS+=",-wrap,unlink"
@@ -205,13 +218,24 @@ CP_WRAPPERS+=",-wrap,rename"
 CP_WRAPPERS+=",-wrap,truncate"
 CP_WRAPPERS+=",-wrap,stat"
 CP_WRAPPERS+=",-wrap,fstat"
-CP_WRAPPERS+=",-wrap,__lxstat"
-CP_WRAPPERS+=",-wrap,__xstat"
+
+AC_CHECK_FUNCS(__lxstat,[
+    CP_WRAPPERS+=",-wrap,__lxstat"
+],[])
+AC_CHECK_FUNCS(__xstat,[
+    CP_WRAPPERS+=",-wrap,__xstat"
+],[])
+
+AC_CHECK_FUNCS(__fxstat,[
+    CP_WRAPPERS+=",-wrap,__fxstat"
+],[])
 
 CP_WRAPPERS+=",-wrap,creat"
 CP_WRAPPERS+=",-wrap,creat64"
 CP_WRAPPERS+=",-wrap,open"
-CP_WRAPPERS+=",-wrap,open64"
+AC_CHECK_FUNCS(open64, [
+    CP_WRAPPERS+=",-wrap,open64"
+],[])
 CP_WRAPPERS+=",-wrap,__open_2"
 CP_WRAPPERS+=",-wrap,read"
 CP_WRAPPERS+=",-wrap,write"
@@ -221,7 +245,9 @@ CP_WRAPPERS+=",-wrap,pread"
 CP_WRAPPERS+=",-wrap,pread64"
 CP_WRAPPERS+=",-wrap,pwrite"
 CP_WRAPPERS+=",-wrap,pwrite64"
-CP_WRAPPERS+=",-wrap,posix_fadvise"
+AC_CHECK_FUNCS(posix_fadvise, [
+    CP_WRAPPERS+=",-wrap,posix_fadvise"
+],[])
 CP_WRAPPERS+=",-wrap,lseek"
 CP_WRAPPERS+=",-wrap,lseek64"
 CP_WRAPPERS+=",-wrap,ftruncate"
@@ -232,7 +258,6 @@ CP_WRAPPERS+=",-wrap,mmap"
 CP_WRAPPERS+=",-wrap,mmap64"
 CP_WRAPPERS+=",-wrap,munmap"
 CP_WRAPPERS+=",-wrap,msync"
-CP_WRAPPERS+=",-wrap,__fxstat"
 CP_WRAPPERS+=",-wrap,close"
 
 # FILE* functions

--- a/examples/src/Makefile.am
+++ b/examples/src/Makefile.am
@@ -1,21 +1,42 @@
 libexec_PROGRAMS = \
-  cr-posix cr-gotcha cr-static \
-  read-posix read-gotcha read-static \
-  write-posix write-gotcha write-static \
-  writeread-posix writeread-gotcha writeread-static \
-  sysio-write-gotcha sysio-write-static \
-  sysio-read-gotcha sysio-read-static \
-  sysio-writeread-gotcha sysio-writeread-static sysio-writeread-posix \
-  sysio-writeread2-gotcha sysio-writeread2-static \
-  sysio-dir-gotcha sysio-dir-static \
-  sysio-stat-gotcha sysio-stat-static \
-  sysio-cp-gotcha sysio-cp-static \
-  app-mpiio-gotcha app-mpiio-static \
-  app-btio-gotcha app-btio-static \
-  app-tileio-gotcha app-tileio-static \
-  transfer-gotcha transfer-static \
-  size-gotcha size-static \
-  chmod-gotcha chmod-static
+  cr-posix cr-static \
+  read-posix read-static \
+  write-posix write-static \
+  writeread-posix writeread-static \
+  sysio-write-static \
+  sysio-read-static \
+  sysio-writeread-static sysio-writeread-posix \
+  sysio-writeread2-static \
+  sysio-dir-static \
+  sysio-stat-static \
+  sysio-cp-static \
+  app-mpiio-static \
+  app-btio-static \
+  app-tileio-static \
+  transfer-static \
+  size-static \
+  chmod-static
+
+if HAVE_GOTCHA
+  libexec_PROGRAMS += \
+    cr-gotcha \
+    read-gotcha \
+    write-gotcha \
+    writeread-gotcha \
+    sysio-write-gotcha \
+    sysio-read-gotcha \
+    sysio-writeread-gotcha \
+    sysio-writeread2-gotcha \
+    sysio-dir-gotcha \
+    sysio-stat-gotcha \
+    sysio-cp-gotcha \
+    app-mpiio-gotcha \
+    app-btio-gotcha \
+    app-tileio-gotcha \
+    transfer-gotcha \
+    size-gotcha \
+    chmod-gotcha
+endif
 
 if HAVE_FORTRAN
 libexec_PROGRAMS += \
@@ -43,39 +64,55 @@ test_cppflags = $(AM_CPPFLAGS) $(MPI_CFLAGS) \
 if HAVE_FORTRAN
 test_ftn_flags   = $(AM_FCFLAGS) $(MPI_FFLAGS) \
    -I$(top_srcdir)/client/src -I$(top_srcdir)/common/src
-test_ftn_ldadd   = $(top_builddir)/client/src/libunifyfsf.la -lrt -lm $(FCLIBS)
+test_ftn_ldadd   = $(top_builddir)/client/src/libunifyfsf.la -lm $(FCLIBS)
+if !HAVE_MACOS
+  test_ftn_ldadd += -lrt
+endif
 test_ftn_ldflags = $(AM_LDFLAGS) $(MPI_FLDFLAGS) \
     $(FLATCC_LDFLAGS) $(FLATCC_LIBS)
 endif
 
-test_gotcha_ldadd   = $(top_builddir)/client/src/libunifyfs_gotcha.la -lrt -lm
+test_gotcha_ldadd   = $(top_builddir)/client/src/libunifyfs_gotcha.la -lm
+if !HAVE_MACOS
+  test_gotcha_ldadd += -lrt
+endif
 test_gotcha_ldflags = $(AM_LDFLAGS) $(MPI_CLDFLAGS) \
     $(FLATCC_LDFLAGS) $(FLATCC_LIBS)
 
 test_posix_cppflags = $(AM_CPPFLAGS) $(MPI_CFLAGS) -DDISABLE_UNIFYFS
-test_posix_ldadd    = -lrt -lm
+test_posix_ldadd    = -lm
+if !HAVE_MACOS
+  test_posix_ldadd += -lrt
+endif
 test_posix_ldflags  = $(AM_LDFLAGS) $(MPI_CLDFLAGS)
 
-test_static_ldadd   = $(top_builddir)/client/src/libunifyfs.la -lrt -lm
+test_static_ldadd   = $(top_builddir)/client/src/libunifyfs.la -lm
+if !HAVE_MACOS
+  test_static_ldadd += -lrt
+endif
 test_static_ldflags = -static $(CP_WRAPPERS) $(AM_LDFLAGS) $(MPI_CLDFLAGS) \
     $(FLATCC_LDFLAGS) $(FLATCC_LIBS)
 
 # Per-target flags begin here
 
+if HAVE_GOTCHA
 sysio_write_gotcha_SOURCES  = sysio-write.c
 sysio_write_gotcha_CPPFLAGS = $(test_cppflags)
 sysio_write_gotcha_LDADD    = $(test_gotcha_ldadd)
 sysio_write_gotcha_LDFLAGS  = $(test_gotcha_ldflags)
+endif
 
 sysio_write_static_SOURCES  = sysio-write.c
 sysio_write_static_CPPFLAGS = $(test_cppflags)
 sysio_write_static_LDADD    = $(test_static_ldadd)
 sysio_write_static_LDFLAGS  = $(test_static_ldflags)
 
+if HAVE_GOTCHA
 sysio_read_gotcha_SOURCES  = sysio-read.c
 sysio_read_gotcha_CPPFLAGS = $(test_cppflags)
 sysio_read_gotcha_LDADD    = $(test_gotcha_ldadd)
 sysio_read_gotcha_LDFLAGS  = $(test_gotcha_ldflags)
+endif
 
 sysio_read_static_SOURCES  = sysio-read.c
 sysio_read_static_CPPFLAGS = $(test_cppflags)
@@ -87,50 +124,60 @@ sysio_writeread_posix_CPPFLAGS = $(test_posix_cppflags)
 sysio_writeread_posix_LDADD    = $(test_posix_ldadd)
 sysio_writeread_posix_LDFLAGS  = $(test_posix_ldflags)
 
+if HAVE_GOTCHA
 sysio_writeread_gotcha_SOURCES  = sysio-writeread.c
 sysio_writeread_gotcha_CPPFLAGS = $(test_cppflags)
 sysio_writeread_gotcha_LDADD    = $(test_gotcha_ldadd)
 sysio_writeread_gotcha_LDFLAGS  = $(test_gotcha_ldflags)
+endif
 
 sysio_writeread_static_SOURCES  = sysio-writeread.c
 sysio_writeread_static_CPPFLAGS = $(test_cppflags)
 sysio_writeread_static_LDADD    = $(test_static_ldadd)
 sysio_writeread_static_LDFLAGS  = $(test_static_ldflags)
 
+if HAVE_GOTCHA
 sysio_writeread2_gotcha_SOURCES  = sysio-writeread2.c
 sysio_writeread2_gotcha_CPPFLAGS = $(test_cppflags)
 sysio_writeread2_gotcha_LDADD    = $(test_gotcha_ldadd)
 sysio_writeread2_gotcha_LDFLAGS  = $(test_gotcha_ldflags)
+endif
 
 sysio_writeread2_static_SOURCES  = sysio-writeread2.c
 sysio_writeread2_static_CPPFLAGS = $(test_cppflags)
 sysio_writeread2_static_LDADD    = $(test_static_ldadd)
 sysio_writeread2_static_LDFLAGS  = $(test_static_ldflags)
 
+if HAVE_GOTCHA
 sysio_dir_gotcha_SOURCES  = sysio-dir.c
 sysio_dir_gotcha_CPPFLAGS = $(test_cppflags)
 sysio_dir_gotcha_LDADD    = $(test_gotcha_ldadd)
 sysio_dir_gotcha_LDFLAGS  = $(test_gotcha_ldflags)
+endif
 
 sysio_dir_static_SOURCES  = sysio-dir.c
 sysio_dir_static_CPPFLAGS = $(test_cppflags)
 sysio_dir_static_LDADD    = $(test_static_ldadd)
 sysio_dir_static_LDFLAGS  = $(test_static_ldflags)
 
+if HAVE_GOTCHA
 sysio_stat_gotcha_SOURCES  = sysio-stat.c
 sysio_stat_gotcha_CPPFLAGS = $(test_cppflags)
 sysio_stat_gotcha_LDADD    = $(test_gotcha_ldadd)
 sysio_stat_gotcha_LDFLAGS  = $(test_gotcha_ldflags)
+endif
 
 sysio_stat_static_SOURCES  = sysio-stat.c
 sysio_stat_static_CPPFLAGS = $(test_cppflags)
 sysio_stat_static_LDADD    = $(test_static_ldadd)
 sysio_stat_static_LDFLAGS  = $(test_static_ldflags)
 
+if HAVE_GOTCHA
 sysio_cp_gotcha_SOURCES  = sysio-cp.c
 sysio_cp_gotcha_CPPFLAGS = $(test_cppflags)
 sysio_cp_gotcha_LDADD    = $(test_gotcha_ldadd)
 sysio_cp_gotcha_LDFLAGS  = $(test_gotcha_ldflags)
+endif
 
 sysio_cp_static_SOURCES  = sysio-cp.c
 sysio_cp_static_CPPFLAGS = $(test_cppflags)
@@ -142,10 +189,12 @@ cr_posix_CPPFLAGS = $(test_posix_cppflags)
 cr_posix_LDADD    = $(test_posix_ldadd)
 cr_posix_LDFLAGS  = $(test_posix_ldflags)
 
+if HAVE_GOTCHA
 cr_gotcha_SOURCES  = checkpoint-restart.c
 cr_gotcha_CPPFLAGS = $(test_cppflags)
 cr_gotcha_LDADD    = $(test_gotcha_ldadd)
 cr_gotcha_LDFLAGS  = $(test_gotcha_ldflags)
+endif
 
 cr_static_SOURCES  = checkpoint-restart.c
 cr_static_CPPFLAGS = $(test_cppflags)
@@ -157,10 +206,12 @@ read_posix_CPPFLAGS = $(test_posix_cppflags)
 read_posix_LDADD    = $(test_posix_ldadd)
 read_posix_LDFLAGS  = $(test_posix_ldflags)
 
+if HAVE_GOTCHA
 read_gotcha_SOURCES  = read.c
 read_gotcha_CPPFLAGS = $(test_cppflags)
 read_gotcha_LDADD    = $(test_gotcha_ldadd)
 read_gotcha_LDFLAGS  = $(test_gotcha_ldflags)
+endif
 
 read_static_SOURCES  = read.c
 read_static_CPPFLAGS = $(test_cppflags)
@@ -172,10 +223,12 @@ write_posix_CPPFLAGS = $(test_posix_cppflags)
 write_posix_LDADD    = $(test_posix_ldadd)
 write_posix_LDFLAGS  = $(test_posix_ldflags)
 
+if HAVE_GOTCHA
 write_gotcha_SOURCES  = write.c
 write_gotcha_CPPFLAGS = $(test_cppflags)
 write_gotcha_LDADD    = $(test_gotcha_ldadd)
 write_gotcha_LDFLAGS  = $(test_gotcha_ldflags)
+endif
 
 write_static_SOURCES  = write.c
 write_static_CPPFLAGS = $(test_cppflags)
@@ -187,40 +240,48 @@ writeread_posix_CPPFLAGS = $(test_posix_cppflags)
 writeread_posix_LDADD    = $(test_posix_ldadd)
 writeread_posix_LDFLAGS  = $(test_posix_ldflags)
 
+if HAVE_GOTCHA
 writeread_gotcha_SOURCES  = writeread.c
 writeread_gotcha_CPPFLAGS = $(test_cppflags)
 writeread_gotcha_LDADD    = $(test_gotcha_ldadd)
 writeread_gotcha_LDFLAGS  = $(test_gotcha_ldflags)
+endif
 
 writeread_static_SOURCES  = writeread.c
 writeread_static_CPPFLAGS = $(test_cppflags)
 writeread_static_LDADD    = $(test_static_ldadd)
 writeread_static_LDFLAGS  = $(test_static_ldflags)
 
+if HAVE_GOTCHA
 app_mpiio_gotcha_SOURCES  = app-mpiio.c
 app_mpiio_gotcha_CPPFLAGS = $(test_cppflags)
 app_mpiio_gotcha_LDADD    = $(test_gotcha_ldadd)
 app_mpiio_gotcha_LDFLAGS  = $(test_gotcha_ldflags)
+endif
 
 app_mpiio_static_SOURCES  = app-mpiio.c
 app_mpiio_static_CPPFLAGS = $(test_cppflags)
 app_mpiio_static_LDADD    = $(test_static_ldadd)
 app_mpiio_static_LDFLAGS  = $(test_static_ldflags)
 
+if HAVE_GOTCHA
 app_btio_gotcha_SOURCES  = app-btio.c
 app_btio_gotcha_CPPFLAGS = $(test_cppflags)
 app_btio_gotcha_LDADD    = $(test_gotcha_ldadd)
 app_btio_gotcha_LDFLAGS  = $(test_gotcha_ldflags)
+endif
 
 app_btio_static_SOURCES  = app-btio.c
 app_btio_static_CPPFLAGS = $(test_cppflags)
 app_btio_static_LDADD    = $(test_static_ldadd)
 app_btio_static_LDFLAGS  = $(test_static_ldflags)
 
+if HAVE_GOTCHA
 app_tileio_gotcha_SOURCES  = app-tileio.c
 app_tileio_gotcha_CPPFLAGS = $(test_cppflags)
 app_tileio_gotcha_LDADD    = $(test_gotcha_ldadd)
 app_tileio_gotcha_LDFLAGS  = $(test_gotcha_ldflags)
+endif
 
 app_tileio_static_SOURCES  = app-tileio.c
 app_tileio_static_CPPFLAGS = $(test_cppflags)
@@ -250,30 +311,36 @@ app_hdf5_writeread_gotcha_LDFLAGS  = $(test_gotcha_ldflags) $(HDF5_LDFLAGS)
 
 endif
 
+if HAVE_GOTCHA
 transfer_gotcha_SOURCES  = transfer.c
 transfer_gotcha_CPPFLAGS = $(test_cppflags)
 transfer_gotcha_LDADD    = $(test_gotcha_ldadd)
 transfer_gotcha_LDFLAGS  = $(test_gotcha_ldflags)
+endif
 
 transfer_static_SOURCES  = transfer.c
 transfer_static_CPPFLAGS = $(test_cppflags)
 transfer_static_LDADD    = $(test_static_ldadd)
 transfer_static_LDFLAGS  = $(test_static_ldflags)
 
+if HAVE_GOTCHA
 size_gotcha_SOURCES  = size.c testutil.c
 size_gotcha_CPPFLAGS = $(test_cppflags)
 size_gotcha_LDADD    = $(test_gotcha_ldadd)
 size_gotcha_LDFLAGS  = $(test_gotcha_ldflags)
+endif
 
 size_static_SOURCES  = size.c testutil.c
 size_static_CPPFLAGS = $(test_cppflags)
 size_static_LDADD    = $(test_static_ldadd)
 size_static_LDFLAGS  = $(test_static_ldflags)
 
+if HAVE_GOTCHA
 chmod_gotcha_SOURCES  = chmod.c testutil.c
 chmod_gotcha_CPPFLAGS = $(test_cppflags)
 chmod_gotcha_LDADD    = $(test_gotcha_ldadd)
 chmod_gotcha_LDFLAGS  = $(test_gotcha_ldflags)
+endif
 
 chmod_static_SOURCES  = chmod.c testutil.c
 chmod_static_CPPFLAGS = $(test_cppflags)

--- a/examples/src/sysio-stat.c
+++ b/examples/src/sysio-stat.c
@@ -22,7 +22,7 @@
 #include <sys/time.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <sys/sysmacros.h>
+//#include <sys/sysmacros.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <dirent.h>

--- a/examples/src/testutil.c
+++ b/examples/src/testutil.c
@@ -5,7 +5,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <time.h>
-#include <sys/sysmacros.h>
+//#include <sys/sysmacros.h>
 #include <unistd.h>
 #include <errno.h>
 #include <stdarg.h>

--- a/m4/gotcha.m4
+++ b/m4/gotcha.m4
@@ -16,10 +16,15 @@ AC_DEFUN([UNIFYFS_AC_GOTCHA], [
   AC_CHECK_LIB([gotcha], [gotcha_wrap],
     [AC_SUBST(GOTCHA_CFLAGS)
      AC_SUBST(GOTCHA_LDFLAGS)
+     gotcha = true
     ],
-    [AC_MSG_ERROR([couldn't find a suitable libgotcha, use --with-gotcha=PATH])],
+    [AC_MSG_WARN([couldn't find a suitable libgotcha, use --with-gotcha=PATH])
+     gotcha = false
+    ],
     []
   )
+
+  AM_CONDITIONAL([HAVE_GOTCHA], [test x$gotcha = xtrue])
 
   # restore flags
   CFLAGS=$GOTCHA_OLD_CFLAGS

--- a/meta/src/data_store.h
+++ b/meta/src/data_store.h
@@ -37,6 +37,8 @@
 #ifndef      __STORE_H
 #define      __STORE_H
 
+#include <pthread.h>
+
 #include "uthash.h"
 #include "mdhim_options.h"
 

--- a/meta/src/ds_leveldb.c
+++ b/meta/src/ds_leveldb.c
@@ -38,7 +38,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
-#include <linux/limits.h>
+//#include <linux/limits.h>
+#include <limits.h>
 #include <sys/time.h>
 #include "ds_leveldb.h"
 

--- a/meta/src/indexes.c
+++ b/meta/src/indexes.c
@@ -36,7 +36,8 @@
 
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <linux/limits.h>
+//#include <linux/limits.h>
+#include <limits.h>
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/meta/src/indexes.h
+++ b/meta/src/indexes.h
@@ -46,6 +46,8 @@
 #define LOCAL_INDEX 3
 #define REMOTE_INDEX 4
 
+#define ulong unsigned long
+
 struct mdhim_t; // avoid circular #include chain
 
 typedef struct rangesrv_info rangesrv_info;

--- a/meta/src/range_server.c
+++ b/meta/src/range_server.c
@@ -39,7 +39,8 @@
 #include <stdio.h>
 #include <unistd.h>
 #include <errno.h>
-#include <linux/limits.h>
+//#include <linux/limits.h>
+#include <limits.h>
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/server/src/Makefile.am
+++ b/server/src/Makefile.am
@@ -33,7 +33,11 @@ unifyfsd_LDADD = \
     $(MPI_CLDFLAGS) \
     $(MARGO_LIBS) \
     $(FLATCC_LIBS) \
-    -lpthread -lm -lstdc++ -lrt
+    -lpthread -lm -lstdc++
+
+if !HAVE_MACOS
+  unifyfsd_LDADD += -lrt
+endif
 
 AM_CPPFLAGS = \
   -I$(top_srcdir)/common/src \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -74,7 +74,11 @@ test_metadata_ldadd = \
 	$(ARGOBOTS_LDFLAGS) $(ARGOBOTS_LIBS) \
 	$(MARGO_LDFLAGS) $(MARGO_LIBS) \
 	$(FLATCC_LDFLAGS) $(FLATCC_LIBS) \
-	-lpthread -lm -lstdc++ -lrt
+	-lpthread -lm -lstdc++
+
+if !HAVE_MACOS
+  test_metadata_ldadd += -lrt
+endif
 
 test_meta_cppflags = \
 	-I$(top_srcdir) \


### PR DESCRIPTION
- remove AC_PROG_RANLIB
- check for dependent libraries early on
- use commoncrypto on MacOS instead of OpenSSL (newer versions do not
  ship with OpenSSL headers)
- Add check for presence of functions to configure (some of the
  functions we wrap do not exist on MacOS and potentially other OS)
- Make Gothca an option (this disables building Gotcha libs and tests)

TODO:
  --wrap is not supported on MacOS, still need to check if the linker
  supports this option and disable static linking if this is not the
  case.

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
