### PR TITLE
client: always use logical_size to get global/local_size

### DIFF
--- a/client/src/unifyfs-sysio.c
+++ b/client/src/unifyfs-sysio.c
@@ -1010,7 +1010,7 @@ ssize_t UNIFYFS_WRAP(write)(int fd, const void* buf, size_t count)
              * file position.
              */
             int fid = unifyfs_get_fid_from_fd(fd);
-            pos = unifyfs_fid_local_size(fid);
+            pos = unifyfs_fid_logical_size(fid);
         } else {
             pos = filedesc->pos;
         }

--- a/client/src/unifyfs.c
+++ b/client/src/unifyfs.c
@@ -1286,9 +1286,8 @@ int unifyfs_fid_open(const char* path, int flags, mode_t mode, int* outfid,
 
         if (flags & O_APPEND) {
             /* We only support O_APPEND on non-laminated (local) files, so
-             * use local_size here. */
-            unifyfs_filemeta_t* meta = unifyfs_get_meta_from_fid(fid);
-            pos = meta->local_size;
+             * this will use local_size here. */
+            pos = unifyfs_fid_logical_size(fid);
         }
     } else {
         /* !found_local && !found_global


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This converts two cases that refer to meta->local size directly to use unifyfs_fid_logical_size instead.  This latter function returns meta->local_size before lamination and it returns meta->global_size after lamination.  This change brings these two references in line with the rest of the functions that already call unifyfs_fid_logical_size.
```
fid_local_size() -- returns meta->local_size
- write() on fd opened in APPEND mode
- fid_open(O_APPEND) and file is defined locally and globally

fid_logical_size() -- returns meta->global_size if laminated, else meta->local_size
- lseek(SEEK_END)
- fseek(SEEK_END)
- stream_write on stream opened with APPEND
- fd_read to check that read is not reading past end of file
```

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
