### PR TITLE
Create test get_size function and additional tests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,6 +20,7 @@
 - [ ] Performance enhancement (non-breaking change which improves efficiency)
 - [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Testing (addition of new tests or update to current tests)
 - [ ] Documentation (a change to man pages or other documentation)
 
 ### Checklist:

--- a/t/lib/testutil.c
+++ b/t/lib/testutil.c
@@ -12,10 +12,12 @@
  * Please read https://github.com/LLNL/UnifyFS/LICENSE for full license text.
  */
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <sys/time.h>
-#include "testutil.h"
+#include <sys/stat.h>
 
 static unsigned long seed;
 
@@ -96,4 +98,26 @@ char* testutil_get_mount_point(void)
     }
 
     return path;
+}
+
+/* Stat the file associated to by path and store the global and log sizes of the
+ * file at path in the addresses of the respective global and log pointers
+ * passed in.
+ * User can ask for one or both sizes. */
+void testutil_get_size(char* path, size_t* global, size_t* log)
+{
+    struct stat sb = {0};
+    int rc;
+
+    rc = stat(path, &sb);
+    if (rc != 0) {
+        printf("Error: %s\n", strerror(errno));
+        exit(1);
+    }
+    if (global) {
+        *global = sb.st_size;
+    }
+    if (log) {
+        *log = sb.st_rdev;
+    }
 }

--- a/t/lib/testutil.h
+++ b/t/lib/testutil.h
@@ -31,3 +31,9 @@ void testutil_rand_path(char* buf, size_t len, const char* pfx);
  * /tmp.
  */
 char* testutil_get_mount_point(void);
+
+/* Stat the file associated to by path and store the global and log sizes of the
+ * file at path in the addresses of the respective global and log pointers
+ * passed in.
+ * User can ask for one or both sizes. */
+void testutil_get_size(char* path, size_t* global, size_t* log);

--- a/t/std/fwrite-fread.c
+++ b/t/std/fwrite-fread.c
@@ -13,8 +13,9 @@
  */
 
  /*
-  * Test fwrite/fread/fseek/fgets/rewind/ftell/feof/chmod
+  * Test fwrite/fread/fgets/rewind/feof/chmod
   */
+
 #include <fcntl.h>
 #include <string.h>
 #include <errno.h>
@@ -26,86 +27,176 @@
 
 int fwrite_fread_test(char* unifyfs_root)
 {
+    diag("Starting UNIFYFS_WRAP(fwrite/fread/fgets/feof) tests");
+
     char path[64];
     char buf[64] = {0};
-    FILE* fp = NULL;
-    int rc;
     char* tmp;
+    FILE* fp = NULL;
+    int fd = 0;
 
     errno = 0;
 
     testutil_rand_path(path, sizeof(path), unifyfs_root);
 
+    /* fwrite to bad FILE stream should segfault */
+    dies_ok({ FILE* p = fopen("/tmp/fakefile", "r");
+              fwrite("hello world", 12, 1, p); },
+       "%s:%d fwrite() to bad FILE stream segfaults: %s",
+       __FILE__, __LINE__, strerror(errno));
+
+    /* fread from bad FILE stream should segfault  */
+    dies_ok({ size_t rc = fread(buf, 15, 1, fp); ok(rc > 0); },
+       "%s:%d fread() from bad FILE stream segfaults: %s",
+       __FILE__, __LINE__, strerror(errno));
+
+    /* fgets from bad FILE stream segfaults */
+    memset(buf, 0, sizeof(buf));
+    dies_ok({ char* tmp = fgets(buf, 15, fp); ok(tmp != NULL); },
+       "%s:%d fgets() from bad FILE stream segfaults: %s",
+       __FILE__, __LINE__, strerror(errno));
+
+    dies_ok({ int rc = feof(fp); ok(rc > 0); },
+            "%s:%d feof() on bad FILE stream segfaults: %s",
+            __FILE__, __LINE__, strerror(errno));
+
     /* Write "hello world" to a file */
     fp = fopen(path, "w");
-    ok(fp != NULL, "%s: fopen(%s): %s", __FILE__, path, strerror(errno));
+    ok(fp != NULL, "%s:%d fopen(%s): %s",
+       __FILE__, __LINE__, path, strerror(errno));
+    ok(fwrite("hello world", 12, 1, fp) == 1,
+       "%s:%d fwrite(\"hello world\") to file %s: %s",
+       __FILE__, __LINE__, path, strerror(errno));
 
-    rc = fwrite("hello world", 12, 1, fp);
-    ok(rc == 1, "%s: fwrite(\"hello world\"): %s", __FILE__, strerror(errno));
+    /* Seek to offset and overwrite "world" with "universe" */
+    ok(fseek(fp, 6, SEEK_SET) == 0, "%s:%d fseek(6) to \"world\": %s",
+       __FILE__, __LINE__, strerror(errno));
+    ok(fwrite("universe", 9, 1, fp) == 1,
+       "%s:%d overwrite \"world\" at offset 6 with \"universe\" : %s",
+       __FILE__, __LINE__, strerror(errno));
 
-    rc = fclose(fp);
-    ok(rc == 0, "%s: fclose() (rc=%d): %s", __FILE__, rc, strerror(errno));
+    /* fread from file open as write-only should fail with errno=EBADF */
+    ok(fseek(fp, 0, SEEK_SET) == 0, "%s:%d fseek(0): %s",
+       __FILE__, __LINE__, strerror(errno));
+    ok(fread(buf, 15, 1, fp) == 0 && errno == EBADF,
+       "%s:%d fread() from file open as write-only should fail (errno=%d): %s",
+       __FILE__, __LINE__, errno, strerror(errno));
+    errno = 0; /* reset errno after test for failure */
+
+    ok(fclose(fp) == 0, "%s:%d fclose(): %s",
+       __FILE__, __LINE__, strerror(errno));
+
+    /* fsync() tests */
+    /* fsync on bad file descriptor should fail with errno=EINVAL */
+    ok(fsync(fd) == -1 && errno == EINVAL,
+       "%s:%d fsync() on bad file descriptor should fail (errno=%d): %s",
+       __FILE__, __LINE__, errno, strerror(errno));
+    errno = 0;
 
     /* Sync extents */
-    int fd;
     fd = open(path, O_RDWR);
-    rc = fsync(fd);
-    ok(rc == 0, "%s: fsync() (rc=%d): %s", __FILE__, rc, strerror(errno));
-    close(fd);
+    ok(fd != -1, "%s:%d open() (fd=%d): %s",
+       __FILE__, __LINE__, fd, strerror(errno));
+    ok(fsync(fd) == 0, "%s:%d fsync(): %s",
+       __FILE__, __LINE__, strerror(errno));
+    ok(close(fd) == 0, "%s:%d close(): %s",
+       __FILE__, __LINE__, strerror(errno));
+
+    /* fsync on non-open file should fail with errno=EBADF */
+    ok(fsync(fd) == -1 && errno == EBADF,
+       "%s:%d fsync() on non-open file should fail (errno=%d): %s",
+       __FILE__, __LINE__, errno, strerror(errno));
+    errno = 0;
 
     /* Laminate */
-    rc = chmod(path, 0444);
-    ok(rc == 0, "%s: chmod(0444) (rc=%d): %s", __FILE__, strerror(errno));
+    ok(chmod(path, 0444) == 0, "%s:%d chmod(0444): %s",
+       __FILE__, __LINE__, strerror(errno));
 
-    /* Read it back */
+    /* fopen a laminated file for write should fail with errno=EROFS */
+    fp = fopen(path, "w");
+    ok(fp == NULL && errno == EROFS,
+       "%s:%d fopen laminated file for write fails (errno=%d): %s",
+       __FILE__, __LINE__, errno, strerror(errno));
+    errno = 0;
+
+    /* fread() tests */
     fp = fopen(path, "r");
-    ok(fp != NULL, "%s: fopen(%s): %s", __FILE__, path, strerror(errno));
+    ok(fp != NULL, "%s:%d fopen(%s): %s",
+       __FILE__, __LINE__, path, strerror(errno));
 
-    rc = fread(buf, 12, 1, fp);
-    ok(rc == 1, "%s: fread() buf[]=\"%s\", (rc %d): %s", __FILE__, buf, rc,
-        strerror(errno));
-    is(buf, "hello world", "%s: saw \"hello world\"", __FILE__);
+    /* fwrite to file open as read-only should fail with errno=EBADF */
+    ok(fwrite("hello world", 12, 1, fp) == 0 && errno == EBADF,
+       "%s:%d fwrite() to file open for read-only fails (errno=%d): %s",
+       __FILE__, __LINE__, errno, strerror(errno));
+    errno = 0;
 
-    fseek(fp, 6, SEEK_SET);
-    rc = ftell(fp);
-    ok(rc == 6, "%s: fseek() (rc %d): %s", __FILE__, rc, strerror(errno));
+    ok(fread(buf, 15, 1, fp) == 1, "%s:%d fread() buf[]=\"%s\": %s",
+       __FILE__, __LINE__, buf, strerror(errno));
+    is(buf, "hello universe", "%s:%d fread() saw \"hello universe\"",
+       __FILE__, __LINE__);
 
-    rc = fread(buf, 6, 1, fp);
-    ok(rc == 1, "%s: fread() at offset 6 buf[]=\"%s\", (rc %d): %s", __FILE__,
-        buf, rc, strerror(errno));
-    is(buf, "world", "%s: saw \"world\"", __FILE__);
+    ok(fseek(fp, 6, SEEK_SET) == 0, "%s:%d fseek(6): %s",
+       __FILE__, __LINE__, strerror(errno));
+    ok(fread(buf, 9, 1, fp) == 1, "%s:%d fread() at offset 6 buf[]=\"%s\": %s",
+       __FILE__, __LINE__, buf, strerror(errno));
+    is(buf, "universe", "%s:%d fread() saw \"universe\"", __FILE__, __LINE__);
 
     rewind(fp);
-    rc = fread(buf, 12, 1, fp);
-    ok(rc == 1, "%s: fread() after rewind() buf[]=\"%s\", (rc %d): %s",
-        __FILE__, buf, rc, strerror(errno));
-    is(buf, "hello world", "%s: saw \"hello world\"", __FILE__);
+    ok(fread(buf, 15, 1, fp) == 1,
+       "%s:%d fread() after rewind() buf[]=\"%s\": %s",
+       __FILE__, __LINE__, buf, strerror(errno));
+    is(buf, "hello universe", "%s:%d fread() saw \"hello universe\"",
+       __FILE__, __LINE__);
 
+    /* fgets() tests */
     rewind(fp);
     memset(buf, 0, sizeof(buf));
-    tmp = fgets(buf, 12, fp);
-    ok(tmp == buf, "%s: fgets() after rewind() buf[]=\"%s\": %s", __FILE__, buf,
-        strerror(errno));
-    is(buf, "hello world", "%s: saw \"hello world\"", __FILE__);
+    tmp = fgets(buf, 15, fp);
+    ok(tmp == buf, "%s:%d fgets() after rewind() buf[]=\"%s\": %s",
+       __FILE__, __LINE__, buf, strerror(errno));
+    is(buf, "hello universe", "%s:%d fgets() saw \"hello universe\"",
+       __FILE__, __LINE__);
 
     rewind(fp);
     memset(buf, 0, sizeof(buf));
     tmp = fgets(buf, 6, fp);
-    ok(tmp == buf, "%s: fgets() with size = 6 after rewind() buf[]=\"%s\": %s",
-        __FILE__, buf, strerror(errno));
-    is(buf, "hello", "%s: saw \"hello\"", __FILE__);
+    ok(tmp == buf, "%s:%d fgets() w/ size = 6 after rewind() buf[]=\"%s\": %s",
+        __FILE__, __LINE__, buf, strerror(errno));
+    is(buf, "hello", "%s:%d fgets() saw \"hello\"", __FILE__, __LINE__);
 
     rewind(fp);
-    rc = fread(buf, sizeof(buf), 1, fp);
-    ok(rc != 1, "%s: fread() past end of file (rc %d): %s", __FILE__, rc,
-        strerror(errno));
+    ok(fread(buf, sizeof(buf), 1, fp) != 1, "%s:%d fread() EOF: %s",
+       __FILE__, __LINE__, strerror(errno));
 
-    rc = feof(fp);
-    ok(rc != 0, "%s: feof() past end of file (rc %d): %s", __FILE__, rc,
-        strerror(errno));
+    ok(feof(fp) != 0, "%s:%d feof() past EOF:  %s",
+       __FILE__, __LINE__, strerror(errno));
 
-    rc = fclose(fp);
-    ok(rc == 0, "%s: fclose() (rc=%d): %s", __FILE__, rc, strerror(errno));
+    ok(fclose(fp) == 0, "%s:%d fclose(): %s",
+       __FILE__, __LINE__, strerror(errno));
+
+    /* fwrite to closed stream fails with errno=EBADF */
+    ok(fwrite("hello world", 12, 1, fp) == 0 && errno == EBADF,
+       "%s:%d fwrite() to closed stream fails (errno=%d): %s",
+       __FILE__, __LINE__, errno, strerror(errno));
+    errno = 0;
+
+    /* fread from closed stream fails with errno=EBADF */
+    ok(fread(buf, 15, 1, fp) == 0 && errno == EBADF,
+       "%s:%d fread() from closed stream fails (errno=%d): %s",
+       __FILE__, __LINE__, errno, strerror(errno));
+    errno = 0;
+
+    /* fgets from closed stream fails with errno=EBADF */
+    memset(buf, 0, sizeof(buf));
+    tmp = fgets(buf, 15, fp);
+    ok(errno == EBADF, "%s:%d fgets() from closed stream fails (errno=%d): %s",
+       __FILE__, __LINE__, errno, strerror(errno));
+    errno = 0;
+
+    ok(feof(fp) != 0, "%s:%d feof() on closed stream: %s",
+       __FILE__, __LINE__, strerror(errno));
+
+    diag("Finished UNIFYFS_WRAP(fwrite/fread/fgets/feof) tests");
 
     return 0;
 }

--- a/t/sys/creat-close.c
+++ b/t/sys/creat-close.c
@@ -34,46 +34,41 @@ int creat_close_test(char* unifyfs_root)
     char path[64];
     int mode = 0600;
     int fd = -1;
-    int rc = -1;
+
+    errno = 0;
 
     /* Create a random file name at the mountpoint path to test on */
     testutil_rand_path(path, sizeof(path), unifyfs_root);
 
     /* Verify closing a non-existent file fails with errno=EBADF */
-    errno = 0;
-    rc = close(fd);
-    ok(rc < 0 && errno == EBADF,
-       "close non-existing file %s should fail (rc=%d, errno=%d): %s",
-       path, rc, errno, strerror(errno));
+    ok(close(fd) == -1 && errno == EBADF,
+       "%s:%d close non-existing file %s should fail (errno=%d): %s",
+       __FILE__, __LINE__, path, errno, strerror(errno));
+    errno = 0; /* Reset errno after test for failure */
 
     /* Verify we can create a non-existent file. */
-    errno = 0;
     fd = creat(path, mode);
-    ok(fd >= 0, "creat non-existing file %s (fd=%d): %s",
-       path, fd, strerror(errno));
+    ok(fd >= 0, "%s:%d creat non-existing file %s (fd=%d): %s",
+       __FILE__, __LINE__, path, fd, strerror(errno));
 
     /* Verify close succeeds. */
-    errno = 0;
-    rc = close(fd);
-    ok(rc == 0, "close new file %s (rc=%d): %s", path, rc, strerror(errno));
+    ok(close(fd) == 0, "%s:%d close new file: %s",
+       __FILE__, __LINE__, strerror(errno));
 
     /* Verify creating an already created file succeeds. */
-    errno = 0;
     fd = creat(path, mode);
-    ok(fd >= 0, "creat existing file %s (fd=%d): %s",
-       path, fd, strerror(errno));
+    ok(fd >= 0, "%s:%d creat existing file %s (fd=%d): %s",
+       __FILE__, __LINE__, path, fd, strerror(errno));
 
     /* Verify close succeeds. */
-    errno = 0;
-    rc = close(fd);
-    ok(rc == 0, "close %s (rc=%d): %s", path, rc, strerror(errno));
+    ok(close(fd) == 0, "%s:%d close %s: %s",
+       __FILE__, __LINE__, path, strerror(errno));
 
     /* Verify closing already closed file fails with errno=EBADF */
+    ok(close(fd) == -1 && errno == EBADF,
+       "%s:%d close already closed file %s should fail (errno=%d): %s",
+       __FILE__, __LINE__, path, errno, strerror(errno));
     errno = 0;
-    rc = close(fd);
-    ok(rc < 0 && errno == EBADF,
-       "close already closed file %s should fail (rc=%d, errno=%d): %s",
-       path, rc, errno, strerror(errno));
 
     /* CLEANUP
      *

--- a/t/sys/lseek.c
+++ b/t/sys/lseek.c
@@ -36,184 +36,159 @@ int lseek_test(char* unifyfs_root)
 
     char path[64];
     int file_mode = 0600;
-    int fd;
-    off_t ret;
+    int fd = -1;
+
+    errno = 0;
 
     /* Create a random file at the mountpoint path to test on */
     testutil_rand_path(path, sizeof(path), unifyfs_root);
 
+    /* lseek in bad file descriptor should fail with errno=EBADF */
+    ok(lseek(fd, 0, SEEK_SET) == -1 && errno == EBADF,
+       "%s:%d lseek in bad file descriptor fails (errno=%d): %s",
+       __FILE__, __LINE__, errno, strerror(errno));
+    errno = 0; /* reset errno after test for failure */
+
     /* Open a file and write to it to test lseek() */
     fd = open(path, O_RDWR | O_CREAT | O_TRUNC, file_mode);
-
-    ret = write(fd, "hello world", 12);
-    ok(ret == 12, "%s: write works (ret=%d): %s",
-        __FILE__, ret, strerror(errno));
+    ok(fd >= 0, "%s:%d open worked: %s", __FILE__, __LINE__, strerror(errno));
+    ok(write(fd, "hello world", 12) == 12, "%s:%d write worked: %s",
+        __FILE__, __LINE__, strerror(errno));
 
     /* lseek with invalid whence fails with errno=EINVAL. */
+    ok(lseek(fd, 0, -1) == -1 && errno == EINVAL,
+       "%s:%d lseek with invalid whence should fail (errno=%d): %s",
+       __FILE__, __LINE__, errno, strerror(errno));
     errno = 0;
-    ret = lseek(fd, 0, -1);
-    ok(ret == -1 && errno == EINVAL,
-       "%s: lseek with invalid whence should fail (ret=%d, errno=%d): %s",
-       __FILE__, ret, errno, strerror(errno));
 
     /* lseek() with SEEK_SET tests */
     /* lseek to negative offset with SEEK_SET should fail with errno=EINVAL */
+    ok(lseek(fd, -1, SEEK_SET) == -1 && errno == EINVAL,
+       "%s:%d lseek(-1) to invalid offset w/ SEEK_SET fails (errno=%d): %s",
+       __FILE__, __LINE__, errno, strerror(errno));
     errno = 0;
-    ret = lseek(fd, -1, SEEK_SET);
-    ok(ret == -1 && errno == EINVAL,
-       "%s: lseek to negative offset w/ SEEK_SET fails (ret=%d, errno=%d): %s",
-       __FILE__, ret, errno, strerror(errno));
 
     /* lseek to valid offset with SEEK_SET succeeds */
-    errno = 0;
-    ret = lseek(fd, 7, SEEK_SET);
-    ok(ret == 7, "%s: lseek to valid offset w/ SEEK_SET (ret=%d): %s",
-       __FILE__, ret, strerror(errno));
+    ok(lseek(fd, 7, SEEK_SET) == 7,
+       "%s:%d lseek(7) to valid offset w/ SEEK_SET: %s",
+       __FILE__, __LINE__, strerror(errno));
 
     /* lseek beyond end of file with SEEK_SET succeeds */
-    errno = 0;
-    ret = lseek(fd, 25, SEEK_SET);
-    ok(ret == 25, "%s: lseek beyond end of file w/ SEEK_SET (ret=%d): %s",
-       __FILE__, ret, strerror(errno));
+    ok(lseek(fd, 25, SEEK_SET) == 25,
+       "%s:%d lseek(25) beyond EOF w/ SEEK_SET: %s",
+       __FILE__, __LINE__, strerror(errno));
 
     /* lseek to beginning of file with SEEK_SET succeeds */
-    errno = 0;
-    ret = lseek(fd, 0, SEEK_SET);
-    ok(ret == 0, "%s: lseek to beginning of file w/ SEEK_SET (ret=%d): %s",
-       __FILE__, ret, strerror(errno));
+    ok(lseek(fd, 0, SEEK_SET) == 0, "%s:%d lseek(0) w/ SEEK_SET: %s",
+       __FILE__, __LINE__, strerror(errno));
 
     /* lseek() with SEEK_CUR tests */
     /* lseek to end of file with SEEK_CUR succeeds */
-    errno = 0;
-    ret = lseek(fd, 12, SEEK_CUR);
-    ok(ret == 12, "%s: lseek to end of file w/ SEEK_CUR (ret=%d): %s",
-       __FILE__, ret, strerror(errno));
+    ok(lseek(fd, 12, SEEK_CUR) == 12, "%s:%d lseek(12) to EOF w/ SEEK_CUR: %s",
+       __FILE__, __LINE__, strerror(errno));
 
     /* lseek to negative offset with SEEK_CUR should fail with errno=EINVAL */
+    ok(lseek(fd, -15, SEEK_CUR) == -1 && errno == EINVAL,
+       "%s:%d lseek(-15) to invalid offset w/ SEEK_CUR fails (errno=%d): %s",
+       __FILE__, __LINE__, errno, strerror(errno));
     errno = 0;
-    ret = lseek(fd, -15, SEEK_CUR);
-    ok(ret == -1 && errno == EINVAL,
-       "%s: lseek to negative offset w/ SEEK_CUR fails (ret=%d, errno=%d): %s",
-       __FILE__, ret, errno, strerror(errno));
 
     /* lseek to beginning of file with SEEK_CUR succeeds */
-    errno = 0;
-    ret = lseek(fd, -12, SEEK_CUR);
-    ok(ret == 0, "%s: lseek to beginning of file w/ SEEK_CUR (ret=%d): %s",
-       __FILE__, ret, strerror(errno));
+    ok(lseek(fd, -12, SEEK_CUR) == 0,
+       "%s:%d lseek(-12) to beginning of file w/ SEEK_CUR: %s",
+       __FILE__, __LINE__, strerror(errno));
 
     /* lseek beyond end of file with SEEK_CUR succeeds */
-    errno = 0;
-    ret = lseek(fd, 25, SEEK_CUR);
-    ok(ret == 25, "%s: lseek beyond end of file w/ SEEK_CUR (ret=%d): %s",
-       __FILE__, ret, strerror(errno));
+    ok(lseek(fd, 25, SEEK_CUR) == 25,
+       "%s:%d lseek(25) beyond EOF w/ SEEK_CUR: %s",
+       __FILE__, __LINE__, strerror(errno));
 
     /* lseek() with SEEK_END tests */
     /* lseek to negative offset with SEEK_END should fail with errno=EINVAL */
+    ok(lseek(fd, -15, SEEK_END) == -1 && errno == EINVAL,
+       "%s:%d lseek(-15) to invalid offset w/ SEEK_END fails (errno=%d): %s",
+       __FILE__, __LINE__, errno, strerror(errno));
     errno = 0;
-    ret = lseek(fd, -15, SEEK_END);
-    ok(ret == -1 && errno == EINVAL,
-       "%s: lseek to negative offset w/ SEEK_END fails (ret=%d, errno=%d): %s",
-       __FILE__, ret, errno, strerror(errno));
 
     /* lseek back one from end of file with SEEK_END succeeds */
-    errno = 0;
-    ret = lseek(fd, -1, SEEK_END);
-    ok(ret == 11,
-       "%s: lseek back one from end of file w/ SEEK_END (ret=%d): %s",
-       __FILE__, ret, strerror(errno));
+    ok(lseek(fd, -1, SEEK_END) == 11,
+       "%s:%d lseek(-1) from EOF w/ SEEK_END: %s",
+       __FILE__, __LINE__, strerror(errno));
 
     /* lseek to beginning of file with SEEK_END succeeds */
-    errno = 0;
-    ret = lseek(fd, -12, SEEK_END);
-    ok(ret == 0, "%s: lseek to beginning of file w/ SEEK_END (ret=%d): %s",
-       __FILE__, ret, strerror(errno));
+    ok(lseek(fd, -12, SEEK_END) == 0,
+       "%s:%d lseek(-12) to beginning of file w/ SEEK_END: %s",
+       __FILE__, __LINE__, strerror(errno));
 
     /* lseek beyond end of file with SEEK_END succeeds */
-    errno = 0;
-    ret = lseek(fd, 25, SEEK_END);
-    ok(ret == 37, "%s: lseek beyond end of file w/ SEEK_END (ret=%d): %s",
-       __FILE__, ret, strerror(errno));
+    ok(lseek(fd, 25, SEEK_END) == 37,
+       "%s:%d lseek(25) beyond EOF w/ SEEK_END: %s",
+       __FILE__, __LINE__, strerror(errno));
 
     /* lseek() with SEEK_DATA tests */
     /* Write beyond end of file to create a hole */
-    ret = write(fd, "hello universe", 15);
-    ok(ret == 15, "%s: write works (ret=%d): %s",
-        __FILE__, ret, strerror(errno));
+    ok(write(fd, "hello universe", 15) == 15, "%s:%d write to create hole: %s",
+        __FILE__, __LINE__, strerror(errno));
 
     /* lseek to negative offset with SEEK_DATA should fail with errno=ENXIO */
+    ok(lseek(fd, -1, SEEK_DATA) == -1 && errno == ENXIO,
+       "%s:%d lseek(-1) to invalid offset w/ SEEK_DATA fails (errno=%d): %s",
+       __FILE__, __LINE__, errno, strerror(errno));
     errno = 0;
-    ret = lseek(fd, -1, SEEK_DATA);
-    ok(ret == -1 && errno == ENXIO,
-       "%s: lseek to negative offset w/ SEEK_DATA fails (ret=%d, errno=%d): %s",
-       __FILE__, ret, errno, strerror(errno));
 
     /* lseek to beginning of file with SEEK_DATA succeeds */
-    errno = 0;
-    ret = lseek(fd, 0, SEEK_DATA);
-    ok(ret == 0, "%s: lseek to beginning of file w/ SEEK_DATA (ret=%d): %s",
-       __FILE__, ret, strerror(errno));
+    ok(lseek(fd, 0, SEEK_DATA) == 0, "%s:%d lseek(0) w/ SEEK_DATA: %s",
+       __FILE__, __LINE__, strerror(errno));
 
-    /* lseek to data after hole with SEEK_DATA returns current offset or offset
-     * of first set of data */
-    errno = 0;
-    ret = lseek(fd, 15, SEEK_DATA);
-    ok(ret == 15 || ret == 37,
-       "%s: lseek to data after hole w/ SEEK_DATA (ret=%d): %s",
-       __FILE__, ret, strerror(errno));
+    /* Fallback implementation: lseek to data after hole with SEEK_DATA returns
+     * current offset */
+    ok(lseek(fd, 15, SEEK_DATA) == 15,
+       "%s:%d lseek(15) to data after hole w/ SEEK_DATA returns offset: %s",
+       __FILE__, __LINE__, strerror(errno));
 
     /* lseek beyond end of file with SEEK_DATA should fail with errno=ENXIO */
+    ok(lseek(fd, 75, SEEK_DATA) == -1 && errno == ENXIO,
+       "%s:%d lseek(75) beyond EOF w/ SEEK_DATA fails (errno=%d): %s",
+       __FILE__, __LINE__, errno, strerror(errno));
     errno = 0;
-    ret = lseek(fd, 75, SEEK_DATA);
-    ok(ret == -1 && errno == ENXIO,
-       "%s: lseek beyond end of file w/ SEEK_DATA fails (ret=%d, errno=%d): %s",
-       __FILE__, ret, errno, strerror(errno));
 
     /* lseek() with SEEK_HOLE tests */
-
     /* lseek to negative offset with SEEK_HOLE should fail with errno=ENXIO */
+    ok(lseek(fd, -1, SEEK_HOLE) == -1 && errno == ENXIO,
+       "%s:%d lseek(-1) to invalid offset w/ SEEK_HOLE fails (errno=%d): %s",
+       __FILE__, __LINE__, errno, strerror(errno));
     errno = 0;
-    ret = lseek(fd, -1, SEEK_HOLE);
-    ok(ret == -1 && errno == ENXIO,
-       "%s: lseek to negative offset w/ SEEK_HOLE fails (ret=%d, errno=%d): %s",
-       __FILE__, ret, errno, strerror(errno));
 
-    /* lseek to first hole of file with SEEK_HOLE succeeds returns start of hole
-     * or EOF */
-    errno = 0;
-    ret = lseek(fd, 0, SEEK_HOLE);
-    ok(ret == 12 || ret == 52,
-       "%s: lseek to first hole in file w/ SEEK_HOLE (ret=%d): %s",
-       __FILE__, ret, strerror(errno));
+    /* Fallback implementation: lseek to first hole of file with SEEK_HOLE
+     * returns or EOF */
+    ok(lseek(fd, 0, SEEK_HOLE) == 52,
+       "%s:%d lseek(0) to first hole in file w/ SEEK_HOLE returns EOF: %s",
+       __FILE__, __LINE__, strerror(errno));
 
-    /* lseek to middle of hole with SEEK_HOLE returns position in hole or EOF */
-    errno = 0;
-    ret = lseek(fd, 18, SEEK_HOLE);
-    ok(ret == 18 || ret == 52,
-       "%s: lseek to middle of hole w/ SEEK_HOLE (ret=%d): %s",
-       __FILE__, ret, strerror(errno));
+    /* Fallback implementation: lseek to middle of hole with SEEK_HOLE returns
+     * EOF */
+    ok(lseek(fd, 18, SEEK_HOLE) == 52,
+       "%s:%d lseek(18) to middle of hole w/ SEEK_HOLE returns EOF: %s",
+       __FILE__, __LINE__, strerror(errno));
 
     /* lseek to end of file with SEEK_HOLE succeeds */
-    errno = 0;
-    ret = lseek(fd, 42, SEEK_HOLE);
-    ok(ret == 52, "%s: lseek to end of file w/ SEEK_HOLE (ret=%d): %s",
-       __FILE__, ret, strerror(errno));
+    ok(lseek(fd, 42, SEEK_HOLE) == 52,
+       "%s:%d lseek(42) to EOF w/ SEEK_HOLE: %s",
+       __FILE__, __LINE__, strerror(errno));
 
     /* lseek beyond end of file with SEEK_HOLE should fail with errno= ENXIO */
+    ok(lseek(fd, 75, SEEK_HOLE) == -1 && errno == ENXIO,
+       "%s:%d lseek beyond EOF w/ SEEK_HOLE fails (errno=%d): %s",
+       __FILE__, __LINE__, errno, strerror(errno));
     errno = 0;
-    ret = lseek(fd, 75, SEEK_HOLE);
-    ok(ret == -1 && errno == ENXIO,
-       "%s: lseek beyond end of file w/ SEEK_HOLE fails (ret=%d, errno=%d): %s",
-       __FILE__, ret, errno, strerror(errno));
 
     close(fd);
 
     /* lseek in non-open file descriptor should fail with errno=EBADF */
+    ok(lseek(fd, 0, SEEK_SET) == -1 && errno == EBADF,
+       "%s:%d lseek in non-open file descriptor fails (errno=%d): %s",
+       __FILE__, __LINE__, errno, strerror(errno));
     errno = 0;
-    ret = lseek(fd, 0, SEEK_SET);
-    ok(ret == -1 && errno == EBADF,
-       "%s: lseek in non-open file descriptor fails (ret=%d, errno=%d): %s",
-       __FILE__, ret, errno, strerror(errno));
 
     diag("Finished UNIFYFS_WRAP(lseek) tests");
 

--- a/t/sys/mkdir-rmdir.c
+++ b/t/sys/mkdir-rmdir.c
@@ -39,7 +39,8 @@ int mkdir_rmdir_test(char* unifyfs_root)
     int file_mode = 0600;
     int dir_mode = 0700;
     int fd;
-    int rc;
+
+    errno = 0;
 
     /* Create random dir and file path names at the mountpoint to test on */
     testutil_rand_path(dir_path, sizeof(dir_path), unifyfs_root);
@@ -64,115 +65,103 @@ int mkdir_rmdir_test(char* unifyfs_root)
 
     /* todo_mkdir_1: Remove when issue is resolved */
     todo("mkdir_1: we currently don't support directory structure");
-    /* Verify we cannot create a dir whose parent dir doesn't exist with
+    /* Verify creating a dir under non-existent parent dir fails with
      * errno=ENOENT */
-    errno = 0;
-    rc = mkdir(subdir_path, dir_mode);
-    ok(rc < 0 && errno == ENOENT,
-       "mkdir dir %s without parent dir should fail (rc=%d, errno=%d): %s",
-       subdir_path, rc, errno, strerror(errno));
-
+    ok(mkdir(subdir_path, dir_mode) == -1 && errno == ENOENT,
+       "%s:%d mkdir dir %s without parent dir should fail (errno=%d): %s",
+       __FILE__, __LINE__, subdir_path, errno, strerror(errno));
     end_todo; /* end todo_mkdir_1 */
+    errno = 0; /* Reset errno after test for failure */
 
     /* Verify rmdir a non-existing directory fails with errno=ENOENT */
+    ok(rmdir(dir_path) == -1 && errno == ENOENT,
+       "%s:%d rmdir non-existing dir %s should fail (errno=%d): %s",
+       __FILE__, __LINE__, dir_path, errno, strerror(errno));
     errno = 0;
-    rc = rmdir(dir_path);
-    ok(rc < 0 && errno == ENOENT,
-       "rmdir non-existing dir %s should fail (rc=%d, errno=%d): %s",
-       dir_path, rc, errno, strerror(errno));
 
     /* Verify we can create a non-existent directory. */
-    errno = 0;
-    rc = mkdir(dir_path, dir_mode);
-    ok(rc == 0, "mkdir non-existing dir %s (rc=%d): %s",
-       dir_path, rc, strerror(errno));
+    ok(mkdir(dir_path, dir_mode) == 0, "%s:%d mkdir non-existing dir %s: %s",
+       __FILE__, __LINE__, dir_path, strerror(errno));
 
-    /* Verify we cannot recreate an already created directory with
-     * errno=EEXIST */
+    /* Verify recreating an already created directory fails with errno=EEXIST */
+    ok(mkdir(dir_path, dir_mode) == -1 && errno == EEXIST,
+       "%s:%d mkdir existing dir %s should fail (errno=%d): %s",
+       __FILE__, __LINE__, dir_path, errno, strerror(errno));
     errno = 0;
-    rc = mkdir(dir_path, dir_mode);
-    ok(rc < 0 && errno == EEXIST,
-       "mkdir existing dir %s should fail (rc=%d, errno=%d): %s",
-       dir_path, rc, errno, strerror(errno));
 
     /* todo_mkdir_2: Remove when issue is resolved */
     todo("mkdir_2: should fail with errno=EISDIR=21");
-    /* Verify we cannot create a file with same name as a directory with
-     * errno=EISDIR */
-    errno = 0;
+    /* Verify creating a file with same name as a dir fails with errno=EISDIR */
     fd = creat(dir_path, file_mode);
-    ok(fd < 0 && errno == EISDIR,
-       "creat file with same name as dir %s should fail (fd=%d, errno=%d): %s",
-       dir_path, fd, errno, strerror(errno));
+    ok(fd == -1 && errno == EISDIR,
+       "%s:%d creat file with same name as dir %s fails (fd=%d, errno=%d): %s",
+       __FILE__, __LINE__, dir_path, fd, errno, strerror(errno));
     end_todo; /* end todo_mkdir_2 */
+    errno = 0;
 
     /* todo_mkdir_3: Remove when issue is resolved */
     todo("mkdir_3: this fails because \"TODO mkdir_1\" is failing");
     /* Verify we can create a subdirectory under an existing directory  */
-    errno = 0;
-    rc = mkdir(subdir_path, dir_mode);
-    ok(rc == 0, "mkdir subdirectory %s in existing dir (rc=%d): %s",
-       subdir_path, rc, strerror(errno));
+    ok(mkdir(subdir_path, dir_mode) == 0,
+       "%s:%d mkdir subdirectory %s in existing dir: %s",
+       __FILE__, __LINE__, subdir_path, strerror(errno));
     end_todo; /* end todo_mkdir_3 */
+    errno = 0; /* can remove when test is passing */
 
     /* Verify we can create a subfile under an existing directory */
-    errno = 0;
     fd = creat(subfile_path, file_mode);
-    ok(fd > 0, "creat subfile %s in existing dir (fd=%d): %s",
-       subfile_path, fd, strerror(errno));
+    ok(fd >= 0, "%s:%d creat subfile %s in existing dir (fd=%d): %s",
+       __FILE__, __LINE__, subfile_path, fd, strerror(errno));
 
-    rc = close(fd);
+    ok(close(fd) == 0, "%s:%d close() worked: %s",
+       __FILE__, __LINE__, strerror(errno));
 
-    /* todo_mkdir_4: Remove when issue is resolved */
-    todo("mkdir_4: unifyfs currently creates all paths as separate entities");
     /* Verify creating a directory whose parent is a file fails with
      * errno=ENOTDIR */
     fd = creat(file_path, file_mode);
-    rc = close(fd);
+    ok(fd >= 0, "%s:%d creat parent file %s (fd=%d): %s",
+       __FILE__, __LINE__, file_path, fd, strerror(errno));
+    ok(close(fd) == 0, "%s:%d close() worked: %s",
+       __FILE__, __LINE__, strerror(errno));
 
-    errno = 0;
-    rc = mkdir(file_subdir_path, dir_mode);
-    ok(rc < 0 && errno == ENOTDIR,
-       "mkdir dir %s whose parent is a file should fail (rc=%d, errno=%d): %s",
-       file_subdir_path, rc, errno, strerror(errno));
+    /* todo_mkdir_4: Remove when issue is resolved */
+    todo("mkdir_4: unifyfs currently creates all paths as separate entities");
+    ok(mkdir(file_subdir_path, dir_mode) == -1 && errno == ENOTDIR,
+       "%s:%d mkdir dir %s where parent is a file should fail (errno=%d): %s",
+       __FILE__, __LINE__, file_subdir_path, errno, strerror(errno));
     end_todo; /* end todo_mkdir_4 */
+    errno = 0;
 
     /* Verify rmdir a non-directory fails with errno=ENOENT */
+    ok(rmdir(file_path) == -1 && errno == ENOTDIR,
+       "%s:%d rmdir non-directory %s should fail (errno=%d): %s",
+       __FILE__, __LINE__, file_path, errno, strerror(errno));
     errno = 0;
-    rc = rmdir(file_path);
-    ok(rc < 0 && errno == ENOTDIR,
-       "rmdir non-directory %s should fail (rc=%d, errno=%d): %s",
-       file_path, rc, errno, strerror(errno));
 
     /* todo_mkdir_5: Remove when issue is resolved */
     todo("mkdir_5: unifyfs currently creates all paths as separate entities");
     /* Verify rmdir a non-empty directory fails with errno=ENOTEMPTY */
-    errno = 0;
-    rc = rmdir(dir_path);
-    ok(rc < 0 && errno == ENOTEMPTY,
-       "rmdir non-empty directory %s should fail (rc=%d, errno=%d): %s",
-       dir_path, rc, errno, strerror(errno));
+    ok(rmdir(dir_path) == -1 && errno == ENOTEMPTY,
+       "%s:%d rmdir non-empty directory %s should fail (errno=%d): %s",
+       __FILE__, __LINE__, dir_path, errno, strerror(errno));
     end_todo; /* end todo_mkdir_5 */
+    errno = 0;
 
     /* Verify we can rmdir an empty directory */
-    errno = 0;
-    rc = rmdir(subdir_path);
-    ok(rc == 0, "rmdir an empty directory %s (rc=%d): %s",
-       subdir_path, rc, strerror(errno));
+    ok(rmdir(subdir_path) == 0, "%s:%d rmdir an empty directory %s: %s",
+       __FILE__, __LINE__, subdir_path, strerror(errno));
 
     /* Verify rmdir an already removed directory fails with errno=ENOENT */
+    ok(rmdir(subdir_path) == -1 && errno == ENOENT,
+       "%s:%d rmdir already removed dir %s should fail (errno=%d): %s",
+       __FILE__, __LINE__, subdir_path, errno, strerror(errno));
     errno = 0;
-    rc = rmdir(subdir_path);
-    ok(rc < 0 && errno == ENOENT,
-       "rmdir already removed dir %s should fail (rc=%d, errno=%d): %s",
-       subdir_path, rc, errno, strerror(errno));
 
     /* Verify trying to rmdir the mount point fails with errno=EBUSY */
+    ok(rmdir(unifyfs_root) == -1 && errno == EBUSY,
+       "%s:%d rmdir mount point %s should fail (errno=%d): %s",
+       __FILE__, __LINE__, unifyfs_root, errno, strerror(errno));
     errno = 0;
-    rc = rmdir(unifyfs_root);
-    ok(rc < 0 && errno == EBUSY,
-       "rmdir mount point %s should fail (rc=%d, errno=%d): %s",
-       unifyfs_root, rc, errno, strerror(errno));
 
     /* CLEANUP
      *

--- a/t/sys/truncate.c
+++ b/t/sys/truncate.c
@@ -20,30 +20,8 @@
 #include <errno.h>
 #include <linux/limits.h>
 #include <stdio.h>
-#include <sys/stat.h>
 #include "t/lib/tap.h"
 #include "t/lib/testutil.h"
-
-/* Get global or log sizes (or all) */
-static
-void get_size(char* path, size_t* global, size_t* log)
-{
-    struct stat sb = {0};
-    int rc;
-
-    rc = stat(path, &sb);
-    if (rc != 0) {
-        printf("Error: %s\n", strerror(errno));
-        exit(1);    /* die on failure */
-    }
-    if (global) {
-        *global = sb.st_size;
-    }
-
-    if (log) {
-        *log = sb.st_rdev;
-    }
-}
 
 int truncate_test(char* unifyfs_root)
 {
@@ -63,7 +41,7 @@ int truncate_test(char* unifyfs_root)
         __FILE__, __LINE__, path, fd, strerror(errno));
 
     /* file should be 0 bytes at this point */
-    get_size(path, &global, &log);
+    testutil_get_size(path, &global, &log);
     ok(global == 0, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, 0);
     ok(log == 0, "%s:%d log size is %d expected %d",
@@ -78,7 +56,7 @@ int truncate_test(char* unifyfs_root)
     ok(rc == 0, "%s:%d fsync() (rc=%d): %s",
         __FILE__, __LINE__, rc, strerror(errno));
 
-    get_size(path, &global, &log);
+    testutil_get_size(path, &global, &log);
     ok(global == 1*bufsize, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, 1*bufsize);
     ok(log == 1*bufsize, "%s:%d log size is %d expected %d",
@@ -97,7 +75,7 @@ int truncate_test(char* unifyfs_root)
     ok(rc == 0, "%s:%d fsync() (rc=%d): %s",
         __FILE__, __LINE__, rc, strerror(errno));
 
-    get_size(path, &global, &log);
+    testutil_get_size(path, &global, &log);
     ok(global == 3*bufsize, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, 3*bufsize);
     ok(log == 2*bufsize, "%s:%d log size is %d expected %d",
@@ -108,7 +86,7 @@ int truncate_test(char* unifyfs_root)
     ok(rc == 0, "%s:%d ftruncate(%d) (rc=%d): %s",
         __FILE__, __LINE__, 5*bufsize, rc, strerror(errno));
 
-    get_size(path, &global, &log);
+    testutil_get_size(path, &global, &log);
     ok(global == 5*bufsize, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, 5*bufsize);
     ok(log == 2*bufsize, "%s:%d log size is %d expected %d",
@@ -121,7 +99,7 @@ int truncate_test(char* unifyfs_root)
     ok(rc == 0, "%s:%d truncate(%d) (rc=%d): %s",
         __FILE__, __LINE__, bufsize/2, rc, strerror(errno));
 
-    get_size(path, &global, &log);
+    testutil_get_size(path, &global, &log);
     ok(global == bufsize/2, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, bufsize/2);
     ok(log == 2*bufsize, "%s:%d log size is %d expected %d",
@@ -132,7 +110,7 @@ int truncate_test(char* unifyfs_root)
     ok(rc == 0, "%s:%d truncate(%d) (rc=%d): %s",
         __FILE__, __LINE__, 0, rc, strerror(errno));
 
-    get_size(path, &global, &log);
+    testutil_get_size(path, &global, &log);
     ok(global == 0, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, 0);
     ok(log == 2*bufsize, "%s:%d log size is %d expected %d",
@@ -160,7 +138,7 @@ int truncate_bigempty(char* unifyfs_root)
     ok(fd != -1, "%s:%d open(%s) (fd=%d): %s",
         __FILE__, __LINE__, path, fd, strerror(errno));
 
-    get_size(path, &global, &log);
+    testutil_get_size(path, &global, &log);
     ok(global == 0, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, 0);
     ok(log == 0, "%s:%d log size is %d expected %d",
@@ -173,7 +151,7 @@ int truncate_bigempty(char* unifyfs_root)
         __FILE__, __LINE__, (unsigned long long) bigempty,
         rc, strerror(errno));
 
-    get_size(path, &global, &log);
+    testutil_get_size(path, &global, &log);
     ok(global == (size_t)bigempty, "%s:%d global size is %llu expected %llu",
         __FILE__, __LINE__, global, (unsigned long long)bigempty,
         strerror(errno));
@@ -203,7 +181,7 @@ int truncate_eof(char* unifyfs_root)
         __FILE__, __LINE__, path, fd, strerror(errno));
 
     /* file should be 0 bytes at this point */
-    get_size(path, &global, &log);
+    testutil_get_size(path, &global, &log);
     ok(global == 0, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, 0);
     ok(log == 0, "%s:%d log size is %d expected %d",
@@ -282,7 +260,7 @@ int truncate_truncsync(char* unifyfs_root)
         __FILE__, __LINE__, path, fd, strerror(errno));
 
     /* file should be 0 bytes at this point */
-    get_size(path, &global, &log);
+    testutil_get_size(path, &global, &log);
     ok(global == 0, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, 0);
     ok(log == 0, "%s:%d log size is %d expected %d",
@@ -299,7 +277,7 @@ int truncate_truncsync(char* unifyfs_root)
         __FILE__, __LINE__, bufsize/2, rc, strerror(errno));
 
     /* file should be 0.5MB bytes at this point */
-    get_size(path, &global, &log);
+    testutil_get_size(path, &global, &log);
     ok(global == bufsize/2, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, bufsize/2);
     ok(log == bufsize, "%s:%d log size is %d expected %d",
@@ -310,7 +288,7 @@ int truncate_truncsync(char* unifyfs_root)
         __FILE__, __LINE__, rc, strerror(errno));
 
     /* file should still be 0.5MB bytes at this point */
-    get_size(path, &global, &log);
+    testutil_get_size(path, &global, &log);
     ok(global == bufsize/2, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, bufsize/2);
     ok(log == bufsize, "%s:%d log size is %d expected %d",
@@ -380,7 +358,7 @@ int truncate_pattern_size(char* unifyfs_root, off_t seekpos)
         __FILE__, __LINE__, path, fd, strerror(errno));
 
     /* file should be 0 bytes at this point */
-    get_size(path, &global, &log);
+    testutil_get_size(path, &global, &log);
     ok(global == 0, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, 0);
     ok(log == 0, "%s:%d log size is %d expected %d",
@@ -410,7 +388,7 @@ int truncate_pattern_size(char* unifyfs_root, off_t seekpos)
         __FILE__, __LINE__, (int)truncsize, rc, strerror(errno));
 
     /* file should be of size 5MB + 42 at this point */
-    get_size(path, &global, &log);
+    testutil_get_size(path, &global, &log);
     ok(global == truncsize, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, (int)truncsize);
     ok(log == 20*bufsize, "%s:%d log size is %d expected %d",
@@ -424,7 +402,7 @@ int truncate_pattern_size(char* unifyfs_root, off_t seekpos)
         __FILE__, __LINE__, rc, strerror(errno));
 
     /* file should still be 5MB + 42 bytes at this point */
-    get_size(path, &global, &log);
+    testutil_get_size(path, &global, &log);
     ok(global == truncsize, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, (int)truncsize);
     ok(log == 20*bufsize, "%s:%d log size is %d expected %d",
@@ -521,7 +499,7 @@ int truncate_empty_read(char* unifyfs_root, off_t seekpos)
         __FILE__, __LINE__, path, fd, strerror(errno));
 
     /* file should be 0 bytes at this point */
-    get_size(path, &global, &log);
+    testutil_get_size(path, &global, &log);
     ok(global == 0, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, 0);
     ok(log == 0, "%s:%d log size is %d expected %d",
@@ -536,7 +514,7 @@ int truncate_empty_read(char* unifyfs_root, off_t seekpos)
         __FILE__, __LINE__, (int)truncsize, rc, strerror(errno));
 
     /* file should be of size 5MB + 42 at this point */
-    get_size(path, &global, &log);
+    testutil_get_size(path, &global, &log);
     ok(global == truncsize, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, (int)truncsize);
     ok(log == 0, "%s:%d log size is %d expected %d",
@@ -550,7 +528,7 @@ int truncate_empty_read(char* unifyfs_root, off_t seekpos)
         __FILE__, __LINE__, rc, strerror(errno));
 
     /* file should still be 5MB + 42 bytes at this point */
-    get_size(path, &global, &log);
+    testutil_get_size(path, &global, &log);
     ok(global == truncsize, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, (int)truncsize);
     ok(log == 0, "%s:%d log size is %d expected %d",
@@ -645,7 +623,7 @@ int truncate_ftrunc_before_sync(char* unifyfs_root)
         __FILE__, __LINE__, path, fd, strerror(errno));
 
     /* file should be 0 bytes at this point */
-    get_size(path, &global, &log);
+    testutil_get_size(path, &global, &log);
     ok(global == 0, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, 0);
     ok(log == 0, "%s:%d log size is %d expected %d",
@@ -673,7 +651,7 @@ int truncate_ftrunc_before_sync(char* unifyfs_root)
     /* finally, check that the file is 0 bytes,
      * i.e., check that the writes happened before the truncate
      * and not at the fsync */
-    get_size(path, &global, &log);
+    testutil_get_size(path, &global, &log);
     ok(global == truncsize, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, (int)truncsize);
     ok(log == bufsize, "%s:%d log size is %d expected %d",
@@ -704,7 +682,7 @@ int truncate_trunc_before_sync(char* unifyfs_root)
         __FILE__, __LINE__, path, fd, strerror(errno));
 
     /* file should be 0 bytes at this point */
-    get_size(path, &global, &log);
+    testutil_get_size(path, &global, &log);
     ok(global == 0, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, 0);
     ok(log == 0, "%s:%d log size is %d expected %d",
@@ -732,7 +710,7 @@ int truncate_trunc_before_sync(char* unifyfs_root)
     /* finally, check that the file is 0 bytes,
      * i.e., check that the writes happened before the truncate
      * and not at the fsync */
-    get_size(path, &global, &log);
+    testutil_get_size(path, &global, &log);
     ok(global == truncsize, "%s:%d global size is %d expected %d",
         __FILE__, __LINE__, global, (int)truncsize);
     ok(log == bufsize, "%s:%d log size is %d expected %d",

--- a/t/sys/write-read-hole.c
+++ b/t/sys/write-read-hole.c
@@ -23,27 +23,6 @@
 #include "t/lib/tap.h"
 #include "t/lib/testutil.h"
 
-/* Get global or log sizes (or all) */
-static
-void get_size(char* path, size_t* global, size_t* log)
-{
-    struct stat sb = {0};
-    int rc;
-
-    rc = stat(path, &sb);
-    if (rc != 0) {
-        printf("Error: %s\n", strerror(errno));
-        exit(1);    /* die on failure */
-    }
-    if (global) {
-        *global = sb.st_size;
-    }
-
-    if (log) {
-        *log = sb.st_rdev;
-    }
-}
-
 static int check_contents(char* buf, size_t len, char c)
 {
     int valid = 1;
@@ -99,7 +78,7 @@ int write_read_hole_test(char* unifyfs_root)
         __FILE__, __LINE__, rc, strerror(errno));
 
     /* Check global size on our un-laminated file */
-    get_size(path, &global, &log);
+    testutil_get_size(path, &global, &log);
     ok(global == 0, "%s:%d global size is %d: %s",
         __FILE__, __LINE__, global, strerror(errno));
     ok(log == 2*bufsize, "%s:%d log size is %d: %s",
@@ -111,7 +90,7 @@ int write_read_hole_test(char* unifyfs_root)
         __FILE__, __LINE__, rc, strerror(errno));
 
     /* Check global size on our un-laminated file */
-    get_size(path, &global, &log);
+    testutil_get_size(path, &global, &log);
     ok(global == 3*bufsize, "%s:%d global size is %d: %s",
         __FILE__, __LINE__, global, strerror(errno));
     ok(log == 2*bufsize, "%s:%d log size is %d: %s",
@@ -129,7 +108,7 @@ int write_read_hole_test(char* unifyfs_root)
         __FILE__, __LINE__, rc, strerror(errno));
 
     /* Check global size on our un-laminated file */
-    get_size(path, &global, &log);
+    testutil_get_size(path, &global, &log);
     ok(global == 4*bufsize, "%s:%d global size is %d: %s",
         __FILE__, __LINE__, global, strerror(errno));
     ok(log == 2*bufsize, "%s:%d log size is %d: %s",

--- a/t/sys/write-read.c
+++ b/t/sys/write-read.c
@@ -24,107 +24,162 @@
 #include "t/lib/tap.h"
 #include "t/lib/testutil.h"
 
-/* Get global or log sizes (or all) */
-static
-void get_size(char* path, size_t* global, size_t* log)
-{
-    struct stat sb = {0};
-    int rc;
-
-    rc = stat(path, &sb);
-    if (rc != 0) {
-        printf("Error: %s\n", strerror(errno));
-        exit(1);    /* die on failure */
-    }
-    if (global) {
-        *global = sb.st_size;
-    }
-
-    if (log) {
-        *log = sb.st_rdev;
-    }
-}
-
 int write_read_test(char* unifyfs_root)
 {
+    diag("Starting UNIFYFS_WRAP(write/read) tests");
+
     char path[64];
-    int rc;
-    int fd;
+    char buf[64] = {0};
+    int fd = -1;
     size_t global, log;
+
+    errno = 0;
 
     testutil_rand_path(path, sizeof(path), unifyfs_root);
 
-    /* Write to the file */
+    /* write to bad file descriptor should fail with errno=EBADF */
+    ok(write(fd, "hello world", 12) == -1 && errno == EBADF,
+       "%s:%d write() to bad file descriptor fails (errno=%d): %s",
+       __FILE__, __LINE__, errno, strerror(errno));
+    errno = 0; /* Reset after test for failure */
+
+    /* read from bad file descriptor should fail with errno=EBADF */
+    ok(read(fd, buf, 12) == -1 && errno == EBADF,
+       "%s:%d read() from bad file descriptor fails (errno=%d): %s",
+       __FILE__, __LINE__, errno, strerror(errno));
+    errno = 0;
+
+    /* Write "hello world" to the file */
     fd = open(path, O_WRONLY | O_CREAT, 0222);
-    ok(fd != -1, "%s: open(%s) (fd=%d): %s", __FILE__, path, fd,
-        strerror(errno));
+    ok(fd != -1, "%s:%d open(%s) (fd=%d): %s",
+       __FILE__, __LINE__, path, fd, strerror(errno));
+    ok(write(fd, "hello world", 12) == 12,
+       "%s:%d write(\"hello world\") to file: %s",
+       __FILE__, __LINE__, strerror(errno));
 
-    rc = write(fd, "hello world", 12);
-    ok(rc == 12, "%s: write() (rc=%d): %s", __FILE__, rc, strerror(errno));
+    /* Write to a different offset by overwriting "world" with "universe" */
+    ok(lseek(fd, 6, SEEK_SET) == 6, "%s:%d lseek(6) to \"world\": %s",
+       __FILE__, __LINE__, strerror(errno));
+    ok(write(fd, "universe", 9) == 9,
+       "%s:%d overwrite \"world\" at offset 6 with \"universe\": %s",
+       __FILE__, __LINE__, strerror(errno));
 
-    /* Test writing to a different offset */
-    rc = lseek(fd, 6, SEEK_SET);
-    ok(rc == 6, "%s: lseek() (rc=%d): %s", __FILE__, rc, strerror(errno));
+    /* Check global size on our un-laminated and un-synced file */
+    testutil_get_size(path, &global, &log);
+    ok(global == 0, "%s:%d global size before fsync is %d: %s",
+       __FILE__, __LINE__, global, strerror(errno));
+    ok(log == 21, "%s:%d log size before fsync is %d: %s",
+       __FILE__, __LINE__, log, strerror(errno));
 
-    rc = write(fd, "universe", 9);
-    ok(rc == 9, "%s: write() (rc=%d): %s", __FILE__, rc, strerror(errno));
+    ok(fsync(fd) == 0, "%s:%d fsync() worked: %s",
+       __FILE__, __LINE__, strerror(errno));
 
     /* Check global size on our un-laminated file */
-    get_size(path, &global, &log);
-    ok(global == 0, "%s: global size is %d: %s",  __FILE__, global,
-        strerror(errno));
-    ok(log == 21, "%s: log size is %d: %s",  __FILE__, log,
-        strerror(errno));
+    testutil_get_size(path, &global, &log);
+    ok(global == 15, "%s:%d global size after fsync is %d: %s",
+       __FILE__, __LINE__, global, strerror(errno));
+    ok(log == 21, "%s:%d log size after fsync is %d: %s",
+       __FILE__, __LINE__, log, strerror(errno));
 
+    /* read from file open as write-only should fail with errno=EBADF */
+    ok(lseek(fd, 0, SEEK_SET) == 0, "%s:%d lseek(0): %s",
+       __FILE__, __LINE__, strerror(errno));
+    todo("Successfully reads and gets 0 bytes back");
+    ok(read(fd, buf, 15) == -1 && errno == EBADF,
+       "%s:%d read() from file open as write-only (errno=%d): %s",
+       __FILE__, __LINE__, errno, strerror(errno));
+    end_todo;
+    errno = 0;
 
-    rc = fsync(fd);
-    ok(rc == 0, "%s: fsync() (rc=%d): %s", __FILE__, rc, strerror(errno));
-
-    /* Check global size on our un-laminated file */
-    get_size(path, &global, &log);
-    ok(global == 15, "%s: global size is %d: %s",  __FILE__, global,
-        strerror(errno));
-    ok(log == 21, "%s: log size is %d: %s",  __FILE__, log,
-        strerror(errno));
-
-
-    close(fd);
+    ok(close(fd) == 0, "%s:%d close() worked: %s",
+       __FILE__, __LINE__, strerror(errno));
 
     /* Test O_APPEND */
     fd = open(path, O_WRONLY | O_APPEND, 0222);
-    ok(fd != -1, "%s: open(%s, O_APPEND) (fd=%d): %s", __FILE__, path, fd,
-        strerror(errno));
+    ok(fd != -1, "%s:%d open(%s, O_APPEND) (fd=%d): %s",
+       __FILE__, __LINE__, path, fd, strerror(errno));
 
     /*
      * Seek to an offset in the file and write.  Since it's O_APPEND, the
      * offset we seeked to doesn't matter - all writes go to the end.
      */
-    rc = lseek(fd, 3, SEEK_SET);
-    ok(rc == 3, "%s: lseek() (rc=%d): %s", __FILE__, rc, strerror(errno));
-
-    rc = write(fd, "<end>", 6);
-    ok(rc == 6, "%s: write() (rc=%d): %s", __FILE__, rc, strerror(errno));
-    close(fd);
+    ok(lseek(fd, 3, SEEK_SET) == 3, "%s:%d lseek(3) worked: %s",
+       __FILE__, __LINE__, strerror(errno));
+    ok(write(fd, "<end>", 6) == 6, "%s:%d append write(\"<end>\"): %s",
+       __FILE__, __LINE__, strerror(errno));
+    ok(close(fd) == 0, "%s:%d close() worked: %s",
+       __FILE__, __LINE__, strerror(errno));
 
     /* Check global size on our un-laminated file */
-    get_size(path, &global, &log);
-    ok(global == 21, "%s: global size is %d: %s",  __FILE__, global,
-        strerror(errno));
-    ok(log == 27, "%s: log size is %d: %s",  __FILE__, log,
-        strerror(errno));
-
+    testutil_get_size(path, &global, &log);
+    ok(global == 21, "%s:%d global size before laminate is %d: %s",
+       __FILE__, __LINE__, global, strerror(errno));
+    ok(log == 27, "%s:%d log size before laminate is %d: %s",
+       __FILE__, __LINE__, log, strerror(errno));
 
     /* Laminate */
-    rc = chmod(path, 0444);
-    ok(rc == 0, "%s: chmod(0444) (rc=%d): %s", __FILE__, rc, strerror(errno));
+    ok(chmod(path, 0444) == 0, "%s:%d chmod(0444): %s",
+       __FILE__, __LINE__, strerror(errno));
 
     /* Verify we're getting the correct file size */
-    get_size(path, &global, &log);
-    ok(global == 21, "%s: global size is %d: %s",  __FILE__, global,
-        strerror(errno));
-    ok(log == 27, "%s: log size is %d: %s",  __FILE__, log,
-        strerror(errno));
+    testutil_get_size(path, &global, &log);
+    ok(global == 21, "%s:%d global size after laminate is %d: %s",
+       __FILE__, __LINE__, global, strerror(errno));
+    ok(log == 27, "%s:%d log size after laminate is %d: %s",
+       __FILE__, __LINE__, log, strerror(errno));
 
+    /* open laminated file for write should fail with errno=EROFS */
+    fd = open(path, O_WRONLY | O_CREAT, 0222);
+    ok(fd == -1 && errno == EROFS,
+       "%s:%d open() laminated file for write fails (fd=%d, errno=%d): %s",
+       __FILE__, __LINE__, fd, errno, strerror(errno));
+    errno = 0;
+
+    /* read() tests */
+    fd = open(path, O_RDONLY, 0444);
+    ok(fd != -1, "%s:%d open(%s, O_RDONLY) for read (fd=%d): %s",
+       __FILE__, __LINE__, path, fd, strerror(errno));
+
+    /* write to file open as read-only should fail with errno=EBADF */
+    ok(write(fd, "hello world", 12) == -1 && errno == EBADF,
+       "%s:%d write() to file open as read-only fails (errno=%d): %s",
+       __FILE__, __LINE__, errno, strerror(errno));
+    errno = 0;
+
+    ok(read(fd, buf, 21) == 21, "%s:%d read() buf[]=\"%s\": %s",
+       __FILE__, __LINE__, buf, strerror(errno));
+    buf[14] = ' '; /* replace '\0' between initial write and append */
+    is(buf, "hello universe <end>", "%s:%d read() saw \"hello universe <end>\"",
+       __FILE__, __LINE__);
+
+    /* Seek and read at a different position */
+    ok(lseek(fd, 6, SEEK_SET) == 6, "%s:%d lseek(6) worked: %s",
+       __FILE__, __LINE__, strerror(errno));
+    ok(read(fd, buf, 9) == 9, "%s:%d read() at offset 6 buf[]=\"%s\": %s",
+       __FILE__, __LINE__, buf, strerror(errno));
+    is(buf, "universe", "%s:%d read() saw \"universe\"", __FILE__, __LINE__);
+
+    ok(lseek(fd, 0, SEEK_SET) == 0, "%s:%d lseek(0) worked: %s",
+       __FILE__, __LINE__, strerror(errno));
+    ok(read(fd, buf, sizeof(buf)) == 21, "%s:%d read() past end of file: %s",
+       __FILE__, __LINE__, strerror(errno));
+
+    ok(close(fd) == 0, "%s:%d close() worked: %s",
+       __FILE__, __LINE__, strerror(errno));
+
+    /* write to closed file descriptor should fail with errno=EBADF */
+    ok(write(fd, "hello world", 12) == -1 && errno == EBADF,
+       "%s:%d write() to bad file descriptor fails (errno=%d): %s",
+       __FILE__, __LINE__, errno, strerror(errno));
+    errno = 0; /* Reset after test for failure */
+
+    /* read from closed file descriptor should fail with errno=EBADF */
+    ok(read(fd, buf, 12) == -1 && errno == EBADF,
+       "%s:%d read() from bad file descriptor fails (errno=%d): %s",
+       __FILE__, __LINE__, errno, strerror(errno));
+    errno = 0;
+
+    diag("Finished UNIFYFS_WRAP(write/read) tests");
 
     return 0;
 }


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->

This pulls the `get_size` function out of several tests, since it is defined and used multiple times, and turns it into a [testutil](t/lib/testutil.c) function.

Fixes a few compiler warnings/errors that showed up for gcc/4.9.3 when `-Werror` was enabled

Updates docs to show examples of how to write additional tests using various sharness and lib/tap testing functions.

Add a testing checkbox to the PR template

Also some additional tests are added as well as some refactoring, to include:
* Add additional tests for failure cases
    * tests with bad parameters or function calls on bad file descriptors
    * tests for bad function calls that segfault on posix. We segfault as well due to falling through to the `REAL` function. This how we want them handled?
* Add `read` tests to t/sys/write-read.c
* Add `__FILE__`/`__LINE__` to tests in files I was already touching for better future debugging
* Cleanup of redundant `errno` resetting
    * Removed calls to reset `errno` from unnecessary places. However, `errno` is not reset after successful function calls. Need to reset after test for failures to avoid subsequent tests appearing to have wrong `errno` value. Added note in docs.
* Turn function calls used for test setup into tests themselves for better future debugging
* Found two issues not yet addressed in this PR
    1. Test for `stat` after `unlink` was failing, as it should, but turns out it's failing with wrong `errno`. Call seems to be making it farther into our wrapper(s) then it should. Initial, quick, attempt to check `fid`/`gfid` where appropriate in wrappers didn't work (need to try again); something might not be getting removed in `unlink` call.

``` C
    todo("Failing with wrong errno. Should fail with errno=ENOENT=2");
    ok(stat(path, &sb) == -1 && errno == ENOENT, "%s:%d stat() after unlink fails (errno=%d): %s", __FILE__, __LINE__, errno, strerror(errno));
    end_todo;
```
Results in:
```
0500-sysio-static.t 351 - ../../t/sys/unlink.c:105 stat() after unlink fails (errno=5): Input/output error
```
*
    2. Test to `read` from a file open as write-only reads successfully, but returns 0 bytes read. Not as issue with `fread`. Potentially a problem in `open` call when flags are set.
``` C
    fd = open(path, O_WRONLY | O_CREAT, 0222);
    ok(fd != -1, "%s:%d open(%s) (fd=%d): %s", __FILE__, __LINE__, path, fd, strerror(errno));
    ⋮
    /* write, fsync, and size check tests */
    ⋮
    ok(lseek(fd, 0, SEEK_SET) == 0, "%s:%d lseek(0): %s", __FILE__, __LINE__, strerror(errno));
    todo("Successfully reads and gets 0 bytes back");
    ok(read(fd, buf, 15) == -1 && errno == EBADF, "%s:%d read() from file open as write-only (errno=%d): %s", __FILE__, __LINE__, errno, strerror(errno));
    end_todo;
```
Last test results in:
```
0500-sysio-static.t 79 - ../../../t/sys/write-read.c:88 read() from file open as write-only (errno=0): Success
```

Skipped checkpatch on the docs as it is complaining about a testing call that it thinks is a typo (The `is/isnt` function).

TEST_CHECKPATCH_SKIP_FILES=docs/testing.rst

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Add additional tests and clean up and remove duplicate code from tests.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Running unit tests locally and on Travis CI

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Testing (addition of new tests or update to current tests)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
