### PR TITLE
trailing whitespace check small but nonzero

### DIFF
--- a/scripts/linux_kernel_checkpatch/checkpatch.pl
+++ b/scripts/linux_kernel_checkpatch/checkpatch.pl
@@ -2747,10 +2747,10 @@ sub process {
 			    $fix) {
 				$fixed[$fixlinenr] =~ s/[\s\015]+$//;
 			}
-		} elsif ($rawline =~ /^\+.*\S\s+$/ || $rawline =~ /^\+\s+$/) {
+		} elsif ($rawline =~ /^\+.*\S\s{10,}$/ || $rawline =~ /^\+\s{15,}$/) {
 			my $herevet = "$here\n" . cat_vet($rawline) . "\n";
 			if (ERROR("TRAILING_WHITESPACE",
-				  "trailing whitespace\n" . $herevet) &&
+				  "excessive trailing whitespace\n" . $herevet) &&
 			    $fix) {
 				$fixed[$fixlinenr] =~ s/\s+$//;
 			}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This patch adds "repeat" tags to the regex in the trailing white space 
check.  Up to 10 whitespace characters are allows on the end of a line 
with non-white space characters, and up to 15 white space characters 
are allowed on a line by themselves.  

However, it won't allow huge lines, or multiline white space lines. 
 It still flags those.  

This change will make editing the documentation via the 
github gui much much easier and more efficient and 
eliminate a lot of cleanup to the source files.  

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This is enough to allow people who use emacs to hit "tab" all the 
time (which either adds 4 or 6 characters per line or one tab, 
depending on configuration) to in most cases still have their 
ource code get by the syntax checker without being flagged.  It 
also allows edits from the github GUI editor (which inserts a 
space here and there when manipulating files) to go in without 
having to separately, externally, scrub out the end line spaces.  

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

I tested editing a source file, looked at the "git diff" and also 
the "git diff | scripts/checkpatch.sh".  As I added a few spaces, 
they showed up in the git diff but not in the checkpatch until 
they hit the desired threshold, at which point the complaint 
was "excessive trailing whitespace".  

I tested this by changing a documentation file with the github gui 
editor in the branch for this change.  The source file was 
successfully validated, only because the checkpatch allows 
the couple of trailing spaces that the gui generates.  I then 
removed that test commit from this branch.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] All commit messages are properly formatted.

