### PR TITLE
client: change fid to gfid in read request structure

### DIFF
--- a/client/src/unifyfs-internal.h
+++ b/client/src/unifyfs-internal.h
@@ -298,7 +298,7 @@ typedef struct {
 
 /*unifyfs structures*/
 typedef struct {
-    int fid;
+    int gfid;
     int errcode;
     size_t offset;
     size_t length;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This changes the fid field in the read request structure to be gfid instead (resolves https://github.com/LLNL/UnifyFS/issues/395).

Applies some style edits to the chmod wrappers.

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
