### PR TITLE
tests: add test for truncate/ftruncate with stat

### DIFF
--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -100,7 +100,8 @@ sys_sysio_gotcha_t_SOURCES = sys/sysio_suite.h \
                              sys/mkdir-rmdir.c \
                              sys/open.c \
                              sys/open64.c \
-                             sys/write-read.c
+                             sys/write-read.c \
+                             sys/truncate.c
 
 sys_sysio_gotcha_t_CPPFLAGS = $(test_cppflags)
 sys_sysio_gotcha_t_LDADD = $(test_ldadd)
@@ -113,7 +114,8 @@ sys_sysio_static_t_SOURCES = sys/sysio_suite.h \
                              sys/mkdir-rmdir.c \
                              sys/open.c \
                              sys/open64.c \
-                             sys/write-read.c
+                             sys/write-read.c \
+                             sys/truncate.c
 
 sys_sysio_static_t_CPPFLAGS = $(test_cppflags)
 sys_sysio_static_t_LDADD = $(test_static_ldadd)

--- a/t/sys/sysio_suite.c
+++ b/t/sys/sysio_suite.c
@@ -83,6 +83,8 @@ int main(int argc, char* argv[])
 
     write_read_test(unifyfs_root);
 
+    truncate_test(unifyfs_root);
+
     MPI_Finalize();
 
     done_testing();

--- a/t/sys/sysio_suite.h
+++ b/t/sys/sysio_suite.h
@@ -47,4 +47,7 @@ int open64_test(char* unifyfs_root);
 
 int write_read_test(char* unifyfs_root);
 
+/* Tests for UNIFYFS_WRAP(ftruncate) and UNIFYFS_WRAP(truncate) */
+int truncate_test(char* unifyfs_root);
+
 #endif /* SYSIO_SUITE_H */

--- a/t/sys/truncate.c
+++ b/t/sys/truncate.c
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2019, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2018, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyFS.
+ * For details, see https://github.com/LLNL/UnifyFS.
+ * Please read https://github.com/LLNL/UnifyFS/LICENSE for full license text.
+ */
+
+ /*
+  * Test truncate and ftruncate
+  */
+#include <fcntl.h>
+#include <string.h>
+#include <errno.h>
+#include <linux/limits.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include "t/lib/tap.h"
+#include "t/lib/testutil.h"
+
+/* Get global, local, or log sizes (or all) */
+static
+void get_size(char* path, size_t* global, size_t* local, size_t* log)
+{
+    struct stat sb = {0};
+    int rc;
+
+    rc = stat(path, &sb);
+    if (rc != 0) {
+        printf("Error: %s\n", strerror(errno));
+        exit(1);    /* die on failure */
+    }
+    if (global) {
+        *global = sb.st_size;
+    }
+
+    if (local) {
+        *local = sb.st_rdev & 0xFFFFFFFF;
+    }
+
+    if (log) {
+        *log = (sb.st_rdev >> 32) & 0xFFFFFFFF;
+    }
+}
+
+int truncate_test(char* unifyfs_root)
+{
+    char path[64];
+    int rc;
+    int fd;
+    size_t global, local, log;
+
+    size_t bufsize = 1024*1024;
+    char* buf = (char*) malloc(bufsize);
+
+    testutil_rand_path(path, sizeof(path), unifyfs_root);
+
+    /* Open a new file for writing */
+    fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0222);
+    ok(fd != -1, "%s: open(%s) (fd=%d): %s", __FILE__, path, fd,
+        strerror(errno));
+
+    /* fsync -- file should be 0 bytes at this point */
+    rc = fsync(fd);
+    ok(rc == 0, "%s: fsync() (rc=%d): %s", __FILE__, rc, strerror(errno));
+
+    get_size(path, &global, &local, &log);
+    ok(global == 0, "%s: global size is %d: %s",  __FILE__, global,
+        strerror(errno));
+    ok(local == 0, "%s: local size is %d: %s",  __FILE__, local,
+        strerror(errno));
+    ok(log == 0, "%s: log size is %d: %s",  __FILE__, log,
+        strerror(errno));
+
+    /* write 1MB and fsync, expect 1MB */
+    rc = write(fd, buf, bufsize);
+    ok(rc == 12, "%s: write() (rc=%d): %s", __FILE__, rc, strerror(errno));
+
+    rc = fsync(fd);
+    ok(rc == 0, "%s: fsync() (rc=%d): %s", __FILE__, rc, strerror(errno));
+
+    get_size(path, &global, &local, &log);
+    ok(global == 1*bufsize, "%s: global size is %d: %s",  __FILE__, global,
+        strerror(errno));
+    ok(local == 1*bufsize, "%s: local size is %d: %s",  __FILE__, local,
+        strerror(errno));
+    ok(log == 1*bufsize, "%s: log size is %d: %s",  __FILE__, log,
+        strerror(errno));
+
+    /* skip a 1MB hole, write another 1MB, and fsync expect 3MB */
+    rc = lseek(fd, 2*bufsize, SEEK_SET);
+    ok(rc == 2*bufsize, "%s: lseek() (rc=%d): %s", __FILE__, rc, strerror(errno));
+
+    rc = write(fd, buf, bufsize);
+    ok(rc == bufsize, "%s: write() (rc=%d): %s", __FILE__, rc, strerror(errno));
+
+    rc = fsync(fd);
+    ok(rc == 0, "%s: fsync() (rc=%d): %s", __FILE__, rc, strerror(errno));
+
+    get_size(path, &global, &local, &log);
+    ok(global == 3*bufsize, "%s: global size is %d: %s",  __FILE__, global,
+        strerror(errno));
+    ok(local == 3*bufsize, "%s: local size is %d: %s",  __FILE__, local,
+        strerror(errno));
+    ok(log == 2*bufsize, "%s: log size is %d: %s",  __FILE__, log,
+        strerror(errno));
+
+    /* ftruncate at 5MB, expect 5MB */
+    rc = ftruncate(fd, 5*bufsize);
+    ok(rc == 0, "%s: ftruncate() (rc=%d): %s", __FILE__, rc, strerror(errno));
+
+    get_size(path, &global, &local, &log);
+    ok(global == 5*bufsize, "%s: global size is %d: %s",  __FILE__, global,
+        strerror(errno));
+    ok(local == 5*bufsize, "%s: local size is %d: %s",  __FILE__, local,
+        strerror(errno));
+    ok(log == 2*bufsize, "%s: log size is %d: %s",  __FILE__, log,
+        strerror(errno));
+
+    close(fd);
+
+    /* truncate at 0.5 MB, expect 0.5MB */
+    rc = truncate(path, bufsize/2);
+    ok(rc == 0, "%s: truncate() (rc=%d): %s", __FILE__, rc, strerror(errno));
+
+    get_size(path, &global, &local, &log);
+    ok(global == bufsize/2, "%s: global size is %d: %s",  __FILE__, global,
+        strerror(errno));
+    ok(local == bufsize/2, "%s: local size is %d: %s",  __FILE__, local,
+        strerror(errno));
+    ok(log == 2*bufsize, "%s: log size is %d: %s",  __FILE__, log,
+        strerror(errno));
+
+    free(buf);
+
+    return 0;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This adds tests to verify that truncate and ftruncate return accurate file sizes are reported by stat.  This depends on https://github.com/LLNL/UnifyFS/pull/419.

We could also test that EOF is detected correctly with read().  That requires https://github.com/LLNL/UnifyFS/pull/421 to be merged, e.g., to test reading to the end of a file that has been extended with truncate.

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
