### PR TITLE
Newsize

### DIFF
--- a/client/src/unifyfs-dirops.c
+++ b/client/src/unifyfs-dirops.c
@@ -144,7 +144,6 @@ DIR* UNIFYFS_WRAP(opendir)(const char* name)
 
     meta->global_size = sb.st_size;
     meta->chunks = sb.st_blocks;
-    meta->local_size = 0; /* no need of local storage for dir operations */
 
     unifyfs_dirstream_t* dirp = unifyfs_dirstream_alloc(fid);
 

--- a/client/src/unifyfs-internal.h
+++ b/client/src/unifyfs-internal.h
@@ -268,7 +268,6 @@ typedef struct {
 
 typedef struct {
     off_t global_size;            /* Global size of the file */
-    off_t local_size;             /* Local size of the file */
     off_t log_size;               /* Log size.  This is the sum of all the
                                    * write counts. */
     pthread_spinlock_t fspinlock; /* file lock variable */
@@ -489,9 +488,6 @@ int unifyfs_fid_is_dir_empty(const char* path);
 
 /* Return current global size of given file id */
 off_t unifyfs_fid_global_size(int fid);
-
-/* Return current local size of given file id */
-off_t unifyfs_fid_local_size(int fid);
 
 /* Return current local size of given file id */
 off_t unifyfs_fid_log_size(int fid);

--- a/client/src/unifyfs-sysio.c
+++ b/client/src/unifyfs-sysio.c
@@ -410,14 +410,13 @@ static int __stat(const char* path, struct stat* buf)
     if (fid >= 0) { /* If we have a local file */
         /*
          * For debugging and testing purposes, we hijack st_rdev to store our
-         * local size and log size.  We also assume the stat struct is
+         * log size.  We also assume the stat struct is
          * the 64-bit variant.  The values are stored as:
          *
-         * st_rdev = log_size << 32 | local_size;
+         * st_rdev = log_size
          *
          */
-        buf->st_rdev  = (unifyfs_fid_log_size(fid) << 32);
-        buf->st_rdev |= (unifyfs_fid_local_size(fid) & 0xFFFFFFFF);
+        buf->st_rdev = unifyfs_fid_log_size(fid);
     }
 
     return 0;
@@ -639,7 +638,6 @@ int unifyfs_fd_write(int fd, off_t pos, const void* buf, size_t count)
     if (write_rc == 0) {
         unifyfs_filemeta_t* meta = unifyfs_get_meta_from_fid(fid);
         meta->needs_sync = 1;
-        meta->local_size = MAX(meta->local_size, pos + count);
         meta->log_size = newlogsize;
     }
     return write_rc;

--- a/client/src/unifyfs.c
+++ b/client/src/unifyfs.c
@@ -633,6 +633,16 @@ off_t unifyfs_fid_logical_size(int fid)
         /* get gfid for this file */
         int gfid = unifyfs_gfid_from_fid(fid);
 
+        /* sync any writes to disk before requesting file size */
+        unifyfs_filemeta_t* meta = unifyfs_get_meta_from_fid(fid);
+        if (meta->needs_sync) {
+            /* we have some changes to sync for this file */
+            unifyfs_sync(gfid);
+
+            /* just synced writes for this file */
+            meta->needs_sync = 0;
+        }
+
         /* get file size for this file */
         size_t filesize;
         int ret = invoke_client_filesize_rpc(gfid, &filesize);

--- a/t/std/size.c
+++ b/t/std/size.c
@@ -25,13 +25,13 @@
 #include "t/lib/testutil.h"
 
 /*
- * Test correctness of local and global file size.  Also, test opening a file
+ * Test correctness of global file size.  Also, test opening a file
  * for append, and test file positioning (fseek, ftell, etc).
  */
 
-/* Get global, local, or log sizes (or all) */
+/* Get global or log sizes (or all) */
 static
-void get_size(char* path, size_t* global, size_t* local, size_t* log)
+void get_size(char* path, size_t* global, size_t* log)
 {
     struct stat sb = {0};
     int rc;
@@ -45,12 +45,8 @@ void get_size(char* path, size_t* global, size_t* local, size_t* log)
         *global = sb.st_size;
     }
 
-    if (local) {
-        *local = sb.st_rdev & 0xFFFFFFFF;
-    }
-
     if (log) {
-        *log = (sb.st_rdev >> 32) & 0xFFFFFFFF;
+        *log = sb.st_rdev;
     }
 }
 
@@ -61,7 +57,7 @@ int size_test(char* unifyfs_root)
     FILE* fp = NULL;
     int rc;
     char* tmp;
-    size_t global, local, log;
+    size_t global, log;
 
     errno = 0;
 
@@ -77,10 +73,8 @@ int size_test(char* unifyfs_root)
     rc = fclose(fp);
     ok(rc == 0, "%s: fclose() (rc=%d): %s", __FILE__, rc, strerror(errno));
 
-    get_size(path, &global, &local, &log);
+    get_size(path, &global, &log);
     ok(global == 12, "%s: global size is %d: %s",  __FILE__, global,
-        strerror(errno));
-    ok(local == 12, "%s: local size is %d: %s",  __FILE__, local,
         strerror(errno));
     ok(log == 12, "%s: log size is %d: %s",  __FILE__, log,
         strerror(errno));
@@ -118,10 +112,8 @@ int size_test(char* unifyfs_root)
     rc = fclose(fp);
     ok(rc == 0, "%s: fclose() (rc=%d): %s", __FILE__, rc, strerror(errno));
 
-    get_size(path, &global, &local, &log);
+    get_size(path, &global, &log);
     ok(global == 30, "%s: global size is %d: %s",  __FILE__, global,
-        strerror(errno));
-    ok(local == 30, "%s: local size is %d: %s",  __FILE__, local,
         strerror(errno));
     ok(log == 30, "%s: log size is %d: %s",  __FILE__, log,
         strerror(errno));
@@ -140,11 +132,9 @@ int size_test(char* unifyfs_root)
     rc = chmod(path, 0444);
     ok(rc == 0, "%s: chmod(0444) (rc=%d): %s", __FILE__, rc, strerror(errno));
 
-    /* Both local and global size should be correct */
-    get_size(path, &global, &local, &log);
+    /* Global size should be correct */
+    get_size(path, &global, &log);
     ok(global == 30, "%s: global size is %d: %s",  __FILE__, global,
-        strerror(errno));
-    ok(local == 30, "%s: local size is %d: %s",  __FILE__, local,
         strerror(errno));
     ok(log == 30, "%s: log size is %d: %s",  __FILE__, log,
         strerror(errno));

--- a/t/std/size.c
+++ b/t/std/size.c
@@ -78,7 +78,7 @@ int size_test(char* unifyfs_root)
     ok(rc == 0, "%s: fclose() (rc=%d): %s", __FILE__, rc, strerror(errno));
 
     get_size(path, &global, &local, &log);
-    ok(global == 0, "%s: global size is %d: %s",  __FILE__, global,
+    ok(global == 12, "%s: global size is %d: %s",  __FILE__, global,
         strerror(errno));
     ok(local == 12, "%s: local size is %d: %s",  __FILE__, local,
         strerror(errno));
@@ -119,7 +119,7 @@ int size_test(char* unifyfs_root)
     ok(rc == 0, "%s: fclose() (rc=%d): %s", __FILE__, rc, strerror(errno));
 
     get_size(path, &global, &local, &log);
-    ok(global == 0, "%s: global size is %d: %s",  __FILE__, global,
+    ok(global == 30, "%s: global size is %d: %s",  __FILE__, global,
         strerror(errno));
     ok(local == 30, "%s: local size is %d: %s",  __FILE__, local,
         strerror(errno));

--- a/t/sys/truncate.c
+++ b/t/sys/truncate.c
@@ -24,9 +24,9 @@
 #include "t/lib/tap.h"
 #include "t/lib/testutil.h"
 
-/* Get global, local, or log sizes (or all) */
+/* Get global or log sizes (or all) */
 static
-void get_size(char* path, size_t* global, size_t* local, size_t* log)
+void get_size(char* path, size_t* global, size_t* log)
 {
     struct stat sb = {0};
     int rc;
@@ -40,12 +40,8 @@ void get_size(char* path, size_t* global, size_t* local, size_t* log)
         *global = sb.st_size;
     }
 
-    if (local) {
-        *local = sb.st_rdev & 0xFFFFFFFF;
-    }
-
     if (log) {
-        *log = (sb.st_rdev >> 32) & 0xFFFFFFFF;
+        *log = sb.st_rdev;
     }
 }
 
@@ -54,7 +50,7 @@ int truncate_test(char* unifyfs_root)
     char path[64];
     int rc;
     int fd;
-    size_t global, local, log;
+    size_t global, log;
 
     size_t bufsize = 1024*1024;
     char* buf = (char*) malloc(bufsize);
@@ -67,11 +63,9 @@ int truncate_test(char* unifyfs_root)
         __FILE__, __LINE__, path, fd, strerror(errno));
 
     /* file should be 0 bytes at this point */
-    get_size(path, &global, &local, &log);
+    get_size(path, &global, &log);
     ok(global == 0, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, 0);
-    ok(local == 0, "%s:%d local size is %d expected %d",
-        __FILE__, __LINE__, local, 0);
     ok(log == 0, "%s:%d log size is %d expected %d",
         __FILE__, __LINE__, log, 0);
 
@@ -84,11 +78,9 @@ int truncate_test(char* unifyfs_root)
     ok(rc == 0, "%s:%d fsync() (rc=%d): %s",
         __FILE__, __LINE__, rc, strerror(errno));
 
-    get_size(path, &global, &local, &log);
+    get_size(path, &global, &log);
     ok(global == 1*bufsize, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, 1*bufsize);
-    ok(local == 1*bufsize, "%s:%d local size is %d expected %d",
-        __FILE__, __LINE__, local, 1*bufsize);
     ok(log == 1*bufsize, "%s:%d log size is %d expected %d",
         __FILE__, __LINE__, log, 1*bufsize);
 
@@ -105,11 +97,9 @@ int truncate_test(char* unifyfs_root)
     ok(rc == 0, "%s:%d fsync() (rc=%d): %s",
         __FILE__, __LINE__, rc, strerror(errno));
 
-    get_size(path, &global, &local, &log);
+    get_size(path, &global, &log);
     ok(global == 3*bufsize, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, 3*bufsize);
-    ok(local == 3*bufsize, "%s:%d local size is %d expected %d",
-        __FILE__, __LINE__, local, 3*bufsize);
     ok(log == 2*bufsize, "%s:%d log size is %d expected %d",
         __FILE__, __LINE__, log, 2*bufsize);
 
@@ -118,11 +108,9 @@ int truncate_test(char* unifyfs_root)
     ok(rc == 0, "%s:%d ftruncate(%d) (rc=%d): %s",
         __FILE__, __LINE__, 5*bufsize, rc, strerror(errno));
 
-    get_size(path, &global, &local, &log);
+    get_size(path, &global, &log);
     ok(global == 5*bufsize, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, 5*bufsize);
-    ok(local == 5*bufsize, "%s:%d local size is %d expected %d",
-        __FILE__, __LINE__, local, 5*bufsize);
     ok(log == 2*bufsize, "%s:%d log size is %d expected %d",
         __FILE__, __LINE__, log, 2*bufsize);
 
@@ -133,11 +121,9 @@ int truncate_test(char* unifyfs_root)
     ok(rc == 0, "%s:%d truncate(%d) (rc=%d): %s",
         __FILE__, __LINE__, bufsize/2, rc, strerror(errno));
 
-    get_size(path, &global, &local, &log);
+    get_size(path, &global, &log);
     ok(global == bufsize/2, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, bufsize/2);
-    ok(local == bufsize/2, "%s:%d local size is %d expected %d",
-        __FILE__, __LINE__, local, bufsize/2);
     ok(log == 2*bufsize, "%s:%d log size is %d expected %d",
         __FILE__, __LINE__, log, 2*bufsize);
 
@@ -146,11 +132,9 @@ int truncate_test(char* unifyfs_root)
     ok(rc == 0, "%s:%d truncate(%d) (rc=%d): %s",
         __FILE__, __LINE__, 0, rc, strerror(errno));
 
-    get_size(path, &global, &local, &log);
+    get_size(path, &global, &log);
     ok(global == 0, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, 0);
-    ok(local == 0, "%s:%d local size is %d expected %d",
-        __FILE__, __LINE__, local, 0);
     ok(log == 2*bufsize, "%s:%d log size is %d expected %d",
         __FILE__, __LINE__, log, 2*bufsize);
 
@@ -164,7 +148,7 @@ int truncate_bigempty(char* unifyfs_root)
     char path[64];
     int rc;
     int fd;
-    size_t global, local, log;
+    size_t global, log;
 
     size_t bufsize = 1024*1024;
     char* buf = (char*) malloc(bufsize);
@@ -176,11 +160,9 @@ int truncate_bigempty(char* unifyfs_root)
     ok(fd != -1, "%s:%d open(%s) (fd=%d): %s",
         __FILE__, __LINE__, path, fd, strerror(errno));
 
-    get_size(path, &global, &local, &log);
+    get_size(path, &global, &log);
     ok(global == 0, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, 0);
-    ok(local == 0, "%s:%d local size is %d expected %d",
-        __FILE__, __LINE__, local, 0);
     ok(log == 0, "%s:%d log size is %d expected %d",
         __FILE__, __LINE__, log, 0);
 
@@ -191,7 +173,7 @@ int truncate_bigempty(char* unifyfs_root)
         __FILE__, __LINE__, (unsigned long long) bigempty,
         rc, strerror(errno));
 
-    get_size(path, &global, &local, &log);
+    get_size(path, &global, &log);
     ok(global == (size_t)bigempty, "%s:%d global size is %llu expected %llu",
         __FILE__, __LINE__, global, (unsigned long long)bigempty,
         strerror(errno));
@@ -208,7 +190,7 @@ int truncate_eof(char* unifyfs_root)
     char path[64];
     int rc;
     int fd;
-    size_t global, local, log;
+    size_t global, log;
 
     size_t bufsize = 1024*1024;
     char* buf = (char*) malloc(bufsize);
@@ -221,11 +203,9 @@ int truncate_eof(char* unifyfs_root)
         __FILE__, __LINE__, path, fd, strerror(errno));
 
     /* file should be 0 bytes at this point */
-    get_size(path, &global, &local, &log);
+    get_size(path, &global, &log);
     ok(global == 0, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, 0);
-    ok(local == 0, "%s:%d local size is %d expected %d",
-        __FILE__, __LINE__, local, 0);
     ok(log == 0, "%s:%d log size is %d expected %d",
         __FILE__, __LINE__, log, 0);
 
@@ -289,7 +269,7 @@ int truncate_truncsync(char* unifyfs_root)
     char path[64];
     int rc;
     int fd;
-    size_t global, local, log;
+    size_t global, log;
 
     size_t bufsize = 1024*1024;
     char* buf = (char*) malloc(bufsize);
@@ -302,11 +282,9 @@ int truncate_truncsync(char* unifyfs_root)
         __FILE__, __LINE__, path, fd, strerror(errno));
 
     /* file should be 0 bytes at this point */
-    get_size(path, &global, &local, &log);
+    get_size(path, &global, &log);
     ok(global == 0, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, 0);
-    ok(local == 0, "%s:%d local size is %d expected %d",
-        __FILE__, __LINE__, local, 0);
     ok(log == 0, "%s:%d log size is %d expected %d",
         __FILE__, __LINE__, log, 0);
 
@@ -321,11 +299,9 @@ int truncate_truncsync(char* unifyfs_root)
         __FILE__, __LINE__, bufsize/2, rc, strerror(errno));
 
     /* file should be 0.5MB bytes at this point */
-    get_size(path, &global, &local, &log);
+    get_size(path, &global, &log);
     ok(global == bufsize/2, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, bufsize/2);
-    ok(local == bufsize/2, "%s:%d local size is %d expected %d",
-        __FILE__, __LINE__, local, bufsize/2);
     ok(log == bufsize, "%s:%d log size is %d expected %d",
         __FILE__, __LINE__, log, bufsize);
 
@@ -334,11 +310,9 @@ int truncate_truncsync(char* unifyfs_root)
         __FILE__, __LINE__, rc, strerror(errno));
 
     /* file should still be 0.5MB bytes at this point */
-    get_size(path, &global, &local, &log);
+    get_size(path, &global, &log);
     ok(global == bufsize/2, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, bufsize/2);
-    ok(local == bufsize/2, "%s:%d local size is %d expected %d",
-        __FILE__, __LINE__, local, bufsize/2);
     ok(log == bufsize, "%s:%d log size is %d expected %d",
         __FILE__, __LINE__, log, bufsize);
 
@@ -392,7 +366,7 @@ int truncate_pattern_size(char* unifyfs_root, off_t seekpos)
     char path[64];
     int rc;
     int fd;
-    size_t global, local, log;
+    size_t global, log;
     int i;
 
     size_t bufsize = 1024*1024;
@@ -406,11 +380,9 @@ int truncate_pattern_size(char* unifyfs_root, off_t seekpos)
         __FILE__, __LINE__, path, fd, strerror(errno));
 
     /* file should be 0 bytes at this point */
-    get_size(path, &global, &local, &log);
+    get_size(path, &global, &log);
     ok(global == 0, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, 0);
-    ok(local == 0, "%s:%d local size is %d expected %d",
-        __FILE__, __LINE__, local, 0);
     ok(log == 0, "%s:%d log size is %d expected %d",
         __FILE__, __LINE__, log, 0);
 
@@ -438,11 +410,9 @@ int truncate_pattern_size(char* unifyfs_root, off_t seekpos)
         __FILE__, __LINE__, (int)truncsize, rc, strerror(errno));
 
     /* file should be of size 5MB + 42 at this point */
-    get_size(path, &global, &local, &log);
+    get_size(path, &global, &log);
     ok(global == truncsize, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, (int)truncsize);
-    ok(local == truncsize, "%s:%d local size is %d expected %d",
-        __FILE__, __LINE__, local, (int)truncsize);
     ok(log == 20*bufsize, "%s:%d log size is %d expected %d",
         __FILE__, __LINE__, log, 20*bufsize);
 
@@ -454,11 +424,9 @@ int truncate_pattern_size(char* unifyfs_root, off_t seekpos)
         __FILE__, __LINE__, rc, strerror(errno));
 
     /* file should still be 5MB + 42 bytes at this point */
-    get_size(path, &global, &local, &log);
+    get_size(path, &global, &log);
     ok(global == truncsize, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, (int)truncsize);
-    ok(local == truncsize, "%s:%d local size is %d expected %d",
-        __FILE__, __LINE__, local, (int)truncsize);
     ok(log == 20*bufsize, "%s:%d log size is %d expected %d",
         __FILE__, __LINE__, log, 20*bufsize);
 
@@ -540,7 +508,7 @@ int truncate_empty_read(char* unifyfs_root, off_t seekpos)
     char path[64];
     int rc;
     int fd;
-    size_t global, local, log;
+    size_t global, log;
     int i;
 
     size_t bufsize = 1024*1024;
@@ -554,11 +522,9 @@ int truncate_empty_read(char* unifyfs_root, off_t seekpos)
         __FILE__, __LINE__, path, fd, strerror(errno));
 
     /* file should be 0 bytes at this point */
-    get_size(path, &global, &local, &log);
+    get_size(path, &global, &log);
     ok(global == 0, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, 0);
-    ok(local == 0, "%s:%d local size is %d expected %d",
-        __FILE__, __LINE__, local, 0);
     ok(log == 0, "%s:%d log size is %d expected %d",
         __FILE__, __LINE__, log, 0);
 
@@ -571,11 +537,9 @@ int truncate_empty_read(char* unifyfs_root, off_t seekpos)
         __FILE__, __LINE__, (int)truncsize, rc, strerror(errno));
 
     /* file should be of size 5MB + 42 at this point */
-    get_size(path, &global, &local, &log);
+    get_size(path, &global, &log);
     ok(global == truncsize, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, (int)truncsize);
-    ok(local == truncsize, "%s:%d local size is %d expected %d",
-        __FILE__, __LINE__, local, (int)truncsize);
     ok(log == 0, "%s:%d log size is %d expected %d",
         __FILE__, __LINE__, log, 0);
 
@@ -587,11 +551,9 @@ int truncate_empty_read(char* unifyfs_root, off_t seekpos)
         __FILE__, __LINE__, rc, strerror(errno));
 
     /* file should still be 5MB + 42 bytes at this point */
-    get_size(path, &global, &local, &log);
+    get_size(path, &global, &log);
     ok(global == truncsize, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, (int)truncsize);
-    ok(local == truncsize, "%s:%d local size is %d expected %d",
-        __FILE__, __LINE__, local, (int)truncsize);
     ok(log == 0, "%s:%d log size is %d expected %d",
         __FILE__, __LINE__, log, 0);
 
@@ -671,7 +633,7 @@ int truncate_ftrunc_before_sync(char* unifyfs_root)
     char path[64];
     int rc;
     int fd;
-    size_t global, local, log;
+    size_t global, log;
 
     size_t bufsize = 1024;
     char* buf = (char*) malloc(bufsize);
@@ -684,11 +646,9 @@ int truncate_ftrunc_before_sync(char* unifyfs_root)
         __FILE__, __LINE__, path, fd, strerror(errno));
 
     /* file should be 0 bytes at this point */
-    get_size(path, &global, &local, &log);
+    get_size(path, &global, &log);
     ok(global == 0, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, 0);
-    ok(local == 0, "%s:%d local size is %d expected %d",
-        __FILE__, __LINE__, local, 0);
     ok(log == 0, "%s:%d log size is %d expected %d",
         __FILE__, __LINE__, log, 0);
 
@@ -714,11 +674,9 @@ int truncate_ftrunc_before_sync(char* unifyfs_root)
     /* finally, check that the file is 0 bytes,
      * i.e., check that the writes happened before the truncate
      * and not at the fsync */
-    get_size(path, &global, &local, &log);
+    get_size(path, &global, &log);
     ok(global == truncsize, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, (int)truncsize);
-    ok(local == truncsize, "%s:%d local size is %d expected %d",
-        __FILE__, __LINE__, local, (int)truncsize);
     ok(log == bufsize, "%s:%d log size is %d expected %d",
         __FILE__, __LINE__, log, bufsize);
 
@@ -734,7 +692,7 @@ int truncate_trunc_before_sync(char* unifyfs_root)
     char path[64];
     int rc;
     int fd;
-    size_t global, local, log;
+    size_t global, log;
 
     size_t bufsize = 1024;
     char* buf = (char*) malloc(bufsize);
@@ -747,11 +705,9 @@ int truncate_trunc_before_sync(char* unifyfs_root)
         __FILE__, __LINE__, path, fd, strerror(errno));
 
     /* file should be 0 bytes at this point */
-    get_size(path, &global, &local, &log);
+    get_size(path, &global, &log);
     ok(global == 0, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, 0);
-    ok(local == 0, "%s:%d local size is %d expected %d",
-        __FILE__, __LINE__, local, 0);
     ok(log == 0, "%s:%d log size is %d expected %d",
         __FILE__, __LINE__, log, 0);
 
@@ -777,11 +733,9 @@ int truncate_trunc_before_sync(char* unifyfs_root)
     /* finally, check that the file is 0 bytes,
      * i.e., check that the writes happened before the truncate
      * and not at the fsync */
-    get_size(path, &global, &local, &log);
+    get_size(path, &global, &log);
     ok(global == truncsize, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, (int)truncsize);
-    ok(local == truncsize, "%s:%d local size is %d expected %d",
-        __FILE__, __LINE__, local, (int)truncsize);
     ok(log == bufsize, "%s:%d log size is %d expected %d",
         __FILE__, __LINE__, log, bufsize);
 

--- a/t/sys/write-read-hole.c
+++ b/t/sys/write-read-hole.c
@@ -23,9 +23,9 @@
 #include "t/lib/tap.h"
 #include "t/lib/testutil.h"
 
-/* Get global, local, or log sizes (or all) */
+/* Get global or log sizes (or all) */
 static
-void get_size(char* path, size_t* global, size_t* local, size_t* log)
+void get_size(char* path, size_t* global, size_t* log)
 {
     struct stat sb = {0};
     int rc;
@@ -39,12 +39,8 @@ void get_size(char* path, size_t* global, size_t* local, size_t* log)
         *global = sb.st_size;
     }
 
-    if (local) {
-        *local = sb.st_rdev & 0xFFFFFFFF;
-    }
-
     if (log) {
-        *log = (sb.st_rdev >> 32) & 0xFFFFFFFF;
+        *log = sb.st_rdev;
     }
 }
 
@@ -65,7 +61,7 @@ int write_read_hole_test(char* unifyfs_root)
     char path[64];
     int rc;
     int fd;
-    size_t global, local, log;
+    size_t global, log;
 
     size_t bufsize = 1024*1024;
     char* buf = (char*) malloc(bufsize);
@@ -102,12 +98,10 @@ int write_read_hole_test(char* unifyfs_root)
     ok(rc == bufsize, "%s:%d write() (rc=%d): %s",
         __FILE__, __LINE__, rc, strerror(errno));
 
-    /* Check global and local size on our un-laminated file */
-    get_size(path, &global, &local, &log);
+    /* Check global size on our un-laminated file */
+    get_size(path, &global, &log);
     ok(global == 0, "%s:%d global size is %d: %s",
         __FILE__, __LINE__, global, strerror(errno));
-    ok(local == 3*bufsize, "%s:%d local size is %d: %s",
-        __FILE__, __LINE__, local, strerror(errno));
     ok(log == 2*bufsize, "%s:%d log size is %d: %s",
         __FILE__, __LINE__, log, strerror(errno));
 
@@ -116,12 +110,10 @@ int write_read_hole_test(char* unifyfs_root)
     ok(rc == 0, "%s:%d fsync() (rc=%d): %s",
         __FILE__, __LINE__, rc, strerror(errno));
 
-    /* Check global and local size on our un-laminated file */
-    get_size(path, &global, &local, &log);
+    /* Check global size on our un-laminated file */
+    get_size(path, &global, &log);
     ok(global == 3*bufsize, "%s:%d global size is %d: %s",
         __FILE__, __LINE__, global, strerror(errno));
-    ok(local == 3*bufsize, "%s:%d local size is %d: %s",
-        __FILE__, __LINE__, local, strerror(errno));
     ok(log == 2*bufsize, "%s:%d log size is %d: %s",
         __FILE__, __LINE__, log, strerror(errno));
 
@@ -136,12 +128,10 @@ int write_read_hole_test(char* unifyfs_root)
     ok(rc == 0, "%s:%d chmod(0444) (rc=%d): %s",
         __FILE__, __LINE__, rc, strerror(errno));
 
-    /* Check global and local size on our un-laminated file */
-    get_size(path, &global, &local, &log);
+    /* Check global size on our un-laminated file */
+    get_size(path, &global, &log);
     ok(global == 4*bufsize, "%s:%d global size is %d: %s",
         __FILE__, __LINE__, global, strerror(errno));
-    ok(local == 4*bufsize, "%s:%d local size is %d: %s",
-        __FILE__, __LINE__, local, strerror(errno));
     ok(log == 2*bufsize, "%s:%d log size is %d: %s",
         __FILE__, __LINE__, log, strerror(errno));
 

--- a/t/sys/write-read.c
+++ b/t/sys/write-read.c
@@ -24,9 +24,9 @@
 #include "t/lib/tap.h"
 #include "t/lib/testutil.h"
 
-/* Get global, local, or log sizes (or all) */
+/* Get global or log sizes (or all) */
 static
-void get_size(char* path, size_t* global, size_t* local, size_t* log)
+void get_size(char* path, size_t* global, size_t* log)
 {
     struct stat sb = {0};
     int rc;
@@ -40,12 +40,8 @@ void get_size(char* path, size_t* global, size_t* local, size_t* log)
         *global = sb.st_size;
     }
 
-    if (local) {
-        *local = sb.st_rdev & 0xFFFFFFFF;
-    }
-
     if (log) {
-        *log = (sb.st_rdev >> 32) & 0xFFFFFFFF;
+        *log = sb.st_rdev;
     }
 }
 
@@ -54,7 +50,7 @@ int write_read_test(char* unifyfs_root)
     char path[64];
     int rc;
     int fd;
-    size_t global, local, log;
+    size_t global, log;
 
     testutil_rand_path(path, sizeof(path), unifyfs_root);
 
@@ -73,11 +69,9 @@ int write_read_test(char* unifyfs_root)
     rc = write(fd, "universe", 9);
     ok(rc == 9, "%s: write() (rc=%d): %s", __FILE__, rc, strerror(errno));
 
-    /* Check global and local size on our un-laminated file */
-    get_size(path, &global, &local, &log);
+    /* Check global size on our un-laminated file */
+    get_size(path, &global, &log);
     ok(global == 0, "%s: global size is %d: %s",  __FILE__, global,
-        strerror(errno));
-    ok(local == 15, "%s: local size is %d: %s",  __FILE__, local,
         strerror(errno));
     ok(log == 21, "%s: log size is %d: %s",  __FILE__, log,
         strerror(errno));
@@ -86,11 +80,9 @@ int write_read_test(char* unifyfs_root)
     rc = fsync(fd);
     ok(rc == 0, "%s: fsync() (rc=%d): %s", __FILE__, rc, strerror(errno));
 
-    /* Check global and local size on our un-laminated file */
-    get_size(path, &global, &local, &log);
+    /* Check global size on our un-laminated file */
+    get_size(path, &global, &log);
     ok(global == 15, "%s: global size is %d: %s",  __FILE__, global,
-        strerror(errno));
-    ok(local == 15, "%s: local size is %d: %s",  __FILE__, local,
         strerror(errno));
     ok(log == 21, "%s: log size is %d: %s",  __FILE__, log,
         strerror(errno));
@@ -114,11 +106,9 @@ int write_read_test(char* unifyfs_root)
     ok(rc == 6, "%s: write() (rc=%d): %s", __FILE__, rc, strerror(errno));
     close(fd);
 
-    /* Check global and local size on our un-laminated file */
-    get_size(path, &global, &local, &log);
+    /* Check global size on our un-laminated file */
+    get_size(path, &global, &log);
     ok(global == 21, "%s: global size is %d: %s",  __FILE__, global,
-        strerror(errno));
-    ok(local == 21, "%s: local size is %d: %s",  __FILE__, local,
         strerror(errno));
     ok(log == 27, "%s: log size is %d: %s",  __FILE__, log,
         strerror(errno));
@@ -129,10 +119,8 @@ int write_read_test(char* unifyfs_root)
     ok(rc == 0, "%s: chmod(0444) (rc=%d): %s", __FILE__, rc, strerror(errno));
 
     /* Verify we're getting the correct file size */
-    get_size(path, &global, &local, &log);
+    get_size(path, &global, &log);
     ok(global == 21, "%s: global size is %d: %s",  __FILE__, global,
-        strerror(errno));
-    ok(local == 21, "%s: local size is %d: %s",  __FILE__, local,
         strerror(errno));
     ok(log == 27, "%s: log size is %d: %s",  __FILE__, log,
         strerror(errno));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This is a start of a PR to make the notion of file size consistent.  We'll need some group-wide discussion on how we want size to be defined in various places.

Related to https://github.com/LLNL/UnifyFS/issues/432

For the case that we need to support for HDF, where HDF requires an accurate file size from stat() before it has laminated the file, things get weird currently.  Our code can return one size with stat, but then if a process reads until EOF, it would deduce there is a different file size.  I'm guessing that inconsistency will be problematic, so this adds code so that the size is consistent in all of those instances (or at least that's the goal).  Thus, it ignores local_size.  It can still use global_size if the file has been laminated.

However, going to the server to get the current file size is more expensive, and codes that do not care about file size before lamination could make do with our existing approach.  If we want to keep both options, we'll need a runtime parameter to pick between them, and we'll want to clearly spell out the semantics in both cases.

This PR fails our test suite because it changes things from using local size to the current true file size as known by the servers.

As a concrete example consider this case:  Rank 0 writes to offsets [0, 10), and rank 1 writes to offsets [10,20).  Both ranks then call fsync() and barrier.  At this point, if rank 0 calls stat() it will get the true file size, which is 20.  However, if rank 0 opens the file and starts reading from offset 0, it will hit an EOF at offset=10.  So stat says the file is 20 bytes long, but read acts like the file is only 10 bytes long.  I'm guessing that will eventually be a problem for someone.  This PR changes the read so that it can use the true file size when determining EOF.

Having said that, there might also be value in keeping the notion of the local size.  Asking for the true file size on a read is somewhat expensive, because it will invoke a global collective across the servers.  For applications that don't require knowing the true file size, they might get by with the notion of our "local size".  To support that, this PR keeps the local size in as a runtime option.  But we might want to also change stat() in that case to return the local size, again to be consistent.

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
