### PR TITLE
move unifyfs_generate_gfid() to common

### DIFF
--- a/client/src/Makefile.am
+++ b/client/src/Makefile.am
@@ -39,7 +39,7 @@ CLIENT_COMMON_LIBADD = \
   $(top_builddir)/common/src/libunifyfs_common.la \
   $(MARGO_LIBS) \
   $(FLATCC_LIBS) \
-  -lcrypto -lrt -lpthread
+  -lrt -lpthread
 
 CLIENT_COMMON_SOURCES = \
   margo_client.c \

--- a/client/src/unifyfs-internal.h
+++ b/client/src/unifyfs-internal.h
@@ -574,8 +574,6 @@ int unifyfs_fid_unlink(int fid);
 
 /* functions used in UnifyFS */
 
-int unifyfs_generate_gfid(const char* path);
-
 int unifyfs_set_global_file_meta_from_fid(
     int fid,
     int create);

--- a/client/src/unifyfs.c
+++ b/client/src/unifyfs.c
@@ -46,7 +46,6 @@
 
 #include <time.h>
 #include <mpi.h>
-#include <openssl/md5.h>
 
 #ifdef UNIFYFS_GOTCHA
 #include "gotcha/gotcha_types.h"
@@ -594,22 +593,6 @@ int unifyfs_fid_is_dir(int fid)
         /* if it doesn't exist, then it's not a directory? */
         return 0;
     }
-}
-
-/*
- * hash a path to gfid
- * @param path: file path
- * return: gfid
- */
-int unifyfs_generate_gfid(const char* path)
-{
-    unsigned char digested[16] = { 0, };
-    unsigned long len = strlen(path);
-    int* ival = (int*) digested;
-
-    MD5((const unsigned char*) path, len, digested);
-
-    return abs(ival[0]);
 }
 
 int unifyfs_gfid_from_fid(const int fid)

--- a/common/src/Makefile.am
+++ b/common/src/Makefile.am
@@ -25,6 +25,7 @@ BASE_SRCS = \
   unifyfs_log.h \
   unifyfs_log.c \
   unifyfs_meta.h \
+  unifyfs_meta.c \
   unifyfs_rpc_util.h \
   unifyfs_rpc_util.c \
   unifyfs_client_rpcs.h \
@@ -68,6 +69,6 @@ libunifyfs_common_la_LDFLAGS = \
   -version-info $(LIBUNIFYFS_LT_VERSION)
 
 libunifyfs_common_la_LIBADD = \
-  $(OPT_LIBS) -lm -lrt
+  $(OPT_LIBS) -lm -lrt -lcrypto
 
 AM_CFLAGS = -Wall -Wno-strict-aliasing

--- a/common/src/unifyfs_meta.c
+++ b/common/src/unifyfs_meta.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2020, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2020, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyFS.
+ * For details, see https://github.com/LLNL/UnifyFS.
+ * Please read https://github.com/LLNL/UnifyFS/LICENSE for full license text.
+ */
+
+#include <endian.h>
+#include <string.h>
+#include <openssl/md5.h>
+
+#include "unifyfs_meta.h"
+
+/**
+ * Hash a file path to a 64-bit unsigned integer using MD5
+ * @param path absolute file path
+ * @return hash value
+ */
+uint64_t compute_path_md5(const char* path)
+{
+    unsigned long len;
+    unsigned char digested[16] = {0};
+
+    len = strlen(path);
+    MD5((const unsigned char*) path, len, digested);
+
+    /* construct uint64_t hash from first 8 digest bytes */
+    uint64_t hash = be64toh(*((uint64_t*)digested));
+    return hash;
+}

--- a/meta/src/indexes.c
+++ b/meta/src/indexes.c
@@ -287,8 +287,8 @@ int update_stat(struct mdhim_t *md, struct index_t *index, void *key, uint32_t k
 		*(unsigned long  *)val1 = get_byte_num(key, key_len);
 		*(unsigned long  *)val2 = *(unsigned long *)val1;
 	} else if (index->key_type == MDHIM_UNIFYFS_KEY) {
-			val1 = get_meta_pair(key, key_len);
-			val2 = get_meta_pair(key, key_len);
+		val1 = copy_unifyfs_key(key, key_len);
+		val2 = copy_unifyfs_key(key, key_len);
 	}
 			gettimeofday(&metaend, NULL);
 			metatime+=1000000*(metaend.tv_sec-metastart.tv_sec)+metaend.tv_usec-metastart.tv_usec;

--- a/meta/src/mdhim_private.c
+++ b/meta/src/mdhim_private.c
@@ -357,7 +357,6 @@ struct mdhim_bgetrm_t *_bget_records(struct mdhim_t *md, struct index_t *index,
 		if ((op == MDHIM_GET_EQ || op == MDHIM_GET_PRIMARY_EQ || op == MDHIM_RANGE_BGET) &&
 		    index->type != LOCAL_INDEX &&
 		    (rl = get_range_servers(md, index, keys[i], key_lens[i])) == NULL) {
-			printf("here\n"); fflush(stdout);
 			mlog(MDHIM_CLIENT_CRIT, "MDHIM Rank: %d - "
 			     "Error while determining range server in mdhimBget",
 			     md->mdhim_rank);

--- a/meta/src/partitioner.c
+++ b/meta/src/partitioner.c
@@ -34,11 +34,14 @@
  *
  */
 
+#include <assert.h>
 #include <math.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <sys/time.h>
 #include "partitioner.h"
+
+#include "unifyfs_metadata.h"
 
 struct timeval calslicestart, calsliceend;
 double calslicetime = 0;
@@ -85,13 +88,12 @@ long double get_str_num(void *key, uint32_t key_len) {
   return str_num;
 }
 
-unsigned long * get_meta_pair(void *key, uint32_t key_len) {
-	ulong *meta_pair = (ulong *)malloc (2*sizeof(ulong));
-	memset(meta_pair, 0, 2*sizeof(unsigned long));
-	meta_pair[0] = *((unsigned long *)(((char *)key)));
-	meta_pair[1] = *((unsigned long *)(((char *)key)+sizeof(unsigned long)));
-	//	printf("meta_pair[1] is %ld\n", meta_pair[1]);
-	return meta_pair;
+/* Allocate a copy of a key and return it. The returned key must be freed. */
+void* copy_unifyfs_key(void* key, uint32_t key_len)
+{
+    void* key_copy = malloc((size_t)key_len);
+    memcpy(key_copy, key, (size_t)key_len);
+    return key_copy;
 }
 
 uint64_t get_byte_num(void *key, uint32_t key_len) {
@@ -386,26 +388,19 @@ int get_slice_num(struct mdhim_t *md, struct index_t *index, void *key, int key_
 		key_num = floorl(map_num * total_keys);
 
 		break;
+    case MDHIM_UNIFYFS_KEY:
+        /* Use only the gfid portion of the key, which ensures all extents
+         * for the same file hash to the same server */
+        key_num = (uint64_t) UNIFYFS_KEY_FID(key);
+        break;
 	default:
 		return 0;
-		break;
 	}
 
 
 	/* Convert the key to a slice number  */
 	slice_num = key_num/index->mdhim_max_recs_per_slice;
 
-	if (key_type == MDHIM_UNIFYFS_KEY) {
-		unsigned long *meta_pair = get_meta_pair(key, key_len);
-		unsigned long surplus =	meta_pair[1];
-		unsigned long highval = (meta_pair[0] << 1);
-		unsigned long multiply = (unsigned long)1 << (sizeof(unsigned long)*8 - 1);
-/*		slice_num = (surplus + highval * multiply%index->mdhim_max_recs_per_slice) % \
-				index->mdhim_max_recs_per_slice;
-*/
-		slice_num = highval * (multiply/index->mdhim_max_recs_per_slice) + surplus/index->mdhim_max_recs_per_slice;
-		free(meta_pair);
-	}
 	//Return the slice number
 	return slice_num;
 }

--- a/meta/src/partitioner.h
+++ b/meta/src/partitioner.h
@@ -102,11 +102,13 @@ long double get_str_num(void *key, uint32_t key_len);
 uint64_t get_byte_num(void *key, uint32_t key_len);
 int get_slice_num(struct mdhim_t *md, struct index_t *index, void *key, int key_len);
 int is_float_key(int type);
-unsigned long * get_meta_pair(void *key, uint32_t key_len);
+
 rangesrv_list *get_range_servers_from_stats(struct mdhim_t *md, struct index_t *index, 
 					    void *key, int key_len, int op);
 rangesrv_list *get_range_servers_from_range(struct mdhim_t *md, struct index_t *index, 
 					    void *start_key, void *end_key, int key_len);
+
+void* copy_unifyfs_key(void* key, uint32_t key_len);
 
 #ifdef __cplusplus
 }

--- a/server/src/unifyfs_cmd_handler.c
+++ b/server/src/unifyfs_cmd_handler.c
@@ -201,6 +201,8 @@ static void unifyfs_mount_rpc(hg_handle_t handle)
     /* fill in and insert a new entry for this app_id
      * if we don't already have one */
     if (tmp_config == NULL) {
+        LOGDBG("creating app_config for app_id=%d", app_id);
+
         /* don't have an app_config for this app_id,
          * so allocate and fill one in */
         tmp_config = (app_config_t*)malloc(sizeof(app_config_t));

--- a/server/src/unifyfs_metadata.c
+++ b/server/src/unifyfs_metadata.c
@@ -255,7 +255,6 @@ int unifyfs_set_file_attribute(
         NULL, NULL);
 
     if (!brm || brm->error) {
-        LOGERR("Error inserting file attribute into MDHIM");
         rc = (int)UNIFYFS_ERROR_MDHIM;
     }
 
@@ -263,6 +262,9 @@ int unifyfs_set_file_attribute(
         mdhim_full_release_msg(brm);
     }
 
+    if (rc != UNIFYFS_SUCCESS) {
+        LOGERR("failed to insert attributes for gfid=%d", gfid);
+    }
     return rc;
 }
 
@@ -286,7 +288,6 @@ int unifyfs_set_file_attributes(int num_entries,
 
     /* check for errors and free resources */
     if (!brm) {
-        LOGERR("Error inserting file attributes into MDHIM");
         rc = (int)UNIFYFS_ERROR_MDHIM;
     } else {
         /* step through linked list of messages,
@@ -294,8 +295,8 @@ int unifyfs_set_file_attributes(int num_entries,
         struct mdhim_brm_t* brmp = brm;
         while (brmp) {
             /* check current item for error */
-            if (brmp->error < 0) {
-                LOGERR("Error inserting file attributes into MDHIM");
+            if (brmp->error) {
+                LOGERR("MDHIM bulk put error=%d", brmp->error);
                 rc = (int)UNIFYFS_ERROR_MDHIM;
             }
 
@@ -308,6 +309,9 @@ int unifyfs_set_file_attributes(int num_entries,
         }
     }
 
+    if (rc != UNIFYFS_SUCCESS) {
+        LOGERR("failed to bulk insert file attributes");
+    }
     return rc;
 }
 
@@ -338,6 +342,9 @@ int unifyfs_get_file_attribute(
         mdhim_full_release_msg(bgrm);
     }
 
+    if (rc != UNIFYFS_SUCCESS) {
+        LOGERR("failed to retrieve attributes for gfid=%d", gfid);
+    }
     return rc;
 }
 
@@ -355,7 +362,6 @@ int unifyfs_delete_file_attribute(
 
     /* check for errors and free resources */
     if (!brm) {
-        LOGERR("Error deleting file attributes from MDHIM");
         rc = (int)UNIFYFS_ERROR_MDHIM;
     } else {
         /* step through linked list of messages,
@@ -363,8 +369,8 @@ int unifyfs_delete_file_attribute(
         struct mdhim_brm_t* brmp = brm;
         while (brmp) {
             /* check current item for error */
-            if (brmp->error < 0) {
-                LOGERR("Error deleting file attributes from MDHIM");
+            if (brmp->error) {
+                LOGERR("MDHIM delete error=%d", brmp->error);
                 rc = (int)UNIFYFS_ERROR_MDHIM;
             }
 
@@ -377,6 +383,9 @@ int unifyfs_delete_file_attribute(
         }
     }
 
+    if (rc != UNIFYFS_SUCCESS) {
+        LOGERR("failed to delete attributes for gfid=%d", gfid);
+    }
     return rc;
 }
 
@@ -411,9 +420,9 @@ int unifyfs_get_file_extents(int num_keys, unifyfs_key_t** keys,
     struct mdhim_bgetrm_t* ptr = bkvlist;
     while (ptr) {
         /* check that we don't have an error condition */
-        if (ptr->error < 0) {
+        if (ptr->error) {
             /* hit an error */
-            LOGERR("MDHIM Range Query error");
+            LOGERR("MDHIM range query error=%d", ptr->error);
             return (int)UNIFYFS_ERROR_MDHIM;
         }
 
@@ -429,7 +438,7 @@ int unifyfs_get_file_extents(int num_keys, unifyfs_key_t** keys,
         tot_num, sizeof(unifyfs_keyval_t));
     if (NULL == kvs) {
         LOGERR("failed to allocate keyvals");
-        return (int)UNIFYFS_ERROR_MDHIM;
+        return ENOMEM;
     }
 
     /* iterate over list and copy each key/value into output array */
@@ -486,7 +495,6 @@ int unifyfs_set_file_extents(int num_entries,
 
     /* check for errors and free resources */
     if (!brm) {
-        LOGERR("Error inserting file extents into MDHIM");
         rc = (int)UNIFYFS_ERROR_MDHIM;
     } else {
         /* step through linked list of messages,
@@ -494,8 +502,8 @@ int unifyfs_set_file_extents(int num_entries,
         struct mdhim_brm_t* brmp = brm;
         while (brmp) {
             /* check current item for error */
-            if (brmp->error < 0) {
-                LOGERR("Error inserting file extents into MDHIM");
+            if (brmp->error) {
+                LOGERR("MDHIM bulk put error=%d", brmp->error);
                 rc = (int)UNIFYFS_ERROR_MDHIM;
             }
 
@@ -508,6 +516,9 @@ int unifyfs_set_file_extents(int num_entries,
         }
     }
 
+    if (rc != UNIFYFS_SUCCESS) {
+        LOGERR("failed to bulk insert file extents");
+    }
     return rc;
 }
 
@@ -529,7 +540,6 @@ int unifyfs_delete_file_extents(
 
     /* check for errors and free resources */
     if (!brm) {
-        LOGERR("Error deleting file extents from MDHIM");
         rc = (int)UNIFYFS_ERROR_MDHIM;
     } else {
         /* step through linked list of messages,
@@ -537,8 +547,8 @@ int unifyfs_delete_file_extents(
         struct mdhim_brm_t* brmp = brm;
         while (brmp) {
             /* check current item for error */
-            if (brmp->error < 0) {
-                LOGERR("Error deleting file extents from MDHIM");
+            if (brmp->error) {
+                LOGERR("MDHIM bulk delete error=%d", brmp->error);
                 rc = (int)UNIFYFS_ERROR_MDHIM;
             }
 
@@ -551,5 +561,8 @@ int unifyfs_delete_file_extents(
         }
     }
 
+    if (rc != UNIFYFS_SUCCESS) {
+        LOGERR("failed to bulk delete file extents");
+    }
     return rc;
 }

--- a/server/src/unifyfs_request_manager.c
+++ b/server/src/unifyfs_request_manager.c
@@ -580,6 +580,7 @@ int rm_cmd_filesize(
                                       &num_vals, &keyvals);
     if (UNIFYFS_SUCCESS != rc) {
         /* failed to look up extents, bail with error */
+        LOGERR("failed to retrieve extent metadata for gfid=%d", gfid);
         return UNIFYFS_FAILURE;
     }
 
@@ -620,6 +621,7 @@ int rm_cmd_filesize(
         filesize_meta = fattr.size;
     } else {
         /* failed to find file attributes for this file */
+        LOGERR("failed to retrieve attributes for gfid=%d", gfid);
         return UNIFYFS_FAILURE;
     }
 
@@ -1024,6 +1026,7 @@ int rm_cmd_laminate(
     mode_t mode = (mode_t) attr.mode;
     if ((mode & S_IFMT) != S_IFREG) {
         /* item is not a regular file */
+        LOGERR("ERROR: only regular files can be laminated (gfid=%d)", gfid);
         return EINVAL;
     }
 
@@ -1032,6 +1035,7 @@ int rm_cmd_laminate(
     ret = rm_cmd_filesize(app_id, client_id, gfid, &filesize);
     if (ret != UNIFYFS_SUCCESS) {
         /* failed to get file size for file */
+        LOGERR("lamination file size calculation failed (gfid=%d)", gfid);
         return ret;
     }
 
@@ -1041,6 +1045,9 @@ int rm_cmd_laminate(
 
     /* update metadata, set size and laminate */
     rc = unifyfs_set_file_attribute(1, 1, &attr);
+    if (rc != UNIFYFS_SUCCESS) {
+        LOGERR("lamination metadata update failed (gfid=%d)", gfid);
+    }
 
     return rc;
 }

--- a/util/unifyfs/src/unifyfs-rm.c
+++ b/util/unifyfs/src/unifyfs-rm.c
@@ -474,7 +474,7 @@ static int jsrun_launch(unifyfs_resource_t* resource,
     char n_nodes[16];
 
     // full command: jsrun <jsrun args> <server args>
-    jsrun_argc = 9;
+    jsrun_argc = 13;
     snprintf(n_nodes, sizeof(n_nodes), "%zu", resource->n_nodes);
 
     server_argc = construct_server_argv(args, NULL);
@@ -486,11 +486,15 @@ static int jsrun_launch(unifyfs_resource_t* resource,
     argv[1] = strdup("--immediate");
     argv[2] = strdup("-e");
     argv[3] = strdup("individual");
-    argv[4] = strdup("--nrs");
-    argv[5] = strdup(n_nodes);
-    argv[6] = strdup("-r1");
-    argv[7] = strdup("-c1");
-    argv[8] = strdup("-a1");
+    argv[4] = strdup("--stdio_stderr");
+    argv[5] = strdup("unifyfsd.err.%h.%p");
+    argv[6] = strdup("--stdio_stdout");
+    argv[7] = strdup("unifyfsd.out.%h.%p");
+    argv[8] = strdup("--nrs");
+    argv[9] = strdup(n_nodes);
+    argv[10] = strdup("-r1");
+    argv[11] = strdup("-c1");
+    argv[12] = strdup("-a1");
     construct_server_argv(args, argv + jsrun_argc);
 
     execvp(argv[0], argv);


### PR DESCRIPTION
### Description
Includes five important changes:
1. Fixes a bug in the hash computation, where abs() was being called on the hash value to enforce a positive integer. This had the potential to result in conflicts between the positive and
negative values of any number (i.e., x and -x). Now, we treat the hash value as unsigned, and just cast to signed, which doesn't change its value.
2. Uses a uint64_t for the hash value, and converts the most significant 32 bits into an integer for use as gfid.
3. Implements a method of hash value construction that will result in the same values on machines with different endianness.
4. Fixes a bug in MDHIM where all extent metadata was being sent to server rank 0.
5. For IBM LSF-CSM systems, have the `unifyfs` command-line tool capture server stdout/err into files. This is helpful since all MDHIM errors get printed to stderr.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
