### PR TITLE
update size field in global meta on truncate

### DIFF
--- a/client/src/margo_client.h
+++ b/client/src/margo_client.h
@@ -15,6 +15,7 @@ typedef struct ClientRpcIds {
     hg_id_t metaset_id;
     hg_id_t metaget_id;
     hg_id_t filesize_id;
+    hg_id_t truncate_id;
     hg_id_t fsync_id;
     hg_id_t read_id;
     hg_id_t mread_id;
@@ -44,6 +45,8 @@ int invoke_client_metaset_rpc(unifyfs_file_attr_t* f_meta);
 int invoke_client_metaget_rpc(int gfid, unifyfs_file_attr_t* f_meta);
 
 int invoke_client_filesize_rpc(int gfid, size_t* filesize);
+
+int invoke_client_truncate_rpc(int gfid, size_t filesize);
 
 int invoke_client_fsync_rpc(int gfid);
 

--- a/client/src/unifyfs.c
+++ b/client/src/unifyfs.c
@@ -1157,37 +1157,27 @@ int unifyfs_fid_truncate(int fid, off_t length)
     /* get meta data for this file */
     unifyfs_filemeta_t* meta = unifyfs_get_meta_from_fid(fid);
     if (meta->is_laminated) {
-        return EINVAL;  /* Can't truncate a laminated file */
+        /* Can't truncate a laminated file */
+        return (int)UNIFYFS_ERROR_INVAL;
     }
 
-    /* get current size of file */
-    off_t size = meta->local_size;
-
-    /* drop data if length is less than current size,
-     * allocate new space and zero fill it if bigger */
-    if (length < size) {
-        /* determine the number of chunks to leave after truncating */
-        int shrink_rc = unifyfs_fid_shrink(fid, length);
-        if (shrink_rc != UNIFYFS_SUCCESS) {
-            return shrink_rc;
-        }
-    } else if (length > size) {
-        /* file size has been extended, allocate space */
-        int extend_rc = unifyfs_fid_extend(fid, length);
-        if (extend_rc != UNIFYFS_SUCCESS) {
-            return (int)UNIFYFS_ERROR_NOSPC;
+    /* determine file storage type */
+    if (meta->storage == FILE_STORAGE_LOGIO) {
+        /* invoke truncate rpc */
+        int gfid = unifyfs_gfid_from_fid(fid);
+        int rc = invoke_client_truncate_rpc(gfid, length);
+        if (rc != UNIFYFS_SUCCESS) {
+            return rc;
         }
 
-        /* write zero values to new bytes */
-        off_t gap_size = length - size;
-        int zero_rc = unifyfs_fid_write_zero(fid, size, gap_size);
-        if (zero_rc != UNIFYFS_SUCCESS) {
-            return (int)UNIFYFS_ERROR_IO;
-        }
+        /* truncate succeeded, update global and local size to
+         * reflect truncated size, note log size is not affected */
+        meta->global_size = length;
+        meta->local_size  = length;
+    } else {
+        /* unknown storage type */
+        return (int)UNIFYFS_ERROR_IO;
     }
-
-    /* set the new size */
-    meta->local_size = length;
 
     return UNIFYFS_SUCCESS;
 }
@@ -1371,13 +1361,19 @@ int unifyfs_fid_close(int fid)
 /* delete a file id and return file its resources to free pools */
 int unifyfs_fid_unlink(int fid)
 {
-    /* return data to free pools */
-    int rc = unifyfs_fid_truncate(fid, 0);
-    if (rc != UNIFYFS_SUCCESS) {
-        /* failed to release storage for the file,
-         * so bail out to keep its file id active */
-        return rc;
+    int rc;
+
+    /* if we have a file, return any data to free pools */
+    if (!unifyfs_fid_is_dir(fid)) {
+        rc = unifyfs_fid_truncate(fid, 0);
+        if (rc != UNIFYFS_SUCCESS) {
+            /* failed to release storage for the file,
+             * so bail out to keep its file id active */
+            return rc;
+        }
     }
+
+    /* TODO: delete global file meta data */
 
     /* finalize the storage we're using for this file */
     rc = unifyfs_fid_store_free(fid);

--- a/common/src/unifyfs_client_rpcs.h
+++ b/common/src/unifyfs_client_rpcs.h
@@ -116,6 +116,19 @@ MERCURY_GEN_PROC(unifyfs_filesize_out_t,
                  ((hg_size_t)(filesize)))
 DECLARE_MARGO_RPC_HANDLER(unifyfs_filesize_rpc)
 
+/* unifyfs_truncate_rpc (client => server)
+ *
+ * given an app_id, client_id, global file id,
+ * and a filesize, truncate file to that size */
+MERCURY_GEN_PROC(unifyfs_truncate_in_t,
+                 ((int32_t)(app_id))
+                 ((int32_t)(local_rank_idx))
+                 ((int32_t)(gfid))
+                 ((hg_size_t)(filesize)))
+MERCURY_GEN_PROC(unifyfs_truncate_out_t,
+                 ((int32_t)(ret)))
+DECLARE_MARGO_RPC_HANDLER(unifyfs_truncate_rpc)
+
 /* unifyfs_read_rpc (client => server)
  *
  * given an app_id, client_id, global file id, an offset, and a length,

--- a/server/src/margo_server.c
+++ b/server/src/margo_server.c
@@ -171,6 +171,10 @@ static void register_client_server_rpcs(margo_instance_id mid)
                    unifyfs_filesize_in_t, unifyfs_filesize_out_t,
                    unifyfs_filesize_rpc);
 
+    MARGO_REGISTER(mid, "unifyfs_truncate_rpc",
+                   unifyfs_truncate_in_t, unifyfs_truncate_out_t,
+                   unifyfs_truncate_rpc);
+
     MARGO_REGISTER(mid, "unifyfs_read_rpc",
                    unifyfs_read_in_t, unifyfs_read_out_t,
                    unifyfs_read_rpc)

--- a/server/src/unifyfs_cmd_handler.c
+++ b/server/src/unifyfs_cmd_handler.c
@@ -495,6 +495,33 @@ static void unifyfs_filesize_rpc(hg_handle_t handle)
 }
 DEFINE_MARGO_RPC_HANDLER(unifyfs_filesize_rpc)
 
+/* given an app_id, client_id, global file id,
+ * and file size, truncate file to that size */
+static void unifyfs_truncate_rpc(hg_handle_t handle)
+{
+    /* get input params */
+    unifyfs_truncate_in_t in;
+    hg_return_t hret = margo_get_input(handle, &in);
+    assert(hret == HG_SUCCESS);
+
+    /* truncate file to specified size */
+    int ret = rm_cmd_truncate(in.app_id, in.local_rank_idx,
+                              in.gfid, in.filesize);
+
+    /* build our output values */
+    unifyfs_truncate_out_t out;
+    out.ret = (int32_t) ret;
+
+    /* return to caller */
+    hret = margo_respond(handle, &out);
+    assert(hret == HG_SUCCESS);
+
+    /* free margo resources */
+    margo_free_input(handle, &in);
+    margo_destroy(handle);
+}
+DEFINE_MARGO_RPC_HANDLER(unifyfs_truncate_rpc)
+
 /* given an app_id, client_id, global file id, an offset, and a length,
  * initiate read operation to lookup and return data,
  * client synchronizes with server again later when data is available

--- a/server/src/unifyfs_metadata.h
+++ b/server/src/unifyfs_metadata.h
@@ -129,6 +129,16 @@ int unifyfs_get_file_extents(int num_keys,
                              int* num_values, unifyfs_keyval_t** keyval);
 
 /**
+ * Delete File extents from the KV-Store.
+ *
+ * @param[in] num_entries number of key value pairs to delete
+ * @param[in] keys array storing the keys
+ * @param[in] key_lens array with the length of the elements in \p keys
+ */
+int unifyfs_delete_file_extents(int num_entries,
+                                unifyfs_key_t** keys, int* key_lens);
+
+/**
  * Store File extents in the KV-Store.
  *
  * @param [in] num_entries number of key value pairs to store

--- a/server/src/unifyfs_request_manager.h
+++ b/server/src/unifyfs_request_manager.h
@@ -110,6 +110,9 @@ int rm_cmd_read(int app_id, int client_id, int gfid,
 
 int rm_cmd_filesize(int app_id, int client_id, int gfid, size_t* outsize);
 
+/* truncate file to specified size */
+int rm_cmd_truncate(int app_id, int client_id, int gfid, size_t size);
+
 /* function called by main thread to instruct
  * resource manager thread to exit,
  * returns UNIFYFS_SUCCESS on success */

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -101,7 +101,8 @@ sys_sysio_gotcha_t_SOURCES = sys/sysio_suite.h \
                              sys/open.c \
                              sys/open64.c \
                              sys/write-read.c \
-                             sys/write-read-hole.c
+                             sys/write-read-hole.c \
+                             sys/truncate.c
 
 sys_sysio_gotcha_t_CPPFLAGS = $(test_cppflags)
 sys_sysio_gotcha_t_LDADD = $(test_ldadd)
@@ -115,7 +116,8 @@ sys_sysio_static_t_SOURCES = sys/sysio_suite.h \
                              sys/open.c \
                              sys/open64.c \
                              sys/write-read.c \
-                             sys/write-read-hole.c
+                             sys/write-read-hole.c \
+                             sys/truncate.c
 
 sys_sysio_static_t_CPPFLAGS = $(test_cppflags)
 sys_sysio_static_t_LDADD = $(test_static_ldadd)

--- a/t/sys/sysio_suite.c
+++ b/t/sys/sysio_suite.c
@@ -85,6 +85,15 @@ int main(int argc, char* argv[])
 
     write_read_hole_test(unifyfs_root);
 
+    truncate_test(unifyfs_root);
+    truncate_bigempty(unifyfs_root);
+    truncate_eof(unifyfs_root);
+    truncate_truncsync(unifyfs_root);
+    truncate_pattern_size(unifyfs_root, 0);
+    truncate_pattern_size(unifyfs_root, 2020);
+    truncate_empty_read(unifyfs_root, 0);
+    truncate_empty_read(unifyfs_root, 2020);
+
     MPI_Finalize();
 
     done_testing();

--- a/t/sys/sysio_suite.h
+++ b/t/sys/sysio_suite.h
@@ -50,4 +50,10 @@ int write_read_test(char* unifyfs_root);
 /* test reading from file with holes */
 int write_read_hole_test(char* unifyfs_root);
 
+/* Tests for UNIFYFS_WRAP(ftruncate) and UNIFYFS_WRAP(truncate) */
+int truncate_test(char* unifyfs_root);
+int truncate_bigempty(char* unifyfs_root);
+int truncate_eof(char* unifyfs_root);
+int truncate_truncsync(char* unifyfs_root);
+
 #endif /* SYSIO_SUITE_H */

--- a/t/sys/truncate.c
+++ b/t/sys/truncate.c
@@ -1,0 +1,667 @@
+/*
+ * Copyright (c) 2019, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2018, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyFS.
+ * For details, see https://github.com/LLNL/UnifyFS.
+ * Please read https://github.com/LLNL/UnifyFS/LICENSE for full license text.
+ */
+
+ /*
+  * Test truncate and ftruncate
+  */
+#include <fcntl.h>
+#include <string.h>
+#include <errno.h>
+#include <linux/limits.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include "t/lib/tap.h"
+#include "t/lib/testutil.h"
+
+/* Get global, local, or log sizes (or all) */
+static
+void get_size(char* path, size_t* global, size_t* local, size_t* log)
+{
+    struct stat sb = {0};
+    int rc;
+
+    rc = stat(path, &sb);
+    if (rc != 0) {
+        printf("Error: %s\n", strerror(errno));
+        exit(1);    /* die on failure */
+    }
+    if (global) {
+        *global = sb.st_size;
+    }
+
+    if (local) {
+        *local = sb.st_rdev & 0xFFFFFFFF;
+    }
+
+    if (log) {
+        *log = (sb.st_rdev >> 32) & 0xFFFFFFFF;
+    }
+}
+
+int truncate_test(char* unifyfs_root)
+{
+    char path[64];
+    int rc;
+    int fd;
+    size_t global, local, log;
+
+    size_t bufsize = 1024*1024;
+    char* buf = (char*) malloc(bufsize);
+
+    testutil_rand_path(path, sizeof(path), unifyfs_root);
+
+    /* Open a new file for writing */
+    fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0222);
+    ok(fd != -1, "%s:%d open(%s) (fd=%d): %s",
+        __FILE__, __LINE__, path, fd, strerror(errno));
+
+    /* file should be 0 bytes at this point */
+    get_size(path, &global, &local, &log);
+    ok(global == 0, "%s:%d global size is %d expected %d",
+        __FILE__, __LINE__, global, 0);
+    ok(local == 0, "%s:%d local size is %d expected %d",
+        __FILE__, __LINE__, local, 0);
+    ok(log == 0, "%s:%d log size is %d expected %d",
+        __FILE__, __LINE__, log, 0);
+
+    /* write 1MB and fsync, expect 1MB */
+    rc = write(fd, buf, bufsize);
+    ok(rc == bufsize, "%s:%d write(%d) (rc=%d): %s",
+        __FILE__, __LINE__, bufsize, rc, strerror(errno));
+
+    rc = fsync(fd);
+    ok(rc == 0, "%s:%d fsync() (rc=%d): %s",
+        __FILE__, __LINE__, rc, strerror(errno));
+
+    get_size(path, &global, &local, &log);
+    ok(global == 1*bufsize, "%s:%d global size is %d expected %d",
+        __FILE__, __LINE__, global, 1*bufsize);
+    ok(local == 1*bufsize, "%s:%d local size is %d expected %d",
+        __FILE__, __LINE__, local, 1*bufsize);
+    ok(log == 1*bufsize, "%s:%d log size is %d expected %d",
+        __FILE__, __LINE__, log, 1*bufsize);
+
+    /* skip a 1MB hole, write another 1MB, and fsync expect 3MB */
+    rc = lseek(fd, 2*bufsize, SEEK_SET);
+    ok(rc == 2*bufsize, "%s:%d lseek(%d) (rc=%d): %s",
+        __FILE__, __LINE__, 2*bufsize, rc, strerror(errno));
+
+    rc = write(fd, buf, bufsize);
+    ok(rc == bufsize, "%s:%d write(%d) (rc=%d): %s",
+        __FILE__, __LINE__, bufsize, rc, strerror(errno));
+
+    rc = fsync(fd);
+    ok(rc == 0, "%s:%d fsync() (rc=%d): %s",
+        __FILE__, __LINE__, rc, strerror(errno));
+
+    get_size(path, &global, &local, &log);
+    ok(global == 3*bufsize, "%s:%d global size is %d expected %d",
+        __FILE__, __LINE__, global, 3*bufsize);
+    ok(local == 3*bufsize, "%s:%d local size is %d expected %d",
+        __FILE__, __LINE__, local, 3*bufsize);
+    ok(log == 2*bufsize, "%s:%d log size is %d expected %d",
+        __FILE__, __LINE__, log, 2*bufsize);
+
+    /* ftruncate at 5MB, expect 5MB */
+    rc = ftruncate(fd, 5*bufsize);
+    ok(rc == 0, "%s:%d ftruncate(%d) (rc=%d): %s",
+        __FILE__, __LINE__, 5*bufsize, rc, strerror(errno));
+
+    get_size(path, &global, &local, &log);
+    ok(global == 5*bufsize, "%s:%d global size is %d expected %d",
+        __FILE__, __LINE__, global, 5*bufsize);
+    ok(local == 5*bufsize, "%s:%d local size is %d expected %d",
+        __FILE__, __LINE__, local, 5*bufsize);
+    ok(log == 2*bufsize, "%s:%d log size is %d expected %d",
+        __FILE__, __LINE__, log, 2*bufsize);
+
+    close(fd);
+
+    /* truncate at 0.5 MB, expect 0.5MB */
+    rc = truncate(path, bufsize/2);
+    ok(rc == 0, "%s:%d truncate(%d) (rc=%d): %s",
+        __FILE__, __LINE__, bufsize/2, rc, strerror(errno));
+
+    get_size(path, &global, &local, &log);
+    ok(global == bufsize/2, "%s:%d global size is %d expected %d",
+        __FILE__, __LINE__, global, bufsize/2);
+    ok(local == bufsize/2, "%s:%d local size is %d expected %d",
+        __FILE__, __LINE__, local, bufsize/2);
+    ok(log == 2*bufsize, "%s:%d log size is %d expected %d",
+        __FILE__, __LINE__, log, 2*bufsize);
+
+    /* truncate to 0, expect 0 */
+    rc = truncate(path, 0);
+    ok(rc == 0, "%s:%d truncate(%d) (rc=%d): %s",
+        __FILE__, __LINE__, 0, rc, strerror(errno));
+
+    get_size(path, &global, &local, &log);
+    ok(global == 0, "%s:%d global size is %d expected %d",
+        __FILE__, __LINE__, global, 0);
+    ok(local == 0, "%s:%d local size is %d expected %d",
+        __FILE__, __LINE__, local, 0);
+    ok(log == 2*bufsize, "%s:%d log size is %d expected %d",
+        __FILE__, __LINE__, log, 2*bufsize);
+
+    free(buf);
+
+    return 0;
+}
+
+int truncate_bigempty(char* unifyfs_root)
+{
+    char path[64];
+    int rc;
+    int fd;
+    size_t global, local, log;
+
+    size_t bufsize = 1024*1024;
+    char* buf = (char*) malloc(bufsize);
+
+    testutil_rand_path(path, sizeof(path), unifyfs_root);
+
+    /* Open a new file for writing */
+    fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0222);
+    ok(fd != -1, "%s:%d open(%s) (fd=%d): %s",
+        __FILE__, __LINE__, path, fd, strerror(errno));
+
+    get_size(path, &global, &local, &log);
+    ok(global == 0, "%s:%d global size is %d expected %d",
+        __FILE__, __LINE__, global, 0);
+    ok(local == 0, "%s:%d local size is %d expected %d",
+        __FILE__, __LINE__, local, 0);
+    ok(log == 0, "%s:%d log size is %d expected %d",
+        __FILE__, __LINE__, log, 0);
+
+    /* ftruncate at 1TB, expect 1TB */
+    off_t bigempty = 1024*1024*1024*1024ULL;
+    rc = ftruncate(fd, bigempty);
+    ok(rc == 0, "%s:%d ftruncate(%llu) (rc=%d): %s",
+        __FILE__, __LINE__, (unsigned long long) bigempty,
+        rc, strerror(errno));
+
+    get_size(path, &global, &local, &log);
+    ok(global == (size_t)bigempty, "%s:%d global size is %llu expected %llu",
+        __FILE__, __LINE__, global, (unsigned long long)bigempty,
+        strerror(errno));
+
+    close(fd);
+
+    free(buf);
+
+    return 0;
+}
+
+int truncate_eof(char* unifyfs_root)
+{
+    char path[64];
+    int rc;
+    int fd;
+    size_t global, local, log;
+
+    size_t bufsize = 1024*1024;
+    char* buf = (char*) malloc(bufsize);
+
+    testutil_rand_path(path, sizeof(path), unifyfs_root);
+
+    /* Open a new file for writing */
+    fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0222);
+    ok(fd != -1, "%s:%d open(%s) (fd=%d): %s",
+        __FILE__, __LINE__, path, fd, strerror(errno));
+
+    /* file should be 0 bytes at this point */
+    get_size(path, &global, &local, &log);
+    ok(global == 0, "%s:%d global size is %d expected %d",
+        __FILE__, __LINE__, global, 0);
+    ok(local == 0, "%s:%d local size is %d expected %d",
+        __FILE__, __LINE__, local, 0);
+    ok(log == 0, "%s:%d log size is %d expected %d",
+        __FILE__, __LINE__, log, 0);
+
+    /* write 1MB */
+    rc = write(fd, buf, bufsize);
+    ok(rc == bufsize, "%s:%d write(%d) (rc=%d): %s",
+        __FILE__, __LINE__, bufsize, rc, strerror(errno));
+
+    rc = fsync(fd);
+    ok(rc == 0, "%s:%d fsync() (rc=%d): %s",
+        __FILE__, __LINE__, rc, strerror(errno));
+
+    /* ftruncate at 0.5MB */
+    rc = ftruncate(fd, bufsize/2);
+    ok(rc == 0, "%s:%d ftruncate(%d) (rc=%d): %s",
+        __FILE__, __LINE__, bufsize/2, rc, strerror(errno));
+
+    close(fd);
+
+    /* Open a file for reading */
+    fd = open(path, O_RDONLY);
+    ok(fd != -1, "%s:%d open(%s) (fd=%d): %s",
+        __FILE__, __LINE__, path, fd, strerror(errno));
+
+    /* ask for 1MB, should only get 0.5MB back */
+    rc = read(fd, buf, bufsize);
+    ok(rc == bufsize/2, "%s:%d read(%d) (rc=%d): %s",
+        __FILE__, __LINE__, bufsize, rc, strerror(errno));
+
+    /* then should get 0 since at EOF */
+    rc = read(fd, buf, bufsize);
+    ok(rc == 0, "%s:%d read(%d) (rc=%d): %s",
+        __FILE__, __LINE__, bufsize, rc, strerror(errno));
+
+    close(fd);
+
+    /* truncate to 0 */
+    rc = truncate(path, 0);
+    ok(rc == 0, "%s:%d truncate(%d) (rc=%d): %s",
+        __FILE__, __LINE__, 0, rc, strerror(errno));
+
+    /* Open a file for reading */
+    fd = open(path, O_RDONLY);
+    ok(fd != -1, "%s:%d open(%s) (fd=%d): %s",
+        __FILE__, __LINE__, path, fd, strerror(errno));
+
+    /* should get 0 since immediately at EOF */
+    rc = read(fd, buf, bufsize);
+    ok(rc == 0, "%s:%d read(%d) (rc=%d): %s",
+        __FILE__, __LINE__, bufsize, rc, strerror(errno));
+
+    close(fd);
+
+    free(buf);
+
+    return 0;
+}
+
+int truncate_truncsync(char* unifyfs_root)
+{
+    char path[64];
+    int rc;
+    int fd;
+    size_t global, local, log;
+
+    size_t bufsize = 1024*1024;
+    char* buf = (char*) malloc(bufsize);
+
+    testutil_rand_path(path, sizeof(path), unifyfs_root);
+
+    /* Open a new file for writing */
+    fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0222);
+    ok(fd != -1, "%s:%d open(%s) (fd=%d): %s",
+        __FILE__, __LINE__, path, fd, strerror(errno));
+
+    /* file should be 0 bytes at this point */
+    get_size(path, &global, &local, &log);
+    ok(global == 0, "%s:%d global size is %d expected %d",
+        __FILE__, __LINE__, global, 0);
+    ok(local == 0, "%s:%d local size is %d expected %d",
+        __FILE__, __LINE__, local, 0);
+    ok(log == 0, "%s:%d log size is %d expected %d",
+        __FILE__, __LINE__, log, 0);
+
+    /* write 1MB */
+    rc = write(fd, buf, bufsize);
+    ok(rc == bufsize, "%s:%d write(%d) (rc=%d): %s",
+        __FILE__, __LINE__, bufsize, rc, strerror(errno));
+
+    /* ftruncate to 0.5MB */
+    rc = ftruncate(fd, bufsize/2);
+    ok(rc == 0, "%s:%d ftruncate(%d) (rc=%d): %s",
+        __FILE__, __LINE__, bufsize/2, rc, strerror(errno));
+
+    /* file should be 0.5MB bytes at this point */
+    get_size(path, &global, &local, &log);
+    ok(global == bufsize/2, "%s:%d global size is %d expected %d",
+        __FILE__, __LINE__, global, bufsize/2);
+    ok(local == bufsize/2, "%s:%d local size is %d expected %d",
+        __FILE__, __LINE__, local, bufsize/2);
+    ok(log == bufsize, "%s:%d log size is %d expected %d",
+        __FILE__, __LINE__, log, bufsize);
+
+    rc = fsync(fd);
+    ok(rc == 0, "%s:%d fsync() (rc=%d): %s",
+        __FILE__, __LINE__, rc, strerror(errno));
+
+    /* file should still be 0.5MB bytes at this point */
+    get_size(path, &global, &local, &log);
+    ok(global == bufsize/2, "%s:%d global size is %d expected %d",
+        __FILE__, __LINE__, global, bufsize/2);
+    ok(local == bufsize/2, "%s:%d local size is %d expected %d",
+        __FILE__, __LINE__, local, bufsize/2);
+    ok(log == bufsize, "%s:%d log size is %d expected %d",
+        __FILE__, __LINE__, log, bufsize);
+
+    close(fd);
+
+    free(buf);
+
+    return 0;
+}
+
+/* fill buffer with known pattern based on file offset */
+int fill_pattern(char* buf, size_t size, size_t start)
+{
+    size_t i;
+    for (i = 0; i < size; i++) {
+        char expected = ((i + start) % 26) + 'A';
+        buf[i] = expected;
+    }
+    return 0;
+}
+
+/* fill buffer with known pattern based on file offset */
+int check_pattern(char* buf, size_t size, size_t start)
+{
+    size_t i;
+    for (i = 0; i < size; i++) {
+        char expected = ((i + start) % 26) + 'A';
+        if (buf[i] != expected) {
+            return (int)(i+1);
+        }
+    }
+    return 0;
+}
+
+/* check that buffer is all zero */
+int check_zeros(char* buf, size_t size)
+{
+    size_t i;
+    for (i = 0; i < size; i++) {
+        if (buf[i] != (char)0) {
+            return (int)(i+1);
+        }
+    }
+    return 0;
+}
+
+/* write a known pattern of a known size, truncate to something smaller,
+ * read until EOF and verify contents along the way */
+int truncate_pattern_size(char* unifyfs_root, off_t seekpos)
+{
+    char path[64];
+    int rc;
+    int fd;
+    size_t global, local, log;
+    int i;
+
+    size_t bufsize = 1024*1024;
+    char* buf = (char*) malloc(bufsize);
+
+    testutil_rand_path(path, sizeof(path), unifyfs_root);
+
+    /* Open a new file for writing */
+    fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0222);
+    ok(fd != -1, "%s:%d open(%s) (fd=%d): %s",
+        __FILE__, __LINE__, path, fd, strerror(errno));
+
+    /* file should be 0 bytes at this point */
+    get_size(path, &global, &local, &log);
+    ok(global == 0, "%s:%d global size is %d expected %d",
+        __FILE__, __LINE__, global, 0);
+    ok(local == 0, "%s:%d local size is %d expected %d",
+        __FILE__, __LINE__, local, 0);
+    ok(log == 0, "%s:%d log size is %d expected %d",
+        __FILE__, __LINE__, log, 0);
+
+    /* write pattern out of 20 MB in size */
+    size_t nwritten = 0;
+    for (i = 0; i < 20; i++) {
+        /* fill buffer with known pattern based on file offset */
+        fill_pattern(buf, bufsize, nwritten);
+
+        /* write data to file */
+        rc = write(fd, buf, bufsize);
+        ok(rc == bufsize, "%s:%d write(%d) (rc=%d): %s",
+            __FILE__, __LINE__, bufsize, rc, strerror(errno));
+
+        /* track number of bytes written so far */
+        nwritten += (size_t)rc;
+    }
+
+    /* set size we'll truncate file to */
+    off_t truncsize = 5*bufsize + 42;
+
+    /* ftruncate to 5MB + 42 bytes */
+    rc = ftruncate(fd, truncsize);
+    ok(rc == 0, "%s:%d ftruncate(%d) (rc=%d): %s",
+        __FILE__, __LINE__, (int)truncsize, rc, strerror(errno));
+
+    /* file should be of size 5MB + 42 at this point */
+    get_size(path, &global, &local, &log);
+    ok(global == truncsize, "%s:%d global size is %d expected %d",
+        __FILE__, __LINE__, global, (int)truncsize);
+    ok(local == truncsize, "%s:%d local size is %d expected %d",
+        __FILE__, __LINE__, local, (int)truncsize);
+    ok(log == 20*bufsize, "%s:%d log size is %d expected %d",
+        __FILE__, __LINE__, log, 20*bufsize);
+
+    /* this kind of tests that the ftruncate above implied an fsync,
+     * can't really since the writes may have gone to disk on their
+     * own before ftruncate call */
+    rc = fsync(fd);
+    ok(rc == 0, "%s:%d fsync() (rc=%d): %s",
+        __FILE__, __LINE__, rc, strerror(errno));
+
+    /* file should still be 5MB + 42 bytes at this point */
+    get_size(path, &global, &local, &log);
+    ok(global == truncsize, "%s:%d global size is %d expected %d",
+        __FILE__, __LINE__, global, (int)truncsize);
+    ok(local == truncsize, "%s:%d local size is %d expected %d",
+        __FILE__, __LINE__, local, (int)truncsize);
+    ok(log == 20*bufsize, "%s:%d log size is %d expected %d",
+        __FILE__, __LINE__, log, 20*bufsize);
+
+    close(fd);
+
+    /* read file back from offset 0 and verify size and contents */
+    fd = open(path, O_RDONLY);
+    ok(fd != -1, "%s:%d open(%s) (fd=%d): %s",
+        __FILE__, __LINE__, path, fd, strerror(errno));
+
+    /* see to position if file if seekpos is set */
+    if (seekpos > 0) {
+        off_t pos = lseek(fd, seekpos, SEEK_SET);
+        ok(pos == seekpos, "%s:%d lseek(%d) (rc=%d): %s",
+            __FILE__, __LINE__, pos, rc, strerror(errno));
+    }
+
+    off_t numread = 0;
+    while (1) {
+        /* compute number of bytes we expect to read on next attempt */
+        ssize_t expected = bufsize;
+        ssize_t remaining = (ssize_t)(truncsize - numread - seekpos);
+        if (expected > remaining) {
+            expected = remaining;
+        }
+
+        /* ask for 1MB, should only get 0.5MB back */
+        rc = read(fd, buf, bufsize);
+        ok(rc == expected, "%s:%d read(%d) (rc=%d) expected=%d %s",
+            __FILE__, __LINE__, bufsize, rc, expected, strerror(errno));
+
+        /* check that contents we read are correct */
+        if (rc > 0) {
+            size_t start = numread + seekpos;
+            int check = check_pattern(buf, rc, start);
+            ok(check == 0, "%s:%d pattern check of bytes [%d, %d) rc=%d",
+                __FILE__, __LINE__, (int)start, (int)(start + rc), check);
+
+            /* add to number of bytes read so far */
+            numread += rc;
+        }
+
+        /* break if we hit end of file */
+        if (rc == 0) {
+            /* check that total read is expected size */
+            ok(numread == (truncsize - seekpos),
+                "%s:%d read %d bytes, expected %d",
+                __FILE__, __LINE__, (int)numread, (int)(truncsize - seekpos));
+            break;
+        }
+
+        /* check that we don't run past expected
+         * end of file (and hang the test) */
+        if (numread > (truncsize - seekpos)) {
+            ok(numread <= (truncsize - seekpos),
+                "%s:%d read %d bytes, expected %d",
+                __FILE__, __LINE__, (int)numread, (int)(truncsize - seekpos));
+            break;
+        }
+
+        /* break if we hit an error, would have been
+         * reported in read above */
+        if (rc < 0) {
+            break;
+        }
+    }
+
+    close(fd);
+
+    free(buf);
+
+    return 0;
+}
+
+/* truncate an empty file to something and read until EOF,
+ * check size and contents of buffer */
+int truncate_empty_read(char* unifyfs_root, off_t seekpos)
+{
+    char path[64];
+    int rc;
+    int fd;
+    size_t global, local, log;
+    int i;
+
+    size_t bufsize = 1024*1024;
+    char* buf = (char*) malloc(bufsize);
+
+    testutil_rand_path(path, sizeof(path), unifyfs_root);
+
+    /* Open a new file for writing */
+    fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0222);
+    ok(fd != -1, "%s:%d open(%s) (fd=%d): %s",
+        __FILE__, __LINE__, path, fd, strerror(errno));
+
+    /* file should be 0 bytes at this point */
+    get_size(path, &global, &local, &log);
+    ok(global == 0, "%s:%d global size is %d expected %d",
+        __FILE__, __LINE__, global, 0);
+    ok(local == 0, "%s:%d local size is %d expected %d",
+        __FILE__, __LINE__, local, 0);
+    ok(log == 0, "%s:%d log size is %d expected %d",
+        __FILE__, __LINE__, log, 0);
+
+    /* set size we'll truncate file to */
+    off_t truncsize = 5*bufsize + 42;
+
+    /* ftruncate to 5MB + 42 bytes */
+    rc = ftruncate(fd, truncsize);
+    ok(rc == 0, "%s:%d ftruncate(%d) (rc=%d): %s",
+        __FILE__, __LINE__, (int)truncsize, rc, strerror(errno));
+
+    /* file should be of size 5MB + 42 at this point */
+    get_size(path, &global, &local, &log);
+    ok(global == truncsize, "%s:%d global size is %d expected %d",
+        __FILE__, __LINE__, global, (int)truncsize);
+    ok(local == truncsize, "%s:%d local size is %d expected %d",
+        __FILE__, __LINE__, local, (int)truncsize);
+    ok(log == 0, "%s:%d log size is %d expected %d",
+        __FILE__, __LINE__, log, 0);
+
+    /* this kind of tests that the ftruncate above implied an fsync,
+     * can't really since the writes may have gone to disk on their
+     * own before ftruncate call */
+    rc = fsync(fd);
+    ok(rc == 0, "%s:%d fsync() (rc=%d): %s",
+        __FILE__, __LINE__, rc, strerror(errno));
+
+    /* file should still be 5MB + 42 bytes at this point */
+    get_size(path, &global, &local, &log);
+    ok(global == truncsize, "%s:%d global size is %d expected %d",
+        __FILE__, __LINE__, global, (int)truncsize);
+    ok(local == truncsize, "%s:%d local size is %d expected %d",
+        __FILE__, __LINE__, local, (int)truncsize);
+    ok(log == 0, "%s:%d log size is %d expected %d",
+        __FILE__, __LINE__, log, 0);
+
+    close(fd);
+
+    /* read file back from offset 0 and verify size and contents */
+    fd = open(path, O_RDONLY);
+    ok(fd != -1, "%s:%d open(%s) (fd=%d): %s",
+        __FILE__, __LINE__, path, fd, strerror(errno));
+
+    /* see to position if file if seekpos is set */
+    if (seekpos > 0) {
+        off_t pos = lseek(fd, seekpos, SEEK_SET);
+        ok(pos == seekpos, "%s:%d lseek(%d) (rc=%d): %s",
+            __FILE__, __LINE__, pos, rc, strerror(errno));
+    }
+
+    off_t numread = 0;
+    while (1) {
+        /* compute number of bytes we expect to read on next attempt */
+        ssize_t expected = bufsize;
+        ssize_t remaining = (ssize_t)(truncsize - numread - seekpos);
+        if (expected > remaining) {
+            expected = remaining;
+        }
+
+        /* ask for 1MB, should only get 0.5MB back */
+        rc = read(fd, buf, bufsize);
+        ok(rc == expected, "%s:%d read(%d) (rc=%d) expected=%d %s",
+            __FILE__, __LINE__, bufsize, rc, expected, strerror(errno));
+
+        /* check that contents we read are correct */
+        if (rc > 0) {
+            size_t start = numread + seekpos;
+            int check = check_zeros(buf, rc);
+            ok(check == 0, "%s:%d pattern check of bytes [%d, %d) rc=%d",
+                __FILE__, __LINE__, (int)start, (int)(start + rc), check);
+
+            /* add to number of bytes read so far */
+            numread += rc;
+        }
+
+        /* break if we hit end of file */
+        if (rc == 0) {
+            /* check that total read is expected size */
+            ok(numread == (truncsize - seekpos),
+                "%s:%d read %d bytes, expected %d",
+                __FILE__, __LINE__, (int)numread, (int)(truncsize - seekpos));
+            break;
+        }
+
+        /* check that we don't run past expected
+         * end of file (and hang the test) */
+        if (numread > (truncsize - seekpos)) {
+            ok(numread <= (truncsize - seekpos),
+                "%s:%d read %d bytes, expected %d",
+                __FILE__, __LINE__, (int)numread, (int)(truncsize - seekpos));
+            break;
+        }
+
+        /* break if we hit an error, would have been
+         * reported in read above */
+        if (rc < 0) {
+            break;
+        }
+    }
+
+    close(fd);
+
+    free(buf);
+
+    return 0;
+}

--- a/t/sys/write-read.c
+++ b/t/sys/write-read.c
@@ -88,7 +88,7 @@ int write_read_test(char* unifyfs_root)
 
     /* Check global and local size on our un-laminated file */
     get_size(path, &global, &local, &log);
-    ok(global == 0, "%s: global size is %d: %s",  __FILE__, global,
+    ok(global == 15, "%s: global size is %d: %s",  __FILE__, global,
         strerror(errno));
     ok(local == 15, "%s: local size is %d: %s",  __FILE__, local,
         strerror(errno));
@@ -116,7 +116,7 @@ int write_read_test(char* unifyfs_root)
 
     /* Check global and local size on our un-laminated file */
     get_size(path, &global, &local, &log);
-    ok(global == 0, "%s: global size is %d: %s",  __FILE__, global,
+    ok(global == 21, "%s: global size is %d: %s",  __FILE__, global,
         strerror(errno));
     ok(local == 21, "%s: local size is %d: %s",  __FILE__, local,
         strerror(errno));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This adds support for truncate and ftruncate for extending and shrinking a file.  A new truncate rpc is defined on the server.  The implementation internally updates the file size field on the global meta data on a truncate call.  The filesize rpc has been updated to take the maximum of this file size field and the maximum offset of any write index as the true file size.

To shrink a file, there are two additional steps done in the truncate rpc in that we delete any index entries that extend beyond the new file size, and we rewrite any entries that happen to overlap (start before and end after) the new file size.

Note that unlinking a file current truncates the file to size=0, which will now delete any write index entries for the file.

If the file is not laminated, the stat wrappers have been updated to query the filesize rpc to get the current size whereas they used to always return 0.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
