### PR TITLE
examples: add write+sync/read bandwidth output from global timers

### DIFF
--- a/examples/src/testutil_rdwr.h
+++ b/examples/src/testutil_rdwr.h
@@ -239,6 +239,21 @@ int write_laminate(test_cfg* cfg, const char* filepath)
     return rc;
 }
 
+static inline
+int stat_file(test_cfg* cfg, const char* filepath)
+{
+    int rc = 0;
+    if (cfg->rank == 0 || cfg->io_pattern == IO_PATTERN_NN) {
+        struct stat s;
+        int stat_rc = stat(filepath, &s);
+        if (-1 == stat_rc) {
+            test_print(cfg, "ERROR - stat(%s) failed", filepath);
+            rc = -1;
+        }
+    }
+    return rc;
+}
+
 /* -------- Read Helper Methods -------- */
 
 static inline

--- a/t/ci/100-writeread-tests.sh
+++ b/t/ci/100-writeread-tests.sh
@@ -68,7 +68,7 @@ unify_test_writeread() {
     # Evaluate output
     test_expect_success "$app_name $app_args: (line_count=${lcount}, rc=$rc)" '
         test $rc = 0 &&
-        test $lcount = 11
+        test $lcount = 17
     '
 }
 
@@ -86,7 +86,7 @@ unify_test_writeread_posix() {
     # Evaluate output
     test_expect_success POSIX "$app_name $1: (line_count=${lcount}, rc=$rc)" '
         test $rc = 0 &&
-        test $lcount = 11 &&
+        test $lcount = 17 &&
         if [[ $io_pattern =~ (n1)$ ]]; then
             test_path_is_file ${CI_POSIX_MP}/$filename
         else


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This adds a line to print global write+sync bandwidth and another line for read bandwidth.  When writing to a disk, like the SSD, the write bandwidth numbers can be inflated because the OS is caching data in memory.  Including the sync cost ensures data is on disk.

This is work in progress.  Associated test cases will need to be updated.

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
