### PR TITLE
Move mpi.h include to fix --enable-mpi-mount bug

### DIFF
--- a/client/src/pmpi_wrappers.c
+++ b/client/src/pmpi_wrappers.c
@@ -14,7 +14,6 @@
 
 #include "pmpi_wrappers.h"
 #include "unifyfs.h"
-#include <mpi.h>
 #include <stdio.h>
 
 int unifyfs_mpi_init(int* argc, char*** argv)

--- a/client/src/pmpi_wrappers.h
+++ b/client/src/pmpi_wrappers.h
@@ -15,6 +15,8 @@
 #ifndef UNIFYFS_PMPI_WRAPPERS_H
 #define UNIFYFS_PMPI_WRAPPERS_H
 
+#include <mpi.h>
+
 /* MPI_Init PMPI wrapper */
 int unifyfs_mpi_init(int* argc, char*** argv);
 int MPI_Init(int* argc, char*** argv);


### PR DESCRIPTION
### Description
This moves the include for mpi.h from pmpi_wrappers.c to pmpi_wrappers.h.

Fixes: #467

### Motivation and Context
To fix the issues reported in #467

### How Has This Been Tested?
Build would fail when using the `--enable-mpi-mount` configure option. After this change, the build starting passing.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
