### PR TITLE
client: satisfy read requests from local extent info if possible

### DIFF
--- a/client/src/unifyfs-internal.h
+++ b/client/src/unifyfs-internal.h
@@ -266,26 +266,27 @@ typedef struct {
 } unifyfs_chunkmeta_t;
 
 typedef struct {
-    off_t global_size;               /* Global size of the file */
-    off_t local_size;                /* Local size of the file */
-    off_t log_size;                  /* Log size.  This is the sum of all the
-                                      * write counts. */
-    pthread_spinlock_t fspinlock;    /* file lock variable */
-    enum flock_enum flock_status;    /* file lock status */
+    off_t global_size;            /* Global size of the file */
+    off_t local_size;             /* Local size of the file */
+    off_t log_size;               /* Log size.  This is the sum of all the
+                                   * write counts. */
+    pthread_spinlock_t fspinlock; /* file lock variable */
+    enum flock_enum flock_status; /* file lock status */
 
-    int storage;                     /* FILE_STORAGE type */
+    int storage;                  /* FILE_STORAGE type */
 
-    int gfid;                        /* global file id for this file */
-    int needs_sync;                  /* have unsynced writes */
+    int gfid;                     /* global file id for this file */
+    int needs_sync;               /* have unsynced writes */
 
-    off_t chunks;                   /* number of chunks allocated to file */
-    off_t chunkmeta_idx;            /* starting index in unifyfs_chunkmeta */
-    int is_laminated;               /* Is this file laminated */
-    uint32_t mode;                  /* st_mode bits.  This has file
-                                     * permission info and will tell you if this
-                                     * is a regular file or directory. */
-    struct seg_tree seg_tree;       /* Segment tree containing our coalesced
-                                     * writes */
+    off_t chunks;                 /* number of chunks allocated to file */
+    off_t chunkmeta_idx;          /* starting index in unifyfs_chunkmeta */
+    int is_laminated;             /* Is this file laminated */
+    uint32_t mode;                /* st_mode bits.  This has file
+                                   * permission info and will tell you if this
+                                   * is a regular file or directory. */
+    struct seg_tree extents_sync; /* Segment tree containing our coalesced
+                                   * writes between sync operations */
+    struct seg_tree extents;      /* Segment tree of all local data extents */
 } unifyfs_filemeta_t;
 
 /* struct used to map a full path to its local file id,
@@ -393,7 +394,8 @@ extern int unifyfs_use_memfs;
 extern int unifyfs_use_spillover;
 
 extern int    unifyfs_max_files;  /* maximum number of files to store */
-extern bool   unifyfs_flatten_writes;    /* enable write flattening */
+extern bool   unifyfs_flatten_writes; /* enable write flattening */
+extern bool   unifyfs_local_extents;  /* enable tracking of local extents */
 extern size_t
 unifyfs_chunk_mem;  /* number of bytes in memory to be used for chunk storage */
 extern int    unifyfs_chunk_bits; /* we set chunk size = 2^unifyfs_chunk_bits */
@@ -483,6 +485,10 @@ const char* unifyfs_path_from_fid(int fid);
 
 /* Given a fid, return a gfid */
 int unifyfs_gfid_from_fid(const int fid);
+
+/* returns fid for corresponding gfid, if one is active,
+ * returns -1 otherwise */
+int unifyfs_fid_from_gfid(const int gfid);
 
 /* given an UNIFYFS error code, return corresponding errno code */
 int unifyfs_err_map_to_errno(int rc);

--- a/common/src/seg_tree.h
+++ b/common/src/seg_tree.h
@@ -22,6 +22,12 @@ void seg_tree_destroy(struct seg_tree* seg_tree);
 int seg_tree_add(struct seg_tree* seg_tree, unsigned long start,
     unsigned long end, unsigned long ptr);
 
+struct seg_tree_node* seg_tree_find_nolock(
+    struct seg_tree* seg_tree,
+    unsigned long start,
+    unsigned long end
+);
+
 struct seg_tree_node* seg_tree_iter(struct seg_tree* seg_tree,
     struct seg_tree_node* start);
 

--- a/common/src/unifyfs_configurator.h
+++ b/common/src/unifyfs_configurator.h
@@ -71,6 +71,7 @@
     UNIFYFS_CFG_CLI(unifyfs, mountpoint, STRING, /unifyfs, "mountpoint directory", NULL, 'm', "specify full path to desired mountpoint") \
     UNIFYFS_CFG(client, max_files, INT, UNIFYFS_MAX_FILES, "client max file count", NULL) \
     UNIFYFS_CFG(client, flatten_writes, BOOL, on, "flatten writes", NULL) \
+    UNIFYFS_CFG(client, local_extents, BOOL, off, "track extents to service reads of local data", NULL) \
     UNIFYFS_CFG_CLI(log, verbosity, INT, 0, "log verbosity level", NULL, 'v', "specify logging verbosity level") \
     UNIFYFS_CFG_CLI(log, file, STRING, unifyfsd.log, "log file name", NULL, 'l', "specify log file name") \
     UNIFYFS_CFG_CLI(log, dir, STRING, LOGDIR, "log file directory", configurator_directory_check, 'L', "specify full path to directory to contain log file") \

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -68,7 +68,14 @@ a given section and key.
    ==============  ======  =================================================================
    max_files       INT     maximum number of open files per client process
    flatten_writes  BOOL    enable flattening writes (optimization for overwrite-heavy codes)
+   local_extents   BOOL    service reads from local data if possible (default: off)
    ==============  ======  =================================================================
+
+Enabling the ``local_extents`` optimization may significantly improve read
+performance.  However, it should not be used by applications
+in which different processes write to a given byte offset within
+the file, nor should it be used with applications that truncate
+files.
 
 .. table:: ``[log]`` section - logging settings
    :widths: auto


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This adds another segment tree to the client metadata of each file (fid) that tracks all extents written to the file.  We use this to satisfy later read requests by having the client refer to this segment tree and then copy data directly from its data logs.  Any request that cannot be fully satisfied on the client is sent to the server for processing.

The goal is to make reads as fast as writes in the case that a client process reads back the same data it wrote.

This optimization cannot be used as currently written for apps that call truncate, because the server has no way to inform the client that it should truncate its extent list.  We'll need to be able to turn this on so apps can opt-in.  Added new UNIFYFS_CLIENT_LOCAL_EXTENTS=1 option to enable local read back. This is off by default.

This moves read request splitting from the client to the server.  Splitting the read requests into 1MB chunks was limiting performance, and this splitting is not necessary when the client is reading its own data.

This also moves the write index splitting from the client to the server.

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
