### PR TITLE
client: do not unlink superblock file on unmount

### DIFF
--- a/common/src/unifyfs_shm.h
+++ b/common/src/unifyfs_shm.h
@@ -19,16 +19,20 @@
 extern "C" {
 #endif
 
-/* allocate and attach a named shared memory region of a particular size
- * and mmap into our memory, returns starting memory address on success,
- * returns NULL on failure */
+/* Allocate and attach a named shared memory region of a particular size
+ * and mmap into our memory.  Returns starting memory address on success.
+ * Returns NULL on failure. */
 void* unifyfs_shm_alloc(const char* name, size_t size);
 
-/* unmaps shared memory region from memory, and releases it,
- * caller should povider the address of a pointer to the region
- * in paddr, sets paddr to NULL on return,
- * returns UNIFYFS_SUCCESS on success */
+/* Unmaps shared memory region from memory.
+ * Caller should povider the address of a pointer to the region
+ * in paddr.  Sets paddr to NULL on return.
+ * Returns UNIFYFS_SUCCESS on success. */
 int unifyfs_shm_free(const char* name, size_t size, void** paddr);
+
+/* Delete file used to attach to shared memory segment.
+ * Returns UNIFYFS_SUCCESS on success. */
+int unifyfs_shm_unlink(const char* name);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/server/src/unifyfs_init.c
+++ b/server/src/unifyfs_init.c
@@ -661,22 +661,31 @@ static int unifyfs_exit(void)
 
         /* free resources allocate for each client */
         for (j = 0; j < MAX_NUM_CLIENTS; j++) {
-            /* release request buffer shared memory region */
+            /* Release request buffer shared memory region.  Client
+             * should have deleted file already, but will not hurt
+             * to do this again. */
             if (app->shm_req_bufs[j] != NULL) {
                 unifyfs_shm_free(app->req_buf_name[j], app->req_buf_sz,
                                  (void**)&(app->shm_req_bufs[j]));
+                unifyfs_shm_unlink(app->req_buf_name[j]);
             }
 
-            /* release receive buffer shared memory region */
+            /* Release receive buffer shared memory region.  Client
+             * should have deleted file already, but will not hurt
+             * to do this again. */
             if (app->shm_recv_bufs[j] != NULL) {
                 unifyfs_shm_free(app->recv_buf_name[j], app->recv_buf_sz,
                                  (void**)&(app->shm_recv_bufs[j]));
+                unifyfs_shm_unlink(app->recv_buf_name[j]);
             }
 
-            /* release super block shared memory region */
+            /* Release super block shared memory region.
+             * Server is responsible for deleting superblock shared
+             * memory file that was created by the client. */
             if (app->shm_superblocks[j] != NULL) {
                 unifyfs_shm_free(app->super_buf_name[j], app->superblock_sz,
                                  (void**)&(app->shm_superblocks[j]));
+                unifyfs_shm_unlink(app->super_buf_name[j]);
             }
 
             /* close spill log file and delete it */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The client was calling shm_unlink during unmount, which deleted the superblock shared memory file so that future clients could not reattach to it.  This has been changed to not shm_unlink that file on the client.  The server now deletes that file during its cleanup logic.

Also, this modifies the client to immediately delete its read request and read reply shared memory files upon returning from the mount_rpc.  The server attaches to those segments during the mount rpc, so it's safe to delete the files at that point.  It also deletes those files in more failures cases for improved cleanup after failure.

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
