### PR TITLE
undef before (re) defining MIN/MAX macros

### DIFF
--- a/client/src/unifyfs-sysio.c
+++ b/client/src/unifyfs-sysio.c
@@ -46,8 +46,9 @@
 #include "ucr_read_builder.h"
 #include "seg_tree.h"
 
-
-#define MAX(a, b) (a > b ? a : b)
+#ifndef MAX
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
+#endif
 
 /* ---------------------------------------
  * POSIX wrappers: paths

--- a/common/src/seg_tree.c
+++ b/common/src/seg_tree.c
@@ -36,8 +36,13 @@
 #include "seg_tree.h"
 #include "tree.h"
 
-#define MIN(a, b) (a < b ? a : b)
-#define MAX(a, b) (a > b ? a : b)
+#ifndef MIN
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+#endif
+
+#ifndef MAX
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
+#endif
 
 int
 compare_func(struct seg_tree_node* node1, struct seg_tree_node* node2)


### PR DESCRIPTION
The recent addition of `-Werror` fails the build because of redefiniting the `MIN`/`MAX` macros. This prevents the compiler warning by `undef` those macros before defining them.

```
../../../../../client/src/unifyfs-sysio.c:50: error: "MAX" redefined [-Werror]
 #define MAX(a, b) (a > b ? a : b)
 
In file included from /ccs/techint/home/hs2/projects/UnifyFS/__run/testbed/prefix/include/margo-diag.h:10,
                 from /ccs/techint/home/hs2/projects/UnifyFS/__run/testbed/prefix/include/margo.h:20,
                 from ../../../../../client/src/margo_client.h:8,
                 from ../../../../../client/src/unifyfs-sysio.c:45:
/usr/include/sys/param.h:98: note: this is the location of the previous definition
 #define MAX(a,b) (((a)>(b))?(a):(b))
```

### How Has This Been Tested?
RHEL7.4/x86_64.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

