### PR TITLE
client: check for overflow when splitting read requests

### DIFF
--- a/client/src/unifyfs-internal.h
+++ b/client/src/unifyfs-internal.h
@@ -310,11 +310,6 @@ typedef struct {
     unifyfs_index_t* index_entry;
 } unifyfs_index_buf_t;
 
-typedef struct {
-    read_req_t read_reqs[UNIFYFS_MAX_READ_CNT];
-    int count;
-} read_req_set_t;
-
 extern unifyfs_index_buf_t unifyfs_indices;
 extern unsigned long unifyfs_max_index_entries;
 extern long unifyfs_spillover_max_chunks;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This checks for overflow when splitting read requests (resolves https://github.com/LLNL/UnifyFS/issues/399).  It is written similarly to the function that splits write index values.

It drops the function to coalesce read requests.  This could be added back.

It drops the commented-out logic that adjusted input read requests based on file size, with the expectation that reading past the end of a file will be handled when processing read replies instead.

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
