### PR TITLE
Nread

### DIFF
--- a/client/src/unifyfs-internal.h
+++ b/client/src/unifyfs-internal.h
@@ -297,12 +297,23 @@ typedef struct {
 } unifyfs_filename_t;
 
 /*unifyfs structures*/
+
+/* This structure defines a client read request for a file.
+ * It is initialized by the client describing the global file id,
+ * offset, and length to be read and provides a pointer to
+ * the user buffer where the data should be placed.  The
+ * server sets the errcode field to UNIFYFS_SUCCESS if the read
+ * succeeds and otherwise records an error code pertaining to
+ * why the read failed.  The server records the number of bytes
+ * read in the nread field, which the client can use to detect
+ * short read operations. */
 typedef struct {
-    int gfid;
-    int errcode;
-    size_t offset;
-    size_t length;
-    char* buf;
+    int gfid;      /* global file id to be read */
+    int errcode;   /* error code for read operation if any */
+    size_t offset; /* logical offset in file to read from */
+    size_t length; /* number of bytes to read */
+    size_t nread;  /* number of bytes actually read */
+    char* buf;     /* pointer to user buffer to place data */
 } read_req_t;
 
 typedef struct {

--- a/client/src/unifyfs-stdio.c
+++ b/client/src/unifyfs-stdio.c
@@ -493,7 +493,7 @@ static int unifyfs_stream_flush(FILE* stream)
 /* reads count bytes from stream into buf, sets stream EOF and error
  * indicators as appropriate, sets errno if error, updates file
  * position, returns number of bytes read in retcount, returns UNIFYFS
- * error codes*/
+ * error codes */
 static int unifyfs_stream_read(
     FILE* stream,
     void* buf,
@@ -599,15 +599,15 @@ static int unifyfs_stream_read(
 
             /* read data from file into buffer */
             size_t bufcount;
-            size_t read_rc = unifyfs_fd_read(s->fd, current, s->buf,
+            ssize_t read_rc = unifyfs_fd_read(s->fd, current, s->buf,
                 s->bufsize);
-            if (read_rc  == -1) {
+            if (read_rc == -1) {
                 /*
                  * ERROR: read error, set error indicator. errno is already set
                  * by unifyfs_fd_read()
                  */
                 s->err = 1;
-                return read_rc;
+                return UNIFYFS_ERROR_IO;
             }
 
             /* record new buffer range within file */
@@ -2270,7 +2270,7 @@ static int __srefill(unifyfs_stream_t* stream)
 
         /* read data from file into buffer */
         size_t bufcount;
-        size_t read_rc = unifyfs_fd_read(s->fd, current, s->buf, s->bufsize);
+        ssize_t read_rc = unifyfs_fd_read(s->fd, current, s->buf, s->bufsize);
         if (read_rc < 0) {
             /* ERROR: read error, set error indicator */
             s->err = 1;

--- a/client/src/unifyfs-sysio.c
+++ b/client/src/unifyfs-sysio.c
@@ -1453,10 +1453,6 @@ static int process_read_data(read_req_t* read_reqs, int count, int* done)
 
     /* get number of read replies in shared memory */
     size_t num = shm_hdr->meta_cnt;
-    if (0 == num) {
-        LOGDBG("no read responses available");
-        return rc;
-    }
 
     /* process each of our read replies */
     size_t i;

--- a/server/src/unifyfs_global.h
+++ b/server/src/unifyfs_global.h
@@ -72,7 +72,8 @@ typedef enum {
 
 // NEW READ REQUEST STRUCTURES
 typedef enum {
-    READREQ_INIT = 0,
+    READREQ_NULL = 0,          /* request not initialized */
+    READREQ_READY,             /* request ready to be issued */
     READREQ_STARTED,           /* chunk requests issued */
     READREQ_PARTIAL_COMPLETE,  /* some reads completed */
     READREQ_COMPLETE           /* all reads completed */

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -100,7 +100,8 @@ sys_sysio_gotcha_t_SOURCES = sys/sysio_suite.h \
                              sys/mkdir-rmdir.c \
                              sys/open.c \
                              sys/open64.c \
-                             sys/write-read.c
+                             sys/write-read.c \
+                             sys/write-read-hole.c
 
 sys_sysio_gotcha_t_CPPFLAGS = $(test_cppflags)
 sys_sysio_gotcha_t_LDADD = $(test_ldadd)
@@ -113,7 +114,8 @@ sys_sysio_static_t_SOURCES = sys/sysio_suite.h \
                              sys/mkdir-rmdir.c \
                              sys/open.c \
                              sys/open64.c \
-                             sys/write-read.c
+                             sys/write-read.c \
+                             sys/write-read-hole.c
 
 sys_sysio_static_t_CPPFLAGS = $(test_cppflags)
 sys_sysio_static_t_LDADD = $(test_static_ldadd)

--- a/t/sys/sysio_suite.c
+++ b/t/sys/sysio_suite.c
@@ -83,6 +83,8 @@ int main(int argc, char* argv[])
 
     write_read_test(unifyfs_root);
 
+    write_read_hole_test(unifyfs_root);
+
     MPI_Finalize();
 
     done_testing();

--- a/t/sys/sysio_suite.h
+++ b/t/sys/sysio_suite.h
@@ -47,4 +47,7 @@ int open64_test(char* unifyfs_root);
 
 int write_read_test(char* unifyfs_root);
 
+/* test reading from file with holes */
+int write_read_hole_test(char* unifyfs_root);
+
 #endif /* SYSIO_SUITE_H */

--- a/t/sys/write-read-hole.c
+++ b/t/sys/write-read-hole.c
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2019, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2018, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyFS.
+ * For details, see https://github.com/LLNL/UnifyFS.
+ * Please read https://github.com/LLNL/UnifyFS/LICENSE for full license text.
+ */
+
+ /*
+  * Test reading from file with holes
+  */
+#include <fcntl.h>
+#include <string.h>
+#include <errno.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include "t/lib/tap.h"
+#include "t/lib/testutil.h"
+
+/* Get global, local, or log sizes (or all) */
+static
+void get_size(char* path, size_t* global, size_t* local, size_t* log)
+{
+    struct stat sb = {0};
+    int rc;
+
+    rc = stat(path, &sb);
+    if (rc != 0) {
+        printf("Error: %s\n", strerror(errno));
+        exit(1);    /* die on failure */
+    }
+    if (global) {
+        *global = sb.st_size;
+    }
+
+    if (local) {
+        *local = sb.st_rdev & 0xFFFFFFFF;
+    }
+
+    if (log) {
+        *log = (sb.st_rdev >> 32) & 0xFFFFFFFF;
+    }
+}
+
+static int check_contents(char* buf, size_t len, char c)
+{
+    int valid = 1;
+    size_t i;
+    for (i = 0; i < len; i++) {
+        if (buf[i] != c) {
+            valid = 0;
+        }
+    }
+    return valid;
+}
+
+int write_read_hole_test(char* unifyfs_root)
+{
+    char path[64];
+    int rc;
+    int fd;
+    size_t global, local, log;
+
+    size_t bufsize = 1024*1024;
+    char* buf = (char*) malloc(bufsize);
+    int i;
+    for (i = 0; i < bufsize; i++) {
+        buf[i] = 1;
+    }
+
+    testutil_rand_path(path, sizeof(path), unifyfs_root);
+
+    /* create a file that contains:
+     * [0, 1MB)   - data = "1"
+     * [1MB, 2MB) - hole = "0" implied
+     * [2MB, 3MB) - data = "1" */
+
+    /* Write to the file */
+    fd = open(path, O_WRONLY | O_CREAT, 0222);
+    ok(fd != -1, "%s:%d open(%s) (fd=%d): %s",
+        __FILE__, __LINE__, path, fd, strerror(errno));
+
+    rc = write(fd, buf, bufsize);
+    ok(rc == bufsize, "%s:%d write() (rc=%d): %s",
+        __FILE__, __LINE__, rc, strerror(errno));
+
+    /* Test writing to a different offset */
+    rc = lseek(fd, 2*bufsize, SEEK_SET);
+    ok(rc == 2*bufsize, "%s:%d lseek() (rc=%d): %s",
+        __FILE__, __LINE__, rc, strerror(errno));
+
+    rc = write(fd, buf, bufsize);
+    ok(rc == bufsize, "%s:%d write() (rc=%d): %s",
+        __FILE__, __LINE__, rc, strerror(errno));
+
+    /* Check global and local size on our un-laminated file */
+    get_size(path, &global, &local, &log);
+    ok(global == 0, "%s:%d global size is %d: %s",
+        __FILE__, __LINE__, global, strerror(errno));
+    ok(local == 3*bufsize, "%s:%d local size is %d: %s",
+        __FILE__, __LINE__, local, strerror(errno));
+    ok(log == 2*bufsize, "%s:%d log size is %d: %s",
+        __FILE__, __LINE__, log, strerror(errno));
+
+    /* flush writes */
+    rc = fsync(fd);
+    ok(rc == 0, "%s:%d fsync() (rc=%d): %s",
+        __FILE__, __LINE__, rc, strerror(errno));
+
+    /* Laminate */
+    rc = chmod(path, 0444);
+    ok(rc == 0, "%s:%d chmod(0444) (rc=%d): %s",
+        __FILE__, __LINE__, rc, strerror(errno));
+
+    /* Check global and local size on our un-laminated file */
+    get_size(path, &global, &local, &log);
+    ok(global == 3*bufsize, "%s:%d global size is %d: %s",
+        __FILE__, __LINE__, global, strerror(errno));
+    ok(local == 3*bufsize, "%s:%d local size is %d: %s",
+        __FILE__, __LINE__, local, strerror(errno));
+    ok(log == 2*bufsize, "%s:%d log size is %d: %s",
+        __FILE__, __LINE__, log, strerror(errno));
+
+    close(fd);
+
+    /***************
+     * open file for reading
+     ***************/
+
+    fd = open(path, O_RDONLY);
+    ok(fd != -1, "%s:%d open(%s) (fd=%d): %s",
+        __FILE__, __LINE__, path, fd, strerror(errno));
+
+
+    /* read segment [0, 1MB) -- should be all "1"
+     * this should be a full read, all from actual data */
+    memset(buf, 2, bufsize);
+    ssize_t nread = pread(fd, buf, bufsize, 0*bufsize);
+    ok(nread == bufsize, "%s:%d pread(%s) (fd=%d): %s",
+        __FILE__, __LINE__, path, fd, strerror(errno));
+
+    /* check that full buffer is "1" */
+    int valid = check_contents(buf, bufsize, 1);
+    ok(valid == 1, "%s:%d data check",
+        __FILE__, __LINE__);
+
+
+    /* read segment [1MB, 2MB) -- should be all "0"
+     * this should be a full read, all from a hole */
+    memset(buf, 2, bufsize);
+    nread = pread(fd, buf, bufsize, 1*bufsize);
+    ok(nread == bufsize, "%s:%d pread(%s) (fd=%d): %s",
+        __FILE__, __LINE__, path, fd, strerror(errno));
+
+    /* check that full buffer is "0" */
+    valid = check_contents(buf, bufsize, 0);
+    ok(valid == 1, "%s:%d data check",
+        __FILE__, __LINE__);
+
+
+    /* read segment [0.5MB, 1.5MB)
+     * should be a full read, half data, half hole */
+    memset(buf, 2, bufsize);
+    nread = pread(fd, buf, bufsize, bufsize/2);
+    ok(nread == bufsize, "%s:%d pread(%s) (fd=%d): %s",
+        __FILE__, __LINE__, path, fd, strerror(errno));
+
+    /* check that data portion is "1" */
+    valid = check_contents(buf, bufsize/2, 1);
+    ok(valid == 1, "%s:%d data check",
+        __FILE__, __LINE__);
+
+    /* check that hole portion is "0" */
+    valid = check_contents(buf + bufsize/2, bufsize/2, 0);
+    ok(valid == 1, "%s:%d data check",
+        __FILE__, __LINE__);
+
+
+    /* read segment [2.5MB, 3.5MB)
+     * should read only half of requested amount,
+     * half data, half past end of file */
+    memset(buf, 2, bufsize);
+    nread = pread(fd, buf, bufsize, 2*bufsize + bufsize/2);
+    ok(nread == bufsize/2, "%s:%d pread(%s) (fd=%d): %s",
+        __FILE__, __LINE__, path, fd, strerror(errno));
+
+    /* first half of buffer should be "1" */
+    valid = check_contents(buf, bufsize/2, 1);
+    ok(valid == 1, "%s:%d data check",
+        __FILE__, __LINE__);
+
+    /* second half of buffer should not be changed, still "2" */
+    valid = check_contents(buf + bufsize/2, bufsize/2, 2);
+    ok(valid == 1, "%s:%d data check",
+        __FILE__, __LINE__);
+
+
+    close(fd);
+
+    free(buf);
+
+    return 0;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This adds an nread field to the client-side read request structure.  We use this to count the max offset within each read request that has valid data.  It is used to handle short reads and to deal with holes.

This also updates the server to handle read requests that generate no write index entries.

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
