### PR TITLE
add unifyfs_set_log_level()

### DIFF
--- a/client/src/unifyfs.c
+++ b/client/src/unifyfs.c
@@ -1747,7 +1747,7 @@ static int unifyfs_init(int rank)
         if (cfgval != NULL) {
             rc = configurator_int_val(cfgval, &l);
             if (rc == 0) {
-                unifyfs_log_level = (int)l;
+                unifyfs_set_log_level((unifyfs_log_level_t)l);
             }
         }
 

--- a/common/src/unifyfs_log.h
+++ b/common/src/unifyfs_log.h
@@ -45,7 +45,8 @@ typedef enum {
     LOG_ERR   = 2,
     LOG_WARN  = 3,
     LOG_INFO  = 4,
-    LOG_DBG   = 5
+    LOG_DBG   = 5,
+    LOG_LEVEL_MAX
 } unifyfs_log_level_t;
 
 extern unifyfs_log_level_t unifyfs_log_level;
@@ -92,6 +93,9 @@ int unifyfs_log_open(const char* file);
 /* close our debug file stream,
  * returns UNIFYFS_SUCCESS on success */
 int unifyfs_log_close(void);
+
+/* set log level */
+void unifyfs_set_log_level(unifyfs_log_level_t lvl);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/server/src/unifyfs_init.c
+++ b/server/src/unifyfs_init.c
@@ -282,7 +282,7 @@ int main(int argc, char* argv[])
         long l;
         rc = configurator_int_val(server_cfg.log_verbosity, &l);
         if (0 == rc) {
-            unifyfs_log_level = (int)l;
+            unifyfs_set_log_level((unifyfs_log_level_t)l);
         }
     }
 


### PR DESCRIPTION
### Description

Use the `unifyfs_set_log_level()` method, which validates the passed level, rather than directly setting the global variable.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
