### PR TITLE
Fix -wrap configure bug

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -176,11 +176,11 @@ AC_TRY_COMPILE(
     AC_MSG_RESULT(no)
 )
 
-AC_MSG_CHECKING(if linker suppots -wrap)
+AC_MSG_CHECKING(if linker supports -wrap)
 OLD_LDFLAGS=$LDFLAGS
 LDFLAGS=$LDFLAGS
 LDFLAGS+="-Wl,-wrap,malloc"
-AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <stdlib.h>]],[[int *test = malloc(sizeof(int));]])],
+AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <stdlib.h>]],[[void* __wrap_malloc(size_t size);]],[[int *test = malloc(sizeof(int));]])],
 [
     AC_MSG_RESULT([yes])
     AM_CONDITIONAL([HAVE_LD_WRAP],[true])


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
When building on some systems, the configure check `checking if linker supports -wrap...` when checking for `HAVE_LD_WRAP`. This would fail with an undefined reference to `__wrap_malloc`. This would result in the static examples not being built and installed.

This adds a definition for __wrap_malloc for this test to pass.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Building without this does not build/install the static examples. Building with this change does.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
