### PR TITLE
fsync file data before truncate

### DIFF
--- a/client/src/unifyfs-internal.h
+++ b/client/src/unifyfs-internal.h
@@ -328,6 +328,9 @@ extern unifyfs_index_buf_t unifyfs_indices;
 extern unsigned long unifyfs_max_index_entries;
 extern long unifyfs_spillover_max_chunks;
 
+/* tracks total number of unsync'd segments for all files */
+extern unsigned long unifyfs_segment_count;
+
 extern int local_rank_cnt;
 extern int local_rank_idx;
 extern int local_del_cnt;

--- a/client/src/unifyfs.c
+++ b/client/src/unifyfs.c
@@ -77,6 +77,9 @@ static size_t unifyfs_fattr_buf_size;
 unsigned long unifyfs_max_index_entries; /* max metadata log entries */
 int unifyfs_spillmetablock;
 
+/* tracks total number of unsync'd segments for all files */
+unsigned long unifyfs_segment_count;
+
 int global_rank_cnt;  /* count of world ranks */
 int local_rank_cnt;
 int local_rank_idx;

--- a/t/sys/sysio_suite.c
+++ b/t/sys/sysio_suite.c
@@ -93,6 +93,8 @@ int main(int argc, char* argv[])
     truncate_pattern_size(unifyfs_root, 2020);
     truncate_empty_read(unifyfs_root, 0);
     truncate_empty_read(unifyfs_root, 2020);
+    truncate_ftrunc_before_sync(unifyfs_root);
+    truncate_trunc_before_sync(unifyfs_root);
 
     MPI_Finalize();
 

--- a/t/sys/sysio_suite.h
+++ b/t/sys/sysio_suite.h
@@ -55,5 +55,9 @@ int truncate_test(char* unifyfs_root);
 int truncate_bigempty(char* unifyfs_root);
 int truncate_eof(char* unifyfs_root);
 int truncate_truncsync(char* unifyfs_root);
+int truncate_pattern_size(char* unifyfs_root, int pos);
+int truncate_empty_read(char* unifyfs_root, int pos);
+int truncate_ftrunc_before_sync(char* unifyfs_root);
+int truncate_trunc_before_sync(char* unifyfs_root);
 
 #endif /* SYSIO_SUITE_H */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This uses the unifyfs_sync(gfid) function to fsync data before truncating a file.  It updates the truncate(), ftruncate() and fsync() wrappers to call unifyfs_sync(gfid).

It ensures that the spillover file is synced to disk in unifyfs_fsync() before it invokes the client-to-server fsync rpc.  Without this, the data that was meant to be written to the spillover file might still be cached in memory and not on disk when another process attempts to read it.  We should be sure it's on disk before it's registered with the server.

Since the index rewrite that happens during sync rewrites entries for all files, this uses the global segment count across all files for the test that triggers a sync.

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
