### PR TITLE
Add unit tests for lseek and fseek and fix related bugs

### DIFF
--- a/client/src/Makefile.am
+++ b/client/src/Makefile.am
@@ -20,7 +20,8 @@ endif
 
 CLIENT_COMMON_CPPFLAGS = \
   -I$(top_builddir)/client \
-  -I$(top_srcdir)/common/src
+  -I$(top_srcdir)/common/src \
+  -D_GNU_SOURCE
 
 CLIENT_COMMON_CFLAGS = \
   $(MPI_CFLAGS) \

--- a/client/src/unifyfs-sysio.c
+++ b/client/src/unifyfs-sysio.c
@@ -885,7 +885,7 @@ off_t UNIFYFS_WRAP(lseek)(int fd, off_t offset, int whence)
         unifyfs_fd_t* filedesc = unifyfs_get_filedesc_from_fd(fd);
 
         /* get current file position */
-        off_t current_pos = filedesc->pos;
+        off_t logical_eof, current_pos = filedesc->pos;
 
         /* TODO: support SEEK_DATA and SEEK_HOLE? */
 
@@ -893,15 +893,28 @@ off_t UNIFYFS_WRAP(lseek)(int fd, off_t offset, int whence)
         switch (whence) {
         case SEEK_SET:
             /* seek to offset */
+            if (offset < 0) {
+                errno = EINVAL;
+                return (off_t)(-1);
+            }
             current_pos = offset;
             break;
         case SEEK_CUR:
             /* seek to current position + offset */
+            if (current_pos + offset < 0) {
+                errno = EINVAL;
+                return (off_t)(-1);
+            }
             current_pos += offset;
             break;
         case SEEK_END:
             /* seek to EOF + offset */
-            current_pos = unifyfs_fid_logical_size(fid);
+            logical_eof = unifyfs_fid_logical_size(fid);
+            if (logical_eof + offset < 0) {
+                errno = EINVAL;
+                return (off_t)(-1);
+            }
+            current_pos = logical_eof + offset;
             break;
         default:
             errno = EINVAL;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -134,6 +134,7 @@ sys_sysio_static_t_LDFLAGS = $(test_static_ldflags)
 std_stdio_gotcha_t_SOURCES = std/stdio_suite.h \
                              std/stdio_suite.c \
                              std/fopen-fclose.c \
+                             std/fseek-ftell.c \
                              std/fwrite-fread.c \
                              std/fflush.c \
                              std/size.c
@@ -145,6 +146,7 @@ std_stdio_gotcha_t_LDFLAGS = $(AM_LDFLAGS)
 std_stdio_static_t_SOURCES = std/stdio_suite.h \
                              std/stdio_suite.c \
                              std/fopen-fclose.c \
+                             std/fseek-ftell.c \
                              std/fwrite-fread.c \
                              std/fflush.c \
                              std/size.c

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -104,6 +104,7 @@ sys_sysio_gotcha_t_SOURCES = sys/sysio_suite.h \
                              sys/mkdir-rmdir.c \
                              sys/open.c \
                              sys/open64.c \
+                             sys/lseek.c \
                              sys/write-read.c \
                              sys/write-read-hole.c \
                              sys/truncate.c \
@@ -120,6 +121,7 @@ sys_sysio_static_t_SOURCES = sys/sysio_suite.h \
                              sys/mkdir-rmdir.c \
                              sys/open.c \
                              sys/open64.c \
+                             sys/lseek.c \
                              sys/write-read.c \
                              sys/write-read-hole.c \
                              sys/truncate.c \

--- a/t/std/fseek-ftell.c
+++ b/t/std/fseek-ftell.c
@@ -1,0 +1,251 @@
+/*
+ * Copyright (c) 2018, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2018, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyFS.
+ * For details, see https://github.com/LLNL/UnifyFS.
+ * Please read https://github.com/LLNL/UnifyFS/LICENSE for full license text.
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "t/lib/tap.h"
+#include "t/lib/testutil.h"
+
+/* This function contains the tests for UNIFYFS_WRAP(fseek),
+ * UNIFYFS_WRAP(ftell), and UNIFYFS_WRAP(rewind) found in
+ * client/src/unifyfs-stdio.c.
+ *
+ * Notice the tests are ordered in a logical testing order. Changing the order
+ * or adding new tests in between two others could negatively affect the
+ * desired results. */
+int fseek_ftell_test(char* unifyfs_root)
+{
+    /* Diagnostic message for reading and debugging output */
+    diag("Starting UNIFYFS_WRAP(fseek/ftell/rewind) tests");
+
+    char path[64];
+    FILE* fd;
+    int ret;
+    long pos;
+
+    /* Create a random file at the mountpoint path to test on */
+    testutil_rand_path(path, sizeof(path), unifyfs_root);
+
+    /* Open a file and write to it to test fseek() */
+    fd = fopen(path, "w");
+    fwrite("hello world", 12, 1, fd);
+
+    /* fseek with invalid whence fails with errno=EINVAL. */
+    errno = 0;
+    ret = fseek(fd, 0, -1);
+    ok(ret == -1 && errno == EINVAL,
+       "%s: fseek with invalid whence should fail (ret=%d, errno=%d): %s",
+       __FILE__, ret, errno, strerror(errno));
+
+    /* fseek() with SEEK_SET tests */
+    /* fseek to negative offset with SEEK_SET should fail with errno=EINVAL */
+    errno = 0;
+    ret = fseek(fd, -1, SEEK_SET);
+    ok(ret == -1 && errno == EINVAL,
+       "%s: fseek to negative offset w/ SEEK_SET fails (ret=%d, errno=%d): %s",
+       __FILE__, ret, errno, strerror(errno));
+
+    /* ftell after invalid fseek should return last offset */
+    errno = 0;
+    pos = ftell(fd);
+    ok(pos == 12,
+       "%s: ftell after fseek to negative offset w/ SEEK_SET (pos=%ld): %s",
+       __FILE__, pos, strerror(errno));
+
+    /* fseek to valid offset with SEEK_SET succeeds */
+    errno = 0;
+    ret = fseek(fd, 7, SEEK_SET);
+    ok(ret == 0, "%s: fseek to valid offset w/ SEEK_SET (ret=%d): %s",
+       __FILE__, ret, strerror(errno));
+
+    /* ftell after valid fseek with SEEK_SET */
+    errno = 0;
+    pos = ftell(fd);
+    ok(pos == 7, "%s: ftell after valid fseek w/ SEEK_SET (pos=%ld): %s",
+       __FILE__, pos, strerror(errno));
+
+    /* fseek beyond end of file with SEEK_SET succeeds */
+    errno = 0;
+    ret = fseek(fd, 25, SEEK_SET);
+    ok(ret == 0, "%s: fseek beyond end of file w/ SEEK_SET (ret=%d): %s",
+       __FILE__, ret, strerror(errno));
+
+    /* ftell after fseek beyond end of file with SEEK_SET */
+    errno = 0;
+    pos = ftell(fd);
+    ok(pos == 25,
+       "%s: ftell after fseek beyond end of file w/ SEEK_SET (pos=%ld): %s",
+       __FILE__, pos, strerror(errno));
+
+    /* fseek to beginning of file with SEEK_SET succeeds */
+    errno = 0;
+    ret = fseek(fd, 0, SEEK_SET);
+    ok(ret == 0, "%s: fseek to beginning of file w/ SEEK_SET (ret=%d): %s",
+       __FILE__, ret, strerror(errno));
+
+    /* ftell after fseek to beginning of file with SEEK_SET */
+    errno = 0;
+    pos = ftell(fd);
+    ok(pos == 0,
+       "%s: ftell after fseek to beginning of file w/ SEEK_SET (pos=%ld): %s",
+       __FILE__, pos, strerror(errno));
+
+    /* fseek() with SEEK_CUR tests */
+    /* fseek to end of file with SEEK_CUR succeeds */
+    errno = 0;
+    ret = fseek(fd, 12, SEEK_CUR);
+    ok(ret == 0, "%s: fseek to end of file w/ SEEK_CUR (ret=%d): %s",
+       __FILE__, ret, strerror(errno));
+
+    /* ftell after fseek to end of file with SEEK_CUR */
+    errno = 0;
+    pos = ftell(fd);
+    ok(pos == 12,
+       "%s: ftell after fseek to beginning of file w/ SEEK_CUR (pos=%ld): %s",
+       __FILE__, pos, strerror(errno));
+
+    /* fseek to negative offset with SEEK_CUR should fail with errno=EINVAL */
+    errno = 0;
+    ret = fseek(fd, -15, SEEK_CUR);
+    ok(ret == -1 && errno == EINVAL,
+       "%s: fseek to negative offset w/ SEEK_CUR fails (ret=%d, errno=%d): %s",
+       __FILE__, ret, errno, strerror(errno));
+
+    /* ftell after fseek to negative offset with SEEK_CUR */
+    errno = 0;
+    pos = ftell(fd);
+    ok(pos == 12,
+       "%s: ftell after fseek to negative offset w/ SEEK_CUR (pos=%ld): %s",
+       __FILE__, pos, strerror(errno));
+
+    /* fseek to beginning of file with SEEK_CUR succeeds */
+    errno = 0;
+    ret = fseek(fd, -12, SEEK_CUR);
+    ok(ret == 0, "%s: fseek to beginning of file w/ SEEK_CUR (ret=%d): %s",
+       __FILE__, ret, strerror(errno));
+
+    /* ftell after fseek to beginning of file with SEEK_CUR */
+    errno = 0;
+    pos = ftell(fd);
+    ok(pos == 0,
+       "%s: ftell after fseek to beginnig of file w/ SEEK_CUR (pos=%ld): %s",
+       __FILE__, pos, strerror(errno));
+
+    /* fseek beyond end of file with SEEK_CUR succeeds */
+    errno = 0;
+    ret = fseek(fd, 25, SEEK_CUR);
+    ok(ret == 0, "%s: fseek beyond end of file w/ SEEK_CUR (ret=%d): %s",
+       __FILE__, ret, strerror(errno));
+
+    /* ftell after fseek beyond end of file with SEEK_CUR */
+    errno = 0;
+    pos = ftell(fd);
+    ok(pos == 25,
+       "%s: ftell after fseek beyond end of file w/ SEEK_CUR (pos=%ld): %s",
+       __FILE__, pos, strerror(errno));
+
+    /* rewind test */
+    /* ftell after rewind reports beginning of file */
+    rewind(fd);
+    errno = 0;
+    pos = ftell(fd);
+    ok(pos == 0,
+       "%s: ftell after rewind reports beginning of file (pos=%ld): %s",
+       __FILE__, pos, strerror(errno));
+
+    /* fseek() with SEEK_END tests */
+    /* fseek to negative offset with SEEK_END should fail with errno=EINVAL */
+    errno = 0;
+    ret = fseek(fd, -15, SEEK_END);
+    ok(ret == -1 && errno == EINVAL,
+       "%s: fseek to negative offset w/ SEEK_END fails (ret=%d, errno=%d): %s",
+       __FILE__, ret, errno, strerror(errno));
+
+    /* ftell after fseek to negative offset with SEEK_END */
+    errno = 0;
+    pos = ftell(fd);
+    ok(pos == 0,
+       "%s: ftell after fseek to negative offset w/ SEEK_END (pos=%ld): %s",
+       __FILE__, pos, strerror(errno));
+
+    /* fseek back one from end of file with SEEK_END succeeds */
+    errno = 0;
+    ret = fseek(fd, -1, SEEK_END);
+    ok(ret == 0,
+       "%s: fseek back one from end of file w/ SEEK_END (ret=%d): %s",
+       __FILE__, ret, strerror(errno));
+
+    /* ftell after fseek back one from end of file with SEEK_END */
+    errno = 0;
+    pos = ftell(fd);
+    ok(pos == 11,
+       "%s: ftell after fseek back one from end w/ SEEK_END (pos=%ld): %s",
+       __FILE__, pos, strerror(errno));
+
+    /* fseek to beginning of file with SEEK_END succeeds */
+    errno = 0;
+    ret = fseek(fd, -12, SEEK_END);
+    ok(ret == 0, "%s: fseek to beginning of file w/ SEEK_END (ret=%d): %s",
+       __FILE__, ret, strerror(errno));
+
+    /* ftell after fseek to beginning of file with SEEK_END */
+    errno = 0;
+    pos = ftell(fd);
+    ok(pos == 0,
+       "%s: ftell after fseek to beginning of file w/ SEEK_END (pos=%ld): %s",
+       __FILE__, pos, strerror(errno));
+
+    /* fseek beyond end of file with SEEK_END succeeds */
+    errno = 0;
+    ret = fseek(fd, 25, SEEK_END);
+    ok(ret == 0, "%s: fseek beyond end of file w/ SEEK_END (ret=%d): %s",
+       __FILE__, ret, strerror(errno));
+
+    /* ftell after fseek beyond end of file with SEEK_END */
+    errno = 0;
+    pos = ftell(fd);
+    ok(pos == 37,
+       "%s: ftell after fseek beyond end of file w/ SEEK_END (pos=%ld): %s",
+       __FILE__, pos, strerror(errno));
+
+    fclose(fd);
+
+    /* fseek in non-open file descriptor should fail with errno=EBADF */
+    errno = 0;
+    ret = fseek(fd, 0, SEEK_SET);
+    ok(ret == -1 && errno == EBADF,
+       "%s: fseek in non-open file descriptor fails (ret=%d, errno=%d): %s",
+       __FILE__, ret, errno, strerror(errno));
+
+    /* ftell on non-open file descriptor should fail with errno=EBADF */
+    errno = 0;
+    pos = ftell(fd);
+    ok(pos == -1 && errno == EBADF,
+       "%s: ftell on non-open file descriptor fails (pos=%ld, errno=%d): %s",
+       __FILE__, pos, errno, strerror(errno));
+
+    /* rewind on non-open file descriptor should fail with errno=EBADF */
+    errno = 0;
+    rewind(fd);
+    ok(errno == EBADF,
+       "%s: rewind on non-open file descriptor fails (errno=%d): %s",
+       __FILE__, errno, strerror(errno));
+
+    diag("Finished UNIFYFS_WRAP(fseek/ftell/rewind) tests");
+
+    return 0;
+}

--- a/t/std/stdio_suite.c
+++ b/t/std/stdio_suite.c
@@ -70,8 +70,13 @@ int main(int argc, char* argv[])
      * failures to start passing. */
 
     fopen_fclose_test(unifyfs_root);
+
+    fseek_ftell_test(unifyfs_root);
+
     fwrite_fread_test(unifyfs_root);
+
     fflush_test(unifyfs_root);
+
     size_test(unifyfs_root);
 
     MPI_Finalize();

--- a/t/std/stdio_suite.h
+++ b/t/std/stdio_suite.h
@@ -32,8 +32,17 @@
 
 /* Tests for UNIFYFS_WRAP(fopen) and UNIFYFS_WRAP(fclose) */
 int fopen_fclose_test(char* unifyfs_root);
+
+/* Tests for UNIFYFS_WRAP(fseek/ftell/rewind) */
+int fseek_ftell_test(char* unifyfs_root);
+
+/* Tests for UNIFYFS_WRAP(fwrite) and UNIFYFS_WRAP(fread) */
 int fwrite_fread_test(char* unifyfs_root);
+
+/* Tests for UNIFYFS_WRAP(fflush) */
 int fflush_test(char* unifyfs_root);
+
+/* Tests for UNIFYFS_WRAP(size) */
 int size_test(char* unifyfs_root);
 
 #endif /* STDIO_SUITE_H */

--- a/t/sys/lseek.c
+++ b/t/sys/lseek.c
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2018, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2018, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyFS.
+ * For details, see https://github.com/LLNL/UnifyFS.
+ * Please read https://github.com/LLNL/UnifyFS/LICENSE for full license text.
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <linux/limits.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "t/lib/tap.h"
+#include "t/lib/testutil.h"
+
+/* This function contains the tests for UNIFYFS_WRAP(lseek) found in
+ * client/src/unifyfs-sysio.c.
+ *
+ * Notice the tests are ordered in a logical testing order. Changing the order
+ * or adding new tests in between two others could negatively affect the
+ * desired results. */
+int lseek_test(char* unifyfs_root)
+{
+    /* Diagnostic message for reading and debugging output */
+    diag("Starting UNIFYFS_WRAP(lseek) tests");
+
+    char path[64];
+    int file_mode = 0600;
+    int fd, rc;
+    off_t ret;
+
+    /* Create a random file and dir name at the mountpoint path to test on */
+    testutil_rand_path(path, sizeof(path), unifyfs_root);
+
+    /* Open a file and write to it to test lseek() */
+    fd = open(path, O_RDWR | O_CREAT | O_TRUNC, file_mode);
+    rc = write(fd, "hello world", 12);
+
+    /* lseek with invalid whence fails with errno=EINVAL. */
+    errno = 0;
+    ret = lseek(fd, 0, -1);
+    ok(ret == -1 && errno == EINVAL,
+       "%s: lseek with invalid whence should fail (ret=%d, errno=%d): %s",
+       __FILE__, ret, errno, strerror(errno));
+
+    /* lseek() with SEEK_SET tests */
+    /* lseek to negative offset with SEEK_SET should fail with errno=EINVAL */
+    errno = 0;
+    ret = lseek(fd, -1, SEEK_SET);
+    ok(ret == -1 && errno == EINVAL,
+       "%s: lseek to negative offset w/ SEEK_SET fails (ret=%d, errno=%d): %s",
+       __FILE__, ret, errno, strerror(errno));
+
+    /* lseek beyond end of file with SEEK_SET succeeds */
+    errno = 0;
+    ret = lseek(fd, 25, SEEK_SET);
+    ok(ret == 25, "%s: lseek beyond end of file w/ SEEK_SET (ret=%d): %s",
+       __FILE__, ret, strerror(errno));
+
+    /* lseek to beginning of file with SEEK_SET succeeds */
+    errno = 0;
+    ret = lseek(fd, 0, SEEK_SET);
+    ok(ret == 0, "%s: lseek to beginning of file w/ SEEK_SET (ret=%d): %s",
+       __FILE__, ret, strerror(errno));
+
+    /* lseek() with SEEK_CUR tests */
+    /* lseek to end of file with SEEK_CUR succeeds */
+    errno = 0;
+    ret = lseek(fd, 12, SEEK_CUR);
+    ok(ret == 12, "%s: lseek to end of file w/ SEEK_CUR (ret=%d): %s",
+       __FILE__, ret, strerror(errno));
+
+    /* lseek to negative offset with SEEK_CUR should fail with errno=EINVAL */
+    errno = 0;
+    ret = lseek(fd, -15, SEEK_CUR);
+    ok(ret == -1 && errno == EINVAL,
+       "%s: lseek to negative offset w/ SEEK_CUR fails (ret=%d, errno=%d): %s",
+       __FILE__, ret, errno, strerror(errno));
+
+    /* lseek to beginning of file with SEEK_CUR succeeds */
+    errno = 0;
+    ret = lseek(fd, -12, SEEK_CUR);
+    ok(ret == 0, "%s: lseek to beginning of file w/ SEEK_CUR (ret=%d): %s",
+       __FILE__, ret, strerror(errno));
+
+    /* lseek beyond end of file with SEEK_CUR succeeds */
+    errno = 0;
+    ret = lseek(fd, 25, SEEK_CUR);
+    ok(ret == 25, "%s: lseek beyond end of file w/ SEEK_CUR (ret=%d): %s",
+       __FILE__, ret, strerror(errno));
+
+    /* lseek() with SEEK_END tests */
+    /* lseek to negative offset with SEEK_END should fail with errno=EINVAL */
+    errno = 0;
+    ret = lseek(fd, -15, SEEK_END);
+    ok(ret == -1 && errno == EINVAL,
+       "%s: lseek to negative offset w/ SEEK_END fails (ret=%d, errno=%d): %s",
+       __FILE__, ret, errno, strerror(errno));
+
+    /* lseek back one from end of file with SEEK_END succeeds */
+    errno = 0;
+    ret = lseek(fd, -1, SEEK_END);
+    ok(ret == 11,
+       "%s: lseek back one from end of file w/ SEEK_END (ret=%d): %s",
+       __FILE__, ret, strerror(errno));
+
+    /* lseek to beginning of file with SEEK_END succeeds */
+    errno = 0;
+    ret = lseek(fd, -12, SEEK_END);
+    ok(ret == 0, "%s: lseek to beginning of file w/ SEEK_END (ret=%d): %s",
+       __FILE__, ret, strerror(errno));
+
+    /* lseek beyond end of file with SEEK_END succeeds */
+    errno = 0;
+    ret = lseek(fd, 25, SEEK_END);
+    ok(ret == 37, "%s: lseek beyond end of file w/ SEEK_END (ret=%d): %s",
+       __FILE__, ret, strerror(errno));
+
+    /* lseek() with SEEK_DATA tests */
+    /* Write beyond end of file to create a hole */
+    rc = write(fd, "hello universe", 15);
+
+    todo("SEEK_DATA and SEEK_HOLE not yet implemented");
+    /* lseek to negative offset with SEEK_DATA should fail with errno=ENXIO */
+    errno = 0;
+    ret = lseek(fd, -1, SEEK_DATA);
+    ok(ret == -1 && errno == ENXIO,
+       "%s: lseek to negative offset w/ SEEK_DATA fails (ret=%d, errno=%d): %s",
+       __FILE__, ret, errno, strerror(errno));
+
+    /* lseek to beginning of file with SEEK_DATA succeeds */
+    errno = 0;
+    ret = lseek(fd, 0, SEEK_DATA);
+    ok(ret == 0, "%s: lseek to beginning of file w/ SEEK_DATA (ret=%d): %s",
+       __FILE__, ret, strerror(errno));
+
+    /* lseek to data after hole with SEEK_DATA returs current offset or offset
+     * of first set of data */
+    errno = 0;
+    ret = lseek(fd, 15, SEEK_DATA);
+    ok(ret == 15 || ret == 37,
+       "%s: lseek to data after hole w/ SEEK_DATA (ret=%d): %s",
+       __FILE__, ret, strerror(errno));
+
+    /* lseek beyond end of file with SEEK_DATA should fail with errno=ENXIO */
+    errno = 0;
+    ret = lseek(fd, -1, SEEK_DATA);
+    ok(ret == -1 && errno == ENXIO,
+       "%s: lseek beyond end of file w/ SEEK_DATA fails (ret=%d, errno=%d): %s",
+       __FILE__, ret, errno, strerror(errno));
+
+    /* lseek() with SEEK_HOLE tests */
+
+    /* lseek to negative offset with SEEK_HOLE should fail with errno=ENXIO */
+    errno = 0;
+    ret = lseek(fd, -1, SEEK_HOLE);
+    ok(ret == -1 && errno == ENXIO,
+       "%s: lseek to negative offset w/ SEEK_HOLE fails (ret=%d, errno=%d): %s",
+       __FILE__, ret, errno, strerror(errno));
+
+    /* lseek to first hole of file with SEEK_HOLE succeeds returns start of hole
+     * or EOF */
+    errno = 0;
+    ret = lseek(fd, 0, SEEK_HOLE);
+    ok(ret == 12 || ret == 52,
+       "%s: lseek to first hole in file w/ SEEK_HOLE (ret=%d): %s",
+       __FILE__, ret, strerror(errno));
+
+    /* lseek to middle of hole with SEEK_HOLE returns position in hole or EOF */
+    errno = 0;
+    ret = lseek(fd, 18, SEEK_HOLE);
+    ok(ret == 18 || ret == 52,
+       "%s: lseek to middle of hole w/ SEEK_HOLE (ret=%d): %s",
+       __FILE__, ret, strerror(errno));
+
+    /* lseek to end of file with SEEK_HOLE succeeds */
+    errno = 0;
+    ret = lseek(fd, 42, SEEK_HOLE);
+    ok(ret == 52, "%s: lseek to end of file w/ SEEK_HOLE (ret=%d): %s",
+       __FILE__, ret, strerror(errno));
+
+    /* lseek beyond end of file with SEEK_HOLE should fail with errno= ENXIO */
+    errno = 0;
+    ret = lseek(fd, 75, SEEK_HOLE);
+    ok(ret == -1 && errno == ENXIO,
+       "%s: lseek beyond end of file w/ SEEK_HOLE fails (ret=%d, errno=%d): %s",
+       __FILE__, ret, errno, strerror(errno));
+
+    end_todo;
+
+    rc = close(fd);
+
+    /* lseek in non-open file descriptor should fail with errno=EBADF */
+    errno = 0;
+    ret = lseek(fd, 0, SEEK_SET);
+    ok(ret == -1 && errno == EBADF,
+       "%s: lseek in non-open file descriptor fails (ret=%d, errno=%d): %s",
+       __FILE__, ret, errno, strerror(errno));
+
+    diag("Finished UNIFYFS_WRAP(lseek) tests");
+
+    return 0;
+}

--- a/t/sys/sysio_suite.c
+++ b/t/sys/sysio_suite.c
@@ -81,6 +81,8 @@ int main(int argc, char* argv[])
 
     open64_test(unifyfs_root);
 
+    lseek_test(unifyfs_root);
+
     write_read_test(unifyfs_root);
 
     write_read_hole_test(unifyfs_root);

--- a/t/sys/sysio_suite.h
+++ b/t/sys/sysio_suite.h
@@ -45,6 +45,9 @@ int open_test(char* unifyfs_root);
 /* Tests for UNIFYFS_WRAP(open64) */
 int open64_test(char* unifyfs_root);
 
+/* Tests for UNIFYFS_WRAP(lseek) */
+int lseek_test(char* unifyfs_root);
+
 int write_read_test(char* unifyfs_root);
 
 /* test reading from file with holes */


### PR DESCRIPTION
### Description (Updated)
<!--- Describe your changes in detail -->
This adds unit tests for our `lseek()`, `fseek()`, `ftell()`, and `rewind()`wrappers and fixes some related bugs. These mostly had to do with setting errno when invalid offsets are passed.

The `-D_GNU_SOURCE` is needed in `client/src/Makefile.am` in order to use `SEEK_DATA` and `SEEK_HOLE`.

Also adds tests for `SEEK_DATA` and `SEEK_HOLE` within `lseek()`, and adds the fallback support as stated in the man page:

> For  the  purposes of these operations, a hole
       is a sequence of zeros that (normally) has not
       been allocated in the underlying file storage.
       However, a  file  system  is  not  obliged  to
       report  holes,  so  these operations are not a
       guaranteed mechanism for mapping  the  storage
       space actually allocated to a file.  (Further‐
       more, a sequence of zeros  that  actually  has
       been written to the underlying storage may not
       be reported  as  a  hole.)   In  the  simplest
       implementation,  a file system can support the
       operations by making SEEK_HOLE  always  return
       the  offset of the end of the file, and making
       SEEK_DATA always return offset (i.e., even  if
       the  location referred to by offset is a hole,
       it can be considered to consist of  data  that
       is a sequence of zeros).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
