### PR TITLE
Fix compiler warnings, set -Werror by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: c
-dist: xenial
+dist: bionic
 os: linux
 
 addons:

--- a/client/src/Makefile.am
+++ b/client/src/Makefile.am
@@ -10,7 +10,7 @@ if HAVE_FORTRAN
 lib_LTLIBRARIES += libunifyfsf.la
 endif
 
-AM_CFLAGS = -Wall -Wno-strict-aliasing
+AM_CFLAGS = -Wall -Wno-strict-aliasing -Werror
 
 include_HEADERS = unifyfs.h
 
@@ -19,10 +19,12 @@ include_HEADERS += unifyfsf.h
 endif
 
 CLIENT_COMMON_CPPFLAGS = \
+  -Wall -Werror \
   -I$(top_builddir)/client \
   -I$(top_srcdir)/common/src
 
 CLIENT_COMMON_CFLAGS = \
+  -Wall -Werror \
   $(MPI_CFLAGS) \
   $(MERCURY_CFLAGS) \
   $(ARGOBOTS_CFLAGS) \

--- a/client/src/unifyfs-internal.h
+++ b/client/src/unifyfs-internal.h
@@ -491,6 +491,11 @@ int unifyfs_fid_is_dir_empty(const char* path);
 /* Return current global size of given file id */
 off_t unifyfs_fid_global_size(int fid);
 
+/* if we have a local fid structure corresponding to the gfid
+ * in question, we attempt the file lookup with the fid method
+ * otherwise call back to the rpc */
+off_t unifyfs_gfid_filesize(int gfid);
+
 /* Return current local size of given file id */
 off_t unifyfs_fid_log_size(int fid);
 

--- a/client/src/unifyfs-sysio.c
+++ b/client/src/unifyfs-sysio.c
@@ -1722,7 +1722,7 @@ int unifyfs_fd_logreadlist(read_req_t* in_reqs, int in_count)
         if (reqs != NULL) {
             free(reqs);
         }
-        return read_rc;
+        return ENOSPC;
     }
 
     /* order read request by increasing file id, then increasing offset */

--- a/client/src/unifyfsf.c
+++ b/client/src/unifyfsf.c
@@ -94,6 +94,11 @@ static int unifyfs_fstr2cstr(const char* fstr, int flen, char* cstr, int clen)
     return rc;
 }
 
+/*
+ * Marking unifyfs_cstr2fstr() with an '#if 0' block, since this function
+ * isn't used yet.
+ */
+#if 0
 /* convert a C string to a Fortran string, adding trailing spaces
  * as necessary */
 static int unifyfs_cstr2fstr(const char* cstr, char* fstr, int flen)
@@ -128,6 +133,7 @@ static int unifyfs_cstr2fstr(const char* cstr, char* fstr, int flen)
 
     return rc;
 }
+#endif
 
 /*================================================
  * Mount, Unmount

--- a/common/src/Makefile.am
+++ b/common/src/Makefile.am
@@ -33,6 +33,8 @@ BASE_SRCS = \
   unifyfs_logio.c \
   unifyfs_meta.h \
   unifyfs_meta.c \
+  unifyfs_misc.c \
+  unifyfs_misc.h \
   unifyfs_rpc_util.h \
   unifyfs_rpc_util.c \
   unifyfs_client_rpcs.h \
@@ -75,4 +77,4 @@ libunifyfs_common_la_LDFLAGS = \
 libunifyfs_common_la_LIBADD = \
   $(OPT_LIBS) -lm -lrt -lcrypto -lpthread
 
-AM_CFLAGS = -Wall -Wno-strict-aliasing
+AM_CFLAGS = -Wall -Werror -Wno-strict-aliasing

--- a/common/src/ini.c
+++ b/common/src/ini.c
@@ -17,6 +17,7 @@ https://github.com/benhoyt/inih
 #include <string.h>
 
 #include "ini.h"
+#include "unifyfs_misc.h"
 
 #if !INI_USE_STACK
 #include <stdlib.h>
@@ -73,8 +74,7 @@ static char *find_chars_or_comment(const char *s, const char *chars)
 /* Version of strncpy that ensures dest (size bytes) is null-terminated. */
 static char *strncpy0(char *dest, const char *src, size_t size)
 {
-    strncpy(dest, src, size);
-    dest[size - 1] = '\0';
+    strlcpy(dest, src, size);
     return dest;
 }
 

--- a/common/src/unifyfs_log.c
+++ b/common/src/unifyfs_log.c
@@ -29,6 +29,10 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
+#include <sys/syscall.h>
+#include <sys/types.h>
+
 #include "unifyfs_log.h"
 #include "unifyfs_const.h"
 
@@ -99,4 +103,16 @@ void unifyfs_set_log_level(unifyfs_log_level_t lvl)
     if (lvl < LOG_LEVEL_MAX) {
         unifyfs_log_level = lvl;
     }
+}
+
+pid_t unifyfs_gettid(void)
+{
+#if defined(gettid)
+    return gettid();
+#elif defined(SYS_gettid)
+    return syscall(SYS_gettid);
+#else
+#error no gettid()
+#endif
+    return 0;
 }

--- a/common/src/unifyfs_log.h
+++ b/common/src/unifyfs_log.h
@@ -32,9 +32,8 @@
 
 #include <stdio.h>
 #include <time.h>
-#include <unistd.h>
-#include <sys/syscall.h>
 #include <sys/time.h>
+#include <sys/types.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -56,13 +55,7 @@ extern struct tm* unifyfs_log_ltime;
 extern char unifyfs_log_timestamp[256];
 extern size_t unifyfs_log_source_base_len;
 
-#if defined(__NR_gettid)
-#define gettid() syscall(__NR_gettid)
-#elif defined(SYS_gettid)
-#define gettid() syscall(SYS_gettid)
-#else
-#error gettid syscall is not defined
-#endif
+pid_t unifyfs_gettid(void);
 
 #define LOG(level, ...) \
     if (level <= unifyfs_log_level) { \
@@ -75,7 +68,7 @@ extern size_t unifyfs_log_source_base_len;
             unifyfs_log_stream = stderr; \
         } \
         fprintf(unifyfs_log_stream, "%s tid=%ld @ %s() [%s:%d] ", \
-            unifyfs_log_timestamp, (long)gettid(), \
+            unifyfs_log_timestamp, (long)unifyfs_gettid(), \
             __func__, srcfile, __LINE__); \
         fprintf(unifyfs_log_stream, __VA_ARGS__); \
         fprintf(unifyfs_log_stream, "\n"); \

--- a/common/src/unifyfs_logio.c
+++ b/common/src/unifyfs_logio.c
@@ -676,7 +676,7 @@ int unifyfs_logio_read(logio_context* ctx,
                   &sz_in_mem, &sz_in_spill, &spill_offset);
 
     /* do reads */
-    int err_rc;
+    int err_rc = 0;
     if (sz_in_mem > 0) {
         /* read data from shared memory */
         char* shmem_data = (char*)(ctx->shmem->addr) + shmem_hdr->data_offset;
@@ -749,7 +749,7 @@ int unifyfs_logio_write(logio_context* ctx,
                   &sz_in_mem, &sz_in_spill, &spill_offset);
 
     /* do writes */
-    int err_rc;
+    int err_rc = 0;
     if (sz_in_mem > 0) {
         /* write data to shared memory */
         char* shmem_data = (char*)(ctx->shmem->addr) + shmem_hdr->data_offset;

--- a/common/src/unifyfs_meta.h
+++ b/common/src/unifyfs_meta.h
@@ -19,6 +19,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <string.h>
 
 #include "unifyfs_const.h"
 

--- a/common/src/unifyfs_misc.c
+++ b/common/src/unifyfs_misc.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2020, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2020, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyFS.
+ * For details, see https://github.com/LLNL/UnifyFS.
+ * Please read https://github.com/LLNL/UnifyFS/LICENSE for full license text.
+ */
+
+/*
+ * This file contains miscellaneous common functions that don't fit into a
+ * particular common/src/ file.
+ */
+#include <string.h>
+#include <stdio.h>
+#include <stdarg.h>
+
+/*
+ * Re-implementation of BSD's strlcpy() function.
+ *
+ * This is a basically a safer version of strlncpy() since it always
+ * NULL-terminates the buffer.  Google 'strlcpy' for full documentation.
+ */
+size_t strlcpy(char* dest, const char* src, size_t size)
+{
+    size_t src_len = strnlen(src, size);
+
+    memcpy(dest, src, src_len);
+    if (src_len == size) {
+        dest[size - 1] = '\0';
+    }
+    return strlen(dest);
+}
+
+/*
+ * This is a re-implementation of the Linux kernel's scnprintf() function.
+ *
+ * It's snprintf() but returns the number of chars actually written into buf[]
+ * not including the '\0'.  It also avoids the -Wformat-truncation warnings.
+ */
+int scnprintf(char* buf, size_t size, const char* fmt, ...)
+{
+        va_list args;
+        int rc;
+
+        va_start(args, fmt);
+        rc = vsnprintf(buf, size, fmt, args);
+        va_end(args);
+
+        if (rc >= size) {
+                /* We truncated */
+                return size - 1;
+        }
+
+        return rc;
+}

--- a/common/src/unifyfs_misc.h
+++ b/common/src/unifyfs_misc.h
@@ -1,0 +1,5 @@
+#ifndef __UNIFYFS_MISC__
+#define __UNIFYFS_MISC__
+size_t strlcpy(char* dest, const char* src, size_t size);
+int scnprintf(char* buf, size_t size, const char* fmt, ...);
+#endif

--- a/examples/src/app-hdf5-create.c
+++ b/examples/src/app-hdf5-create.c
@@ -162,18 +162,18 @@ int main(int argc, char** argv)
         /* Create a new file using default properties. */
         file_id = H5Fcreate(targetfile, H5F_ACC_TRUNC, H5P_DEFAULT,
                             H5P_DEFAULT);
-        printf("H5Fcreate: %d\n", file_id);
+        printf("H5Fcreate: %ld\n", (long) file_id);
 
         /* Create the data space for the dataset. */
         dims[0] = 4;
         dims[1] = 6;
         dataspace_id = H5Screate_simple(2, dims, NULL);
-        printf("H5Screate_simple: %d\n", dataspace_id);
+        printf("H5Screate_simple: %ld\n", (long) dataspace_id);
 
         /* Create the dataset. */
         dataset_id = H5Dcreate2(file_id, "/dset", H5T_STD_I32BE, dataspace_id,
                                 H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-        printf("H5Dcreate2: %d\n", dataset_id);
+        printf("H5Dcreate2: %ld\n", (long) dataset_id);
 
         if (write_data) {
             int i, j;

--- a/examples/src/app-hdf5-writeread.c
+++ b/examples/src/app-hdf5-writeread.c
@@ -186,11 +186,11 @@ int main(int argc, char** argv)
 
         /* Open an existing file. */
         file_id = H5Fopen(targetfile, H5F_ACC_RDWR, H5P_DEFAULT);
-        printf("H5Fopen: %d\n", file_id);
+        printf("H5Fopen: %ld\n", (long) file_id);
 
         /* Open an existing dataset. */
         dataset_id = H5Dopen2(file_id, "/dset", H5P_DEFAULT);
-        printf("H5open2: %d\n", dataset_id);
+        printf("H5open2: %ld\n", (long) dataset_id);
 
         if (!readonly) {
             /* Write the dataset. */

--- a/examples/src/multi-write.c
+++ b/examples/src/multi-write.c
@@ -140,7 +140,10 @@ int do_test(test_cfg* cfg)
         /* + 1 so we always write at least 1 byte */
         count = (rand() % (MAX_WRITE-1)) + 1;
         lseek(fd, start, SEEK_SET);
-        write(fd, &bigbuf[start], count);
+        if (write(fd, &bigbuf[start], count) != count) {
+            perror("Couldn't write");
+            exit(1);
+        }
     }
 
     /* Sync extents of all our files and laminate them */

--- a/m4/gotcha.m4
+++ b/m4/gotcha.m4
@@ -7,7 +7,7 @@ AC_DEFUN([UNIFYFS_AC_GOTCHA], [
   AC_ARG_WITH([gotcha], [AC_HELP_STRING([--with-gotcha=PATH],
     [path to installed libgotcha [default=/usr/local]])], [
     GOTCHA_CFLAGS="-I${withval}/include"
-    GOTCHA_LDFLAGS="-L${withval}/lib64"
+    GOTCHA_LDFLAGS="-L${withval}/lib64 -L${withval}/lib"
     CFLAGS="$CFLAGS ${GOTCHA_CFLAGS}"
     CXXFLAGS="$CXXFLAGS ${GOTCHA_CFLAGS}"
     LDFLAGS="$LDFLAGS ${GOTCHA_LDFLAGS}"

--- a/meta/src/Makefile.am
+++ b/meta/src/Makefile.am
@@ -36,6 +36,6 @@ AM_CPPFLAGS = -I$(top_srcdir)/meta/src/Mlog2 \
               -I$(top_srcdir)/server/src
 
 AM_CFLAGS = -DLEVELDB_SUPPORT $(LEVELDB_CFLAGS) $(MPI_CFLAGS) $(MARGO_CFLAGS)
-AM_CFLAGS += -Wall
+AM_CFLAGS += -Wall -Werror
 
 CLEANFILES =

--- a/meta/src/Mlog2/mlog2.c
+++ b/meta/src/Mlog2/mlog2.c
@@ -1174,6 +1174,8 @@ void mlog_setmasks(char *mstr, int mlen0)
         /* process priority */
         if (prilen > 5) {    /* we know it can't be longer than this */
             prino = -1;
+        } else if (prilen < 0) {     /* This if() block gets rid of a */
+            prino = -1;              /* compiler warning.             */
         } else {
             memset(pbuf, 0, sizeof(pbuf));
             strncpy(pbuf, pri, prilen);

--- a/meta/src/ds_leveldb.c
+++ b/meta/src/ds_leveldb.c
@@ -397,6 +397,7 @@ int mdhim_leveldb_put(void *dbh, void *key, int key_len, void *data, int32_t dat
     gettimeofday(&start, NULL);
     options = mdhimdb->write_options;    	    
     leveldb_put(mdhimdb->db, options, key, key_len, data, data_len, &err);
+    gettimeofday(&end, NULL);
     /*
      * temporarily mute the error message until the file metadata
      * operation is fully defined and implemented */

--- a/server/src/Makefile.am
+++ b/server/src/Makefile.am
@@ -40,7 +40,7 @@ AM_CPPFLAGS = \
   -I$(top_srcdir)/meta/src/uthash \
   -I$(top_srcdir)/meta/src/Mlog2
 
-AM_CFLAGS = -Wall \
+AM_CFLAGS = -Wall -Werror \
   $(LEVELDB_CFLAGS) \
   $(MPI_CFLAGS) \
   $(MERCURY_CFLAGS) \

--- a/server/src/unifyfs_cmd_handler.c
+++ b/server/src/unifyfs_cmd_handler.c
@@ -40,6 +40,7 @@
 #include "margo_server.h"
 #include "unifyfs_client_rpcs.h"
 #include "unifyfs_rpc_util.h"
+#include "unifyfs_misc.h"
 
 /**
  * attach to the client-side shared memory
@@ -331,7 +332,7 @@ static void unifyfs_metaset_rpc(hg_handle_t handle)
     memset(&fattr, 0, sizeof(fattr));
     int create         = (int) in.create;
     fattr.gfid         = in.gfid;
-    strncpy(fattr.filename, in.filename, sizeof(fattr.filename));
+    strlcpy(fattr.filename, in.filename, sizeof(fattr.filename));
     fattr.mode         = in.mode;
     fattr.uid          = in.uid;
     fattr.gid          = in.gid;

--- a/server/src/unifyfs_metadata.c
+++ b/server/src/unifyfs_metadata.c
@@ -43,6 +43,7 @@
 #include "indexes.h"
 #include "mdhim.h"
 
+
 struct mdhim_t* md;
 
 /* we use two MDHIM indexes:

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -37,7 +37,7 @@ EXTRA_DIST = \
 	sharness.sh \
 	tap-driver.sh
 
-AM_CFLAGS = -Wall
+AM_CFLAGS = -Wall -Werror
 
 clean-local:
 	rm -fr trash-directory.* test-results *.log test_run_env.sh

--- a/t/lib/Makefile.am
+++ b/t/lib/Makefile.am
@@ -1,4 +1,4 @@
-AM_CFLAGS = -Wall
+AM_CFLAGS = -Wall -Werror
 
 AM_CPPFLAGS =
 

--- a/t/server/metadata_suite.c
+++ b/t/server/metadata_suite.c
@@ -8,7 +8,7 @@ int main(int argc, char* argv[])
 {
     /* need to initialize enough of the server to use the metadata API */
     unifyfs_cfg_t server_cfg;
-    int rc, provided, glb_rank, glb_size;
+    int rc;
 
     /* get the configuration */
     rc = unifyfs_config_init(&server_cfg, argc, argv);

--- a/t/server/metadata_suite.h
+++ b/t/server/metadata_suite.h
@@ -24,6 +24,5 @@
 
 int unifyfs_set_file_attribute_test(void);
 int unifyfs_get_file_attribute_test(void);
-int unifyfs_get_file_extents_test(void);
 
 #endif /* METADATA_SUITE_H */

--- a/t/server/unifyfs_meta_get_test.c
+++ b/t/server/unifyfs_meta_get_test.c
@@ -40,19 +40,3 @@ int unifyfs_get_file_attribute_test(void)
     );
     return 0;
 }
-
-// this test is not run right now
-int unifyfs_get_file_extents_test(void)
-{
-    int rc, num_values, num_keys;
-    int key_lens[16];
-    unifyfs_key_t keys[16];
-    unifyfs_keyval_t keyval[16];
-
-    rc = unifyfs_get_file_extents(num_keys, (unifyfs_key_t**)&keys, key_lens,
-                                  &num_values, (unifyfs_keyval_t**)&keyval);
-    ok(UNIFYFS_SUCCESS == rc,
-        "Retrieved file extents (rc = %d)", rc
-    );
-    return 0;
-}

--- a/t/sys/creat64.c
+++ b/t/sys/creat64.c
@@ -35,7 +35,6 @@ int creat64_test(char* unifyfs_root)
     char path[64];
     int mode = 0600;
     int fd;
-    int rc;
 
     /* Create a random file name at the mountpoint path to test on */
     testutil_rand_path(path, sizeof(path), unifyfs_root);
@@ -47,7 +46,7 @@ int creat64_test(char* unifyfs_root)
     ok(fd >= 0, "creat64 non-existing file %s (fd=%d): %s",
        path, fd, strerror(errno));
 
-    rc = close(fd);
+    ok(close(fd) != -1, "close() worked");
 
     /* Verify creating an already created file succeeds. */
     errno = 0;
@@ -55,7 +54,8 @@ int creat64_test(char* unifyfs_root)
     ok(fd >= 0, "creat64 existing file %s (fd=%d): %s",
        path, fd, strerror(errno));
 
-    rc = close(fd);
+    ok(close(fd) != -1, "close() worked");
+
     end_skip;
 
     diag("Finished UNIFYFS_WRAP(creat64) tests");

--- a/t/sys/lseek.c
+++ b/t/sys/lseek.c
@@ -44,7 +44,10 @@ int lseek_test(char* unifyfs_root)
 
     /* Open a file and write to it to test lseek() */
     fd = open(path, O_RDWR | O_CREAT | O_TRUNC, file_mode);
-    write(fd, "hello world", 12);
+
+    ret = write(fd, "hello world", 12);
+    ok(ret == 12, "%s: write works (ret=%d): %s",
+        __FILE__, ret, strerror(errno));
 
     /* lseek with invalid whence fails with errno=EINVAL. */
     errno = 0;
@@ -134,7 +137,9 @@ int lseek_test(char* unifyfs_root)
 
     /* lseek() with SEEK_DATA tests */
     /* Write beyond end of file to create a hole */
-    write(fd, "hello universe", 15);
+    ret = write(fd, "hello universe", 15);
+    ok(ret == 15, "%s: write works (ret=%d): %s",
+        __FILE__, ret, strerror(errno));
 
     /* lseek to negative offset with SEEK_DATA should fail with errno=ENXIO */
     errno = 0;

--- a/t/sys/open.c
+++ b/t/sys/open.c
@@ -57,7 +57,7 @@ int open_test(char* unifyfs_root)
     ok(fd >= 0, "open non-existing file %s flags O_CREAT|O_EXCL (fd=%d): %s",
        path, fd, strerror(errno));
 
-    rc = close(fd);
+    ok(close(fd) != -1, "close() worked");
 
     /* Verify opening an existing file with O_CREAT|O_EXCL fails with
      * errno=EEXIST. */
@@ -73,12 +73,13 @@ int open_test(char* unifyfs_root)
     ok(fd >= 0, "open existing file %s O_RDWR (fd=%d): %s",
        path, fd, strerror(errno));
 
-    rc = close(fd);
+    ok(close(fd) != -1, "close() worked");
+
+    rc = mkdir(dir_path, dir_mode);
+    ok(rc == 0, "mkdir(%s, %o) worked, rc = %d", dir_path, dir_mode, rc);
 
     /* todo_open_1: Remove when issue is resolved */
     todo("open_1: should fail with errno=EISDIR=21");
-    /* Verify opening a dir for write fails with errno=EISDIR */
-    rc = mkdir(dir_path, dir_mode);
 
     errno = 0;
     fd = open(dir_path, O_RDWR, file_mode);
@@ -92,7 +93,7 @@ int open_test(char* unifyfs_root)
      * Don't unlink `path` so that the final test (9020-mountpoint-empty) can
      * check if open left anything in the mountpoint and thus wasn't wrapped
      * properly. */
-    rc = rmdir(dir_path);
+    ok(rmdir(dir_path) != -1, "rmdir() worked");
 
     diag("Finished UNIFYFS_WRAP(open) tests");
 

--- a/t/sys/open64.c
+++ b/t/sys/open64.c
@@ -37,7 +37,6 @@ int open64_test(char* unifyfs_root)
     char path[64];
     int mode = 0600;
     int fd;
-    int rc;
 
     /* Create a random file name at the mountpoint path to test on */
     testutil_rand_path(path, sizeof(path), unifyfs_root);
@@ -56,7 +55,7 @@ int open64_test(char* unifyfs_root)
     ok(fd >= 0, "open64 non-existing file %s flags O_CREAT|O_EXCL (fd=%d): %s",
        path, fd, strerror(errno));
 
-    rc = close(fd);
+    ok(close(fd) != -1, "close() worked");
 
     /* Verify opening an existing file with O_CREAT|O_EXCL fails with
      * errno=EEXIST. */
@@ -72,7 +71,7 @@ int open64_test(char* unifyfs_root)
     ok(fd >= 0, "open64 existing file %s O_RDWR (fd=%d): %s",
        path, fd, strerror(errno));
 
-    rc = close(fd);
+    ok(close(fd) != -1, "close() worked");
 
     diag("Finished UNIFYFS_WRAP(open64) tests");
 

--- a/t/sys/truncate.c
+++ b/t/sys/truncate.c
@@ -509,7 +509,6 @@ int truncate_empty_read(char* unifyfs_root, off_t seekpos)
     int rc;
     int fd;
     size_t global, log;
-    int i;
 
     size_t bufsize = 1024*1024;
     char* buf = (char*) malloc(bufsize);

--- a/util/unifyfs/src/Makefile.am
+++ b/util/unifyfs/src/Makefile.am
@@ -11,7 +11,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/common/src \
               -DBINDIR=\"$(bindir)\" \
               -DSBINDIR=\"$(sbindir)\"
 
-AM_CFLAGS = -Wall
+AM_CFLAGS = -Wall -Werror
 
 CLEANFILES = $(bin_PROGRAMS)
 

--- a/util/unifyfs/src/unifyfs-rm.c
+++ b/util/unifyfs/src/unifyfs-rm.c
@@ -196,7 +196,7 @@ static int lsf_read_resource(unifyfs_resource_t* resource)
     size_t i, n_nodes;
     char* val;
     char* node;
-    char* last_node;
+    char* last_node = NULL;
     char* lsb_hosts;
     char* pos;
     char** nodes;


### PR DESCRIPTION
### Description
This enables -Werror by default and fixes all compiler warnings on GCC 9.2.1.

### Motivation and Context
Fix build warnings

### How Has This Been Tested?
Build tested only on Fedora 31.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
