### PR TITLE
Put local and log sizes in st_rdev, update bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -104,11 +104,12 @@ cd ..
 cd "$ROOT"
 
 echo "*************************************************************************"
-echo "Dependencies are all built.  You can now build Unify with:"
+echo "Dependencies are all built.  You can now build UnifyFS with:"
 echo ""
-echo "  export PKG_CONFIG_PATH=$INSTALL_DIR/lib/pkgconfig"
-echo "  ./autogen.sh && ./configure --with-leveldb=$INSTALL_DIR" \
-	"--with-gotcha=$INSTALL_DIR --with-flatcc=$INSTALL_DIR"
+echo -n "  export PKG_CONFIG_PATH=$INSTALL_DIR/lib/pkgconfig && "
+echo "export LEVELDB_ROOT=$INSTALL_DIR && export FLATCC_ROOT=$INSTALL_DIR"
+echo -n "  ./autogen.sh && ./configure --with-gotcha=$INSTALL_DIR"
+echo " --prefix=$INSTALL_DIR"
 echo "  make"
 echo ""
 echo "*************************************************************************"

--- a/client/src/unifyfs-sysio.c
+++ b/client/src/unifyfs-sysio.c
@@ -364,17 +364,17 @@ static int __stat(const char* path, struct stat* buf)
     unifyfs_file_attr_to_stat(&fattr, buf);
 
     /*
-     * For debugging purposes, we hijack st_rdev to store our local,
-     * non-laminated file size.  Note: st_rdev is only a 32-bit number,
-     * so don't depend on it if the file is really big (we use the
-     * lower 32-bits of the size).
+     * For debugging and testing purposes, we hijack st_rdev to store our
+     * local size and log size.  We also assume the stat struct is
+     * the 64-bit variant.  The values are stored as:
      *
-     * We also hijack st_dev to store our log_size for debugging.
+     * st_rdev = log_size << 32 | local_size;
+     *
      */
     buf->st_rdev = fid;
     if (fid >= 0) { /* If we have a local file */
-        buf->st_rdev = unifyfs_fid_local_size(fid) & 0xFFFFFFFF;
-        buf->st_dev = unifyfs_fid_log_size(fid) & 0xFFFFFFFF;
+        buf->st_rdev = (unifyfs_fid_log_size(fid) << 32) |
+            (unifyfs_fid_local_size(fid) & 0xFFFFFFFF);
     }
 
     if (!fattr.is_laminated) {

--- a/t/std/size.c
+++ b/t/std/size.c
@@ -46,11 +46,11 @@ void get_size(char* path, size_t* global, size_t* local, size_t* log)
     }
 
     if (local) {
-        *local = sb.st_rdev;
+        *local = sb.st_rdev & 0xFFFFFFFF;
     }
 
     if (log) {
-        *log = sb.st_dev;
+        *log = (sb.st_rdev >> 32) & 0xFFFFFFFF;
     }
 }
 

--- a/t/sys/write-read.c
+++ b/t/sys/write-read.c
@@ -41,11 +41,11 @@ void get_size(char* path, size_t* global, size_t* local, size_t* log)
     }
 
     if (local) {
-        *local = sb.st_rdev;
+        *local = sb.st_rdev & 0xFFFFFFFF;
     }
 
     if (log) {
-        *log = sb.st_dev;
+        *log = (sb.st_rdev >> 32) & 0xFFFFFFFF;
     }
 }
 


### PR DESCRIPTION
### Description
Previously we stored the local size in `stat.st_rdev` and the log size in `stat.st_dev`.  However, HDF5 expects sane values in `st_dev`, so move log size into the upper 32-bits of `st_rdev`.

Also update bootstrap.sh to export `LEVELDB_ROOT` and `FLATCC_ROOT` instead of having them as `--with-leveldb` and `--with-flatcc`, in accordance with #390.  Along with that, add `--prefix` line to point to install dir.

### Motivation and Context
- Fixes #396
- Makes boostrap.sh work again.

### How Has This Been Tested?
Tested bootstrap.sh
Passed 'make check;

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
