### PR TITLE
fix EOF for remote reads after laminate

### DIFF
--- a/client/src/unifyfs-internal.h
+++ b/client/src/unifyfs-internal.h
@@ -500,11 +500,8 @@ off_t unifyfs_fid_log_size(int fid);
  */
 off_t unifyfs_fid_logical_size(int fid);
 
-/* fill in limited amount of stat information for global file id */
-int unifyfs_gfid_stat(int gfid, struct stat* buf);
-
-/* fill in limited amount of stat information */
-int unifyfs_fid_stat(int fid, struct stat* buf);
+/* Update local metadata for file from global metadata */
+int unifyfs_fid_update_file_meta(int fid, unifyfs_file_attr_t* gfattr);
 
 /* allocate a file id slot for a new file
  * return the fid or -1 on error */

--- a/client/src/unifyfs-sysio.c
+++ b/client/src/unifyfs-sysio.c
@@ -359,7 +359,9 @@ static int __stat(const char* path, struct stat* buf)
 
     /* update local file metadata (if applicable) */
     fid = unifyfs_get_fid_from_path(path);
-    unifyfs_fid_update_file_meta(fid, &fattr);
+    if (fid != -1) {
+        unifyfs_fid_update_file_meta(fid, &fattr);
+    }
 
     /* copy attributes to stat struct */
     unifyfs_file_attr_to_stat(&fattr, buf);

--- a/client/src/unifyfs.c
+++ b/client/src/unifyfs.c
@@ -1262,11 +1262,7 @@ int unifyfs_fid_open(const char* path, int flags, mode_t mode, int* outfid,
         }
 
         /* initialize global size of file from global metadata */
-        ret = unifyfs_fid_update_file_meta(fid, &gfattr);
-        if (ret != UNIFYFS_SUCCESS) {
-            LOGERR("failed to update file metadata from global");
-            /* this is not a fatal error, continue */
-        }
+        unifyfs_fid_update_file_meta(fid, &gfattr);
     } else if (found_local && found_global) {
         /* file exists and is valid.  */
         if ((flags & O_CREAT) && (flags & O_EXCL)) {
@@ -1282,11 +1278,7 @@ int unifyfs_fid_open(const char* path, int flags, mode_t mode, int* outfid,
         }
 
         /* update local metadata from global metadata */
-        ret = unifyfs_fid_update_file_meta(fid, &gfattr);
-        if (ret != UNIFYFS_SUCCESS) {
-            LOGERR("failed to update file metadata from global");
-            /* this is not a fatal error, continue */
-        }
+        unifyfs_fid_update_file_meta(fid, &gfattr);
 
         if ((flags & O_TRUNC) && (flags & (O_RDWR | O_WRONLY))) {
             unifyfs_fid_truncate(fid, 0);

--- a/examples/src/testutil_rdwr.h
+++ b/examples/src/testutil_rdwr.h
@@ -15,6 +15,8 @@
 #ifndef UNIFYFS_TESTUTIL_RDWR_H
 #define UNIFYFS_TESTUTIL_RDWR_H
 
+#include "testutil.h"
+
 /* -------- Write Helper Methods -------- */
 
 static inline
@@ -217,8 +219,21 @@ int write_laminate(test_cfg* cfg, const char* filepath)
         int chmod_rc = chmod(filepath, 0444);
         if (-1 == chmod_rc) {
             /* lamination failed */
-            test_print(cfg, "chmod() lamination failed");
+            test_print(cfg, "chmod() during lamination failed");
             rc = -1;
+        }
+    }
+    if (cfg->io_pattern == IO_PATTERN_N1) {
+        test_barrier(cfg);
+        if (cfg->rank != 0) {
+            /* call stat() to update global metadata */
+            struct stat st;
+            int stat_rc = stat(filepath, &st);
+            if (-1 == stat_rc) {
+                /* lamination failed */
+                test_print(cfg, "stat() update during lamination failed");
+                rc = -1;
+            }
         }
     }
     return rc;


### PR DESCRIPTION
### Description
This fixes the writeread example in io_shuffle mode, where each process reads different data than it wrote. Previously, we were seeing EOFs on reads with offsets that exceeded the locally cached file size, which was based on what was written. The cached file size was being used because processes other than rank 0 did not mark the file as laminated. The fix was to add a `stat()` call for the non-zero ranks, and to make sure that the associated call to `unifyfs_get_global_file_meta()` caused the local metadata to be correctly updated, which wasn't the case before.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
