### PR TITLE
fix autogen/configure errors

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,7 @@ SUBDIRS = common meta server client examples extras t util
 
 CONFIG = ordered
 
-#ACLOCAL_AMFLAGS = -I m4
+ACLOCAL_AMFLAGS = -I m4
 
 pkgconfigdir = @pkgconfigdir@
 pkgconfig_DATA = client/unifyfs.pc

--- a/configure.ac
+++ b/configure.ac
@@ -140,9 +140,10 @@ AS_IF([test "x$enable_fortran" = "xyes"],[
     AC_LANG_POP
 ],[])
 
-AS_IF([test "$have_C_mpi" != "yes"],[
-    AC_MSG_ERROR(["Couldn't find MPI"])
-],[])
+AS_IF([test "$have_C_mpi" != "yes"],
+    AC_MSG_ERROR(["Couldn't find MPI"]),
+    []
+)
 
 # look for leveldb library, sets LEVELDB_CFLAGS/LDFLAGS/LIBS
 UNIFYFS_AC_LEVELDB
@@ -193,9 +194,6 @@ AC_CHECK_HEADERS(mntent.h sys/mount.h)
 # HDF found?
 AX_LIB_HDF5
 AM_CONDITIONAL([HAVE_HDF5], [test x$with_hdf5 = xyes])
-
-# Look for pthreads
-AX_PTHREAD([],[AC_MSG_ERROR([pthreads are required])])
 
 # libc functions wrapped by unifyfs
 


### PR DESCRIPTION
First two problems were identified by @Mosseridan in issue #410 
1. Removes extra brackets that were surrounding uses of AC_MSG_ERROR in configure.ac. 
2. Silences a libtoolize warning by uncommenting the line in Makefile.am that set ACLOCAL_AMFLAGS.

The third fix removes use of AX_PTHREAD in configure.ac, since the m4 definition is not always available (which leads to a weird configure failure), and we were not really using it as intended anyway. This fix replaces PR #441 

### How Has This Been Tested?

Configured/built on Summitdev and Summit, where AX_PTHREADS is not available.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
