### PR TITLE
improve server management of app/client state

### DIFF
--- a/client/src/margo_client.h
+++ b/client/src/margo_client.h
@@ -10,6 +10,7 @@
 #include "unifyfs_client_rpcs.h"
 
 typedef struct ClientRpcIds {
+    hg_id_t attach_id;
     hg_id_t mount_id;
     hg_id_t unmount_id;
     hg_id_t metaset_id;
@@ -36,8 +37,10 @@ int unifyfs_client_rpc_init(void);
 
 int unifyfs_client_rpc_finalize(void);
 
-void fill_client_mount_info(unifyfs_mount_in_t* in);
+void fill_client_attach_info(unifyfs_attach_in_t* in);
+int invoke_client_attach_rpc(void);
 
+void fill_client_mount_info(unifyfs_mount_in_t* in);
 int invoke_client_mount_rpc(void);
 
 int invoke_client_unmount_rpc(void);

--- a/client/src/unifyfs-internal.h
+++ b/client/src/unifyfs-internal.h
@@ -258,15 +258,6 @@ enum flock_enum {
 
 enum {FILE_STORAGE_NULL = 0, FILE_STORAGE_LOGIO};
 
-/* TODO: make this an enum */
-#define CHUNK_LOCATION_NULL      0
-#define CHUNK_LOCATION_MEMFS     1
-#define CHUNK_LOCATION_SPILLOVER 2
-
-typedef struct {
-    int location; /* CHUNK_LOCATION type */
-    off_t id;     /* physical id of chunk in its respective storage */
-} unifyfs_chunkmeta_t;
 
 typedef struct {
     off_t global_size;            /* Global size of the file */
@@ -281,7 +272,6 @@ typedef struct {
     int needs_sync;               /* have unsynced writes */
 
     off_t chunks;                 /* number of chunks allocated to file */
-    off_t chunkmeta_idx;          /* starting index in unifyfs_chunkmeta */
     int is_laminated;             /* Is this file laminated */
     uint32_t mode;                /* st_mode bits.  This has file
                                    * permission info and will tell you if this
@@ -343,7 +333,8 @@ extern shm_context* shm_recv_ctx;
 /* log-based I/O context */
 extern logio_context* logio_ctx;
 
-extern int app_id;
+extern int unifyfs_app_id;
+extern int unifyfs_client_id;
 extern size_t unifyfs_key_slice_range;
 
 /* -------------------------------

--- a/common/src/unifyfs_client_rpcs.h
+++ b/common/src/unifyfs_client_rpcs.h
@@ -15,25 +15,34 @@
 extern "C" {
 #endif
 
-/* unifyfs_mount_rpc (client => server)
+/* unifyfs_attach_rpc (client => server)
  *
- * connect application client to the server, and
- * initialize shared memory state */
-MERCURY_GEN_PROC(unifyfs_mount_in_t,
+ * initialize server access to client's shared memory and file state */
+MERCURY_GEN_PROC(unifyfs_attach_in_t,
                  ((int32_t)(app_id))
                  ((int32_t)(client_id))
-                 ((int32_t)(dbg_rank))
-                 ((int32_t)(num_procs_per_node))
-                 ((hg_const_string_t)(client_addr_str))
-                 ((hg_size_t)(recv_buf_sz))
-                 ((hg_size_t)(superblock_sz))
+                 ((hg_size_t)(shmem_data_size))
+                 ((hg_size_t)(shmem_super_size))
                  ((hg_size_t)(meta_offset))
                  ((hg_size_t)(meta_size))
                  ((hg_size_t)(logio_mem_size))
                  ((hg_size_t)(logio_spill_size))
-                 ((hg_const_string_t)(external_spill_dir)))
+                 ((hg_const_string_t)(logio_spill_dir)))
+MERCURY_GEN_PROC(unifyfs_attach_out_t,
+                 ((int32_t)(ret)))
+DECLARE_MARGO_RPC_HANDLER(unifyfs_attach_rpc)
+
+/* unifyfs_mount_rpc (client => server)
+ *
+ * connect application client to the server */
+MERCURY_GEN_PROC(unifyfs_mount_in_t,
+                 ((int32_t)(dbg_rank))
+                 ((hg_const_string_t)(mount_prefix))
+                 ((hg_const_string_t)(client_addr_str)))
 MERCURY_GEN_PROC(unifyfs_mount_out_t,
-                 ((hg_size_t)(max_recs_per_slice))
+                 ((hg_size_t)(meta_slice_sz))
+                 ((int32_t)(app_id))
+                 ((int32_t)(client_id))
                  ((int32_t)(ret)))
 DECLARE_MARGO_RPC_HANDLER(unifyfs_mount_rpc)
 
@@ -41,8 +50,8 @@ DECLARE_MARGO_RPC_HANDLER(unifyfs_mount_rpc)
  *
  * disconnect client from server */
 MERCURY_GEN_PROC(unifyfs_unmount_in_t,
-    ((int32_t)(app_id))
-    ((int32_t)(client_id)))
+                 ((int32_t)(app_id))
+                 ((int32_t)(client_id)))
 MERCURY_GEN_PROC(unifyfs_unmount_out_t, ((int32_t)(ret)))
 DECLARE_MARGO_RPC_HANDLER(unifyfs_unmount_rpc)
 

--- a/common/src/unifyfs_const.h
+++ b/common/src/unifyfs_const.h
@@ -49,21 +49,22 @@
 #define UNIFYFS_MAX_FILENAME KIB
 #define UNIFYFS_MAX_HOSTNAME 64
 
-// Request Manager
+// Server - Request Manager
 #define MAX_META_PER_SEND (4 * KIB)  /* max read request count per server */
 #define REQ_BUF_LEN (MAX_META_PER_SEND * 64) /* chunk read reqs buffer size */
 #define SHM_WAIT_INTERVAL 1000       /* unit: ns */
 #define RM_MAX_ACTIVE_REQUESTS 64    /* number of concurrent read requests */
 
-// Service Manager
+// Server - Service Manager
 #define LARGE_BURSTY_DATA (512 * MIB)
 #define MAX_BURSTY_INTERVAL 10000 /* unit: us */
 #define MIN_SLEEP_INTERVAL 100    /* unit: us */
 #define SLEEP_INTERVAL 500        /* unit: us */
 #define SLEEP_SLICE_PER_UNIT 50   /* unit: us */
 
-// Request and Service Managers, Command Handler
-#define MAX_NUM_CLIENTS 64 /* app processes per server */
+// Server - General
+#define MAX_NUM_APPS 64    /* max # apps supported by a single server */
+#define MAX_APP_CLIENTS 64 /* app processes per server */
 
 // Client
 #define UNIFYFS_MAX_FILES 128

--- a/docs/add-rpcs.rst
+++ b/docs/add-rpcs.rst
@@ -18,9 +18,9 @@ Common
 
    The struct definition macro `MERCURY_GEN_PROC()` is used to define
    both input and output parameters. For client-server RPCs, the
-   definitions should be placed in `common/src/unifyfs_clientcalls_rpc.h`,
+   definitions should be placed in `common/src/unifyfs_client_rpcs.h`,
    while server-server RPC structs are defined in
-   `common/src/unifyfs_servercalls_rpc.h`.
+   `common/src/unifyfs_server_rpcs.h`.
 
    The input parameters struct should contain all values the client needs
    to pass to the server handler function.
@@ -30,23 +30,21 @@ Common
 
 .. code-block:: C
   MERCURY_GEN_PROC(unifyfs_mount_in_t,
-                   ((int32_t)(app_id))
                    ((int32_t)(client_id))
                    ((int32_t)(dbg_rank))
-                   ((int32_t)(num_procs_per_node))
-                   ((hg_const_string_t)(client_addr_str))
-                   ((hg_size_t)(req_buf_sz))
-                   ((hg_size_t)(recv_buf_sz))
-                   ((hg_size_t)(superblock_sz))
+                   ((hg_size_t)(shmem_data_size))
+                   ((hg_size_t)(shmem_super_size))
                    ((hg_size_t)(meta_offset))
                    ((hg_size_t)(meta_size))
-                   ((hg_size_t)(fmeta_offset))
-                   ((hg_size_t)(fmeta_size))
-                   ((hg_size_t)(data_offset))
-                   ((hg_size_t)(data_size))
-                   ((hg_const_string_t)(external_spill_dir)))
+                   ((hg_size_t)(logio_mem_size))
+                   ((hg_size_t)(logio_spill_size))
+                   ((hg_const_string_t)(logio_spill_dir))
+                   ((hg_const_string_t)(mount_prefix))
+                   ((hg_const_string_t)(client_addr_str)))
   MERCURY_GEN_PROC(unifyfs_mount_out_t,
-                   ((hg_size_t)(max_recs_per_slice))
+                   ((hg_size_t)(meta_slice_sz))
+                   ((int32_t)(app_id))
+                   ((int32_t)(client_id))
                    ((int32_t)(ret)))
 
 .. note::
@@ -66,8 +64,7 @@ Server
    This is the function that will be invoked on the client and executed on
    the server. Client-server RPC handler functions are implemented in
    `server/src/unifyfs_cmd_handler.c`, while server-server RPC handlers go
-   in `server/src/unifyfs_service_manager.c`. The RPC handler input and output
-   parameters structs are defined in `common/src/unifyfs_clientcalls_rpc.h`.
+   in `server/src/unifyfs_service_manager.c`.
 
    All the RPC handler functions follow the same protoype, which is passed
    a Mercury handle as the only argument. The handler function should use

--- a/server/src/Makefile.am
+++ b/server/src/Makefile.am
@@ -16,7 +16,7 @@ libunifyfsd_a_SOURCES = \
 
 bin_PROGRAMS = unifyfsd
 
-unifyfsd_SOURCES = unifyfs_init.c
+unifyfsd_SOURCES = unifyfs_server.c
 
 unifyfsd_LDFLAGS = -static \
   $(LEVELDB_LDFLAGS) \

--- a/server/src/margo_server.c
+++ b/server/src/margo_server.c
@@ -147,6 +147,10 @@ static margo_instance_id setup_local_target(void)
 /* register client-server RPCs */
 static void register_client_server_rpcs(margo_instance_id mid)
 {
+    MARGO_REGISTER(mid, "unifyfs_attach_rpc",
+                   unifyfs_attach_in_t, unifyfs_attach_out_t,
+                   unifyfs_attach_rpc);
+
     MARGO_REGISTER(mid, "unifyfs_mount_rpc",
                    unifyfs_mount_in_t, unifyfs_mount_out_t,
                    unifyfs_mount_rpc);
@@ -244,6 +248,18 @@ int margo_server_rpc_finalize(void)
         unifyfsd_rpc_context = NULL;
 
         rpc_clean_local_server_addr();
+
+        /* free global server addresses */
+        for (int i = 0; i < glb_num_servers; i++) {
+            if (glb_servers[i].margo_svr_addr != HG_ADDR_NULL) {
+                margo_addr_free(ctx->svr_mid, glb_servers[i].margo_svr_addr);
+                glb_servers[i].margo_svr_addr = HG_ADDR_NULL;
+            }
+            if (NULL != glb_servers[i].margo_svr_addr_str) {
+                free(glb_servers[i].margo_svr_addr_str);
+                glb_servers[i].margo_svr_addr_str = NULL;
+            }
+        }
 
         /* shut down margo */
         margo_finalize(ctx->svr_mid);

--- a/server/src/unifyfs_metadata.c
+++ b/server/src/unifyfs_metadata.c
@@ -53,7 +53,7 @@ struct mdhim_t* md;
 #define IDX_FILE_ATTR    (1)
 struct index_t* unifyfs_indexes[2];
 
-size_t max_recs_per_slice;
+size_t meta_slice_sz;
 
 void debug_log_key_val(const char* ctx,
                        unifyfs_key_t* key,
@@ -141,7 +141,7 @@ int meta_init_store(unifyfs_cfg_t* cfg)
     if (rc != 0) {
         return -1;
     }
-    max_recs_per_slice = (size_t) range_sz;
+    meta_slice_sz = (size_t) range_sz;
     mdhim_options_set_max_recs_per_slice(db_opts, (uint64_t)range_sz);
 
     md = mdhimInit(&comm, db_opts);

--- a/server/src/unifyfs_metadata.h
+++ b/server/src/unifyfs_metadata.h
@@ -35,6 +35,13 @@
 
 #define MANIFEST_FILE_NAME "mdhim_manifest_"
 
+
+/* extent slice size used for metadata */
+extern size_t meta_slice_sz;
+
+/* Key for file attributes */
+typedef int fattr_key_t;
+
 /**
  * Key for a file extent
  */

--- a/server/src/unifyfs_request_manager.h
+++ b/server/src/unifyfs_request_manager.h
@@ -47,7 +47,7 @@ typedef struct {
  * manager thread, contains shared data structures where main thread
  * issues read requests and request manager processes them, contains
  * condition variable and lock for coordination between threads */
-typedef struct {
+typedef struct reqmgr_thrd {
     /* request manager thread */
     pthread_t thrd;
 
@@ -84,18 +84,12 @@ typedef struct {
 
     /* client_id this thread is serving */
     int client_id;
-
-    /* index within rm_thrd_list */
-    int thrd_ndx;
 } reqmgr_thrd_t;
 
 
 /* create Request Manager thread for application client */
 reqmgr_thrd_t* unifyfs_rm_thrd_create(int app_id,
                                       int client_id);
-
-/* lookup Request Manager thread by index */
-reqmgr_thrd_t* rm_get_thread(int thrd_id);
 
 /* Request Manager pthread main */
 void* rm_delegate_request_thread(void* arg);


### PR DESCRIPTION
### Description

Changes to application management:
 * app_id derived from mountpoint prefix (using same method used
   for gfid calculation)
 * `app_config` structure holds all state for a given application
 * `app_configs[]` - simple array of app_config structure pointers
   (replaces `app_config_list` arraylist)
   - added methods for adding/getting structure for given app_id

Changes to client management:
 * client_id assigned by server during mount rpc
   - can still be passed explicitly for re-attach
 * `app_client` structure holds all state for a given client
 * each app_config has an array of clients (`app_client*`)
   - added methods for adding/getting/removing clients

Miscellaneous code cleanup:
 * static functions should not use `unifyfs_` prefix, only ones
   used by external sources
 * don't use local function variables that shadow global variables
 * renamed `max_recs_per_slice` to `meta_slice_sz`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
