### PR TITLE
Fixes two errors about the system configuration file (/etc/unifyfs):

### DIFF
--- a/common/src/Makefile.am
+++ b/common/src/Makefile.am
@@ -59,6 +59,8 @@ libunifyfs_common_la_CPPFLAGS = \
   $(MARGO_CFLAGS) \
   $(FLATCC_CFLAGS)
 
+libunifyfs_common_la_CPPFLAGS += -DSYSCONFDIR="$(sysconfdir)"
+
 libunifyfs_common_la_LDFLAGS = \
   -version-info $(LIBUNIFYFS_LT_VERSION)
 

--- a/extras/unifyfs.conf.in
+++ b/extras/unifyfs.conf.in
@@ -1,6 +1,9 @@
 # unifyfs.conf
 
-# NOTE: settings with default values are commented out
+# NOTE:
+#  - settings with default values are commented out
+#  - string values should not be quoted, e.g., /var/tmp is correct but
+#    "/var/tmp" is not.
 #
 # COMMENT STYLE:
 #  '#' start of line comment character
@@ -8,9 +11,9 @@
 
 # SECTION: top-level configuration
 [unifyfs]
-# consistency = "LAMINATED" ; NONE | LAMINATED | POSIX
-# daemonize = on            ; servers will become daemons
-# mountpoint = "/unifyfs"   ; mountpoint (i.e., prefix path)
+# consistency = LAMINATED ; NONE | LAMINATED | POSIX
+# daemonize = on          ; servers will become daemons
+# mountpoint = /unifyfs   ; mountpoint (i.e., prefix path)
 
 # SECTION: client settings
 [client]
@@ -24,8 +27,8 @@ verbosity = 5         ; logging verbosity level [0-5] (default: 0)
 
 # SECTION: metadata settings
 [meta]
-# db_name = "unifyfs_metadb" ; metadata datbase name
-db_path = "/var/tmp"         ; metadata database directory path (default: /tmp)
+# db_name = unifyfs_metadb ; metadata datbase name
+db_path = /var/tmp         ; metadata database directory path (default: /tmp)
 
 # SECTION: shared memory segment settings
 [shmem]
@@ -34,7 +37,7 @@ chunk_mem = 67108864 ; segment size for data chunks (default: 256 MiB)
 
 # SECTION: spillover local to each node
 [spillover]
-# enabled = on          ; enable spillover to local storage
-# data_dir = "/mnt/ssd" ; directory path for data spillover
-# meta_dir = "/mnt/ssd" ; directory path for metadata spillover
-size = 268435456        ; data spillover max size (default: 1 GiB)
+# enabled = on        ; enable spillover to local storage
+# data_dir = /mnt/ssd ; directory path for data spillover
+# meta_dir = /mnt/ssd ; directory path for metadata spillover
+size = 268435456      ; data spillover max size (default: 1 GiB)


### PR DESCRIPTION
- consider install prefix when reading /etc/unifyfs/unifyfs.conf
- removing double quotations around strings from the unifyfs.conf
  template file

<!--- Provide a general summary of your changes in the Title above -->

### Description
#412.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)
