### PR TITLE
client: cleanup index slice code

### DIFF
--- a/client/src/unifyfs-fixed.c
+++ b/client/src/unifyfs-fixed.c
@@ -328,7 +328,7 @@ static int unifyfs_coalesce_index(
 
     /* adjust current index to subtract off those bytes */
     next_idx->file_pos += length;
-    next_idx->mem_pos  += length;
+    next_idx->log_pos  += length;
     next_idx->length   -= length;
 
     return UNIFYFS_SUCCESS;
@@ -393,7 +393,7 @@ static int unifyfs_split_index(
          */
 
         /* get starting position in log */
-        long log_pos = cur_idx->mem_pos;
+        long log_pos = cur_idx->log_pos;
 
         /* copy over all fields in current index */
         set[count] = *cur_idx;
@@ -432,7 +432,7 @@ static int unifyfs_split_index(
             set[count].fid      = cur_idx->fid;
             set[count].file_pos = slice_start;
             set[count].length   = length;
-            set[count].mem_pos  = log_pos;
+            set[count].log_pos  = log_pos;
 
             /* advance offset into log */
             log_pos += length;
@@ -459,7 +459,7 @@ static int unifyfs_split_index(
         set[count].fid      = cur_idx->fid;
         set[count].file_pos = slice_start;
         set[count].length   = length;
-        set[count].mem_pos  = log_pos;
+        set[count].log_pos  = log_pos;
         count++;
     }
 
@@ -539,7 +539,7 @@ static int unifyfs_logio_chunk_write(
     unifyfs_index_t cur_idx;
     cur_idx.fid      = ptr_meta_entry->gfid;
     cur_idx.file_pos = pos;
-    cur_idx.mem_pos  = log_offset;
+    cur_idx.log_pos  = log_offset;
     cur_idx.length   = count;
 
     /* lookup number of existing index entries */

--- a/client/src/unifyfs-fixed.c
+++ b/client/src/unifyfs-fixed.c
@@ -460,7 +460,7 @@ static int unifyfs_split_index(
     return UNIFYFS_SUCCESS;
 }
 
-/* read data from specified chunk id, chunk offset, and count into user buffer,
+/* write count bytes from user buffer into specified chunk id at chunk offset,
  * count should fit within chunk starting from specified offset */
 static int unifyfs_logio_chunk_write(
     int fid,                  /* local file id */
@@ -601,11 +601,11 @@ static int unifyfs_logio_chunk_write(
     /* update number of entries in index array */
     (*unifyfs_indices.ptr_num_entries) = num_entries;
 
-    /* assume read was successful if we get to here */
+    /* assume write was successful if we get to here */
     return UNIFYFS_SUCCESS;
 }
 
-/* read data from specified chunk id, chunk offset, and count into user buffer,
+/* write count bytes from user buffer into specified chunk id at chunk offset,
  * count should fit within chunk starting from specified offset */
 static int unifyfs_chunk_write(
     unifyfs_filemeta_t* meta, /* pointer to file meta data */
@@ -641,7 +641,7 @@ static int unifyfs_chunk_write(
         return UNIFYFS_ERROR_IO;
     }
 
-    /* assume read was successful if we get to here */
+    /* assume write was successful if we get to here */
     return UNIFYFS_SUCCESS;
 }
 

--- a/client/src/unifyfs-internal.h
+++ b/client/src/unifyfs-internal.h
@@ -315,11 +315,6 @@ typedef struct {
 } unifyfs_fattr_buf_t;
 
 typedef struct {
-    unifyfs_index_t idxes[UNIFYFS_MAX_SPLIT_CNT];
-    int count;
-} index_set_t;
-
-typedef struct {
     read_req_t read_reqs[UNIFYFS_MAX_READ_CNT];
     int count;
 } read_req_set_t;

--- a/common/src/unifyfs_meta.h
+++ b/common/src/unifyfs_meta.h
@@ -97,10 +97,10 @@ void unifyfs_file_attr_to_stat(unifyfs_file_attr_t* fattr, struct stat* sb)
 }
 
 typedef struct {
-    off_t file_pos;
-    off_t mem_pos;
-    size_t length;
-    int fid;
+    off_t file_pos; /* starting logical offset of data in file */
+    off_t log_pos;  /* starting physical offset of data in log */
+    size_t length;  /* length of data */
+    int fid;        /* global file id */
 } unifyfs_index_t;
 
 /* Header for read request reply in client shared memory region.

--- a/server/src/unifyfs_request_manager.c
+++ b/server/src/unifyfs_request_manager.c
@@ -863,7 +863,7 @@ int rm_cmd_fsync(int app_id, int client_side_id, int gfid)
         unifyfs_keys[i]->fid = meta_payload[i].fid;
         unifyfs_keys[i]->offset = meta_payload[i].file_pos;
 
-        unifyfs_vals[i]->addr = meta_payload[i].mem_pos;
+        unifyfs_vals[i]->addr = meta_payload[i].log_pos;
         unifyfs_vals[i]->len = meta_payload[i].length;
         unifyfs_vals[i]->delegator_rank = glb_pmi_rank;
         unifyfs_vals[i]->app_id = app_id;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This simplifies the unifyfs_split_index() code with shorter variable names and adds more comments.

It also adds a check that we don't overflow the output array when splitting a write index (resolves https://github.com/LLNL/UnifyFS/issues/386).  The split routine also now writes index values directly to the shared memory region, rather than a temporary array.  The index_set_t struct that defined the temporary array has been deleted.

A unifyfs_coalesce_index function is defined to attempt to merge the first index in a write with any existing index.  This packages up and simplifies some existing code that was previously inlined in the chunk write function.  Includes an additional (missing) check that log positions are consecutive.  This may have been implied with the fid and file_pos checks, but this feels safer.

Rename mem_pos to log_pos in unifyfs_index_t structure for clarity, since some log offsets fall in the spill over file, which is not memory.

Handle short writes and errors in pwrite to spillover file (resolves https://github.com/LLNL/UnifyFS/issues/384).

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
