### PR TITLE
Simple addition of more debug info

### DIFF
--- a/client/src/unifyfs-sysio.c
+++ b/client/src/unifyfs-sysio.c
@@ -245,7 +245,8 @@ int UNIFYFS_WRAP(truncate)(const char* path, off_t length)
         /* truncate the file */
         int rc = unifyfs_fid_truncate(fid, length);
         if (rc != UNIFYFS_SUCCESS) {
-            LOGDBG("unifyfs_fid_truncate failed for %s in UNIFYFS", path);
+            LOGDBG("unifyfs_fid_truncate failed for %s, fid %d, length %zu", 
+                path, fid, length);
             errno = EIO;
             return -1;
         }
@@ -999,7 +1000,7 @@ ssize_t UNIFYFS_WRAP(read)(int fd, void* buf, size_t count)
 /* TODO: find right place to msync spillover mapping */
 ssize_t UNIFYFS_WRAP(write)(int fd, const void* buf, size_t count)
 {
-    LOGDBG("write was called for fd %d", fd);
+    LOGDBG("write was called for fd %d, count %zu", fd, count);
     size_t ret;
     off_t pos;
 
@@ -1733,8 +1734,7 @@ static int process_read_data(read_req_t* read_reqs, int count, int* done)
 }
 
 /*
- * get data for a list of read requests from the
- * delegator
+ * get data from the delegator, for a list of read requests 
  * @param read_reqs: a list of read requests
  * @param count: number of read requests
  * @return error code
@@ -1823,7 +1823,7 @@ int unifyfs_fd_logreadlist(read_req_t* read_reqs, int count)
         int gfid      = read_set[0].gfid;
         size_t offset = read_set[0].offset;
         size_t length = read_set[0].length;
-        LOGDBG("read: offset:%zu, len:%zu", offset, length);
+        LOGDBG("read: offset:%zu, len:%zu, gfid:%d", offset, length, gfid);
         read_rc = invoke_client_read_rpc(gfid, offset, length);
     }
 


### PR DESCRIPTION
Add more debug information to the client log

### Description
Include additional arguments to some of the LOGDBG commands in unifyfs-sysio.c, such that
during execution more fields are displayed in the client log. In addition, rectify some of the
comments in the source code such that those comments more precisely define what is done
by the specific fragment of the code. No changes to the logic of the original code are made.

### Motivation and Context
When debugging the execution of the client, it is useful to view as many variables as possible,
in particular those key variables that are passed to main Unify functions. In the original code,
only part of such variables were being displayed.

### How Has This Been Tested?
Testing has been done by running example 'app-hdf5-create-gotcha' (to create a simple HDF5 file under Unify) followed by 'sysio-cp-gotcha', which exports that created file to permanent storage.
For both examples, the logs generated contain the additional information that was inserted by
this change. which helps in verifying the proper behavior of each example.

### Types of changes
- Addition of arguments to LOGDBG () commands
- Change to comments in the code to more precisely define what the code fragment does

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
