### PR TITLE
Move _GNU_SOURCE define to before system headers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: c
-sudo: required
 dist: xenial
+os: linux
 
 addons:
   apt:
@@ -74,9 +74,10 @@ before_cache:
 script:
   # Force git to update the shallow clone and include tags so git-describe works
   - git fetch --unshallow --tags
-  - sh autogen.sh
-  - ./configure --enable-fortran || cat config.log
-  - make -k && make distcheck
+  - export DISTCHECK_CONFIGURE_FLAGS="--enable-fortran"
+  - ./autogen.sh
+  - ./configure $DISTCHECK_CONFIGURE_FLAGS || cat config.log
+  - make distcheck
   - ./scripts/checkpatch.sh || test "$TEST_CHECKPATCH_ALLOW_FAILURE" = yes
 
 after_failure:

--- a/client/src/Makefile.am
+++ b/client/src/Makefile.am
@@ -20,8 +20,7 @@ endif
 
 CLIENT_COMMON_CPPFLAGS = \
   -I$(top_builddir)/client \
-  -I$(top_srcdir)/common/src \
-  -D_GNU_SOURCE
+  -I$(top_srcdir)/common/src
 
 CLIENT_COMMON_CFLAGS = \
   $(MPI_CFLAGS) \

--- a/client/src/unifyfs-internal.h
+++ b/client/src/unifyfs-internal.h
@@ -57,6 +57,10 @@
  * -------------------------------
  */
 
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
 // system headers
 #include <aio.h>
 #include <assert.h>
@@ -85,7 +89,6 @@
 #include <wchar.h>
 #include <dirent.h>
 
-#define _GNU_SOURCE
 #include <pthread.h>
 #include <sched.h>
 
@@ -147,7 +150,6 @@
  * dlsym */
 
 /* we need the dlsym function */
-#define __USE_GNU
 #include <dlfcn.h>
 
 /* define a static variable called __real_open to record address of


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Moves the _GNU_SOURCE definition to before the system headers in unifyfs-internal.h so it is properly defined for the `lseek` cases needed in #473. In turn, removes _GNU_SOURCE from client/src/Makefile.am to avoid redefine warnings. Also removed `#define __USE_GNU` as `#define _GNU_SOURCE` does this implicitly.

Our travis.yml runs `make distcheck` which apparently ignores configure options. Need to use `DISTCHECK_CONFIGURE_FLAGS` envar to pass config options to `make distcheck`.
This also updates .travis.yml to fix warnings caused by depricated `sudo` key, and missing `os` key.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Properly define `_GNU_SOURCE` to remove warnings and make available for wrappers that need it (i.e., `lseek`).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
