### PR TITLE
Enable compile time (configure) option for using MPI for unifyfsd. 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -132,6 +132,15 @@ AC_ARG_ENABLE(st-dev-workaround,
     ]
 ,[])
 
+# use mpi for bootstraping unifyfsd
+AC_ARG_ENABLE(unifyfsd-mpi,
+    [AS_HELP_STRING([--enable-unifyfsd-mpi],[Use MPI for bootstrapping unifyfsd])],[
+        AS_IF([test "x$enableval" = "xyes"],[
+            AC_DEFINE(UNIFYFSD_USE_MPI, 1, Define if unifyfsd has to use mpi for bootstrapping)],[])
+    ]
+,[])
+
+
 # look for MPI and set flags
 LX_FIND_MPI
 AS_IF([test "x$enable_fortran" = "xyes"],[

--- a/server/src/unifyfs_global.h
+++ b/server/src/unifyfs_global.h
@@ -29,6 +29,7 @@
 
 #ifndef UNIFYFS_GLOBAL_H
 #define UNIFYFS_GLOBAL_H
+#include <config.h>
 
 // system headers
 #include <assert.h>

--- a/server/src/unifyfs_server.c
+++ b/server/src/unifyfs_server.c
@@ -149,10 +149,10 @@ void exit_request(int sig)
 }
 
 #if defined(UNIFYFSD_USE_MPI)
-static void init_MPI(void)
+static void init_MPI(int* argc, char*** argv)
 {
     int rc, provided;
-    rc = MPI_Init_thread(&argc, &argv, MPI_THREAD_MULTIPLE, &provided);
+    rc = MPI_Init_thread(argc, argv, MPI_THREAD_MULTIPLE, &provided);
     if (rc != MPI_SUCCESS) {
         exit(1);
     }
@@ -286,7 +286,7 @@ int main(int argc, char* argv[])
     memset(app_configs, 0, sizeof(app_configs));
 
 #if defined(UNIFYFSD_USE_MPI)
-    init_MPI();
+    init_MPI(&argc, &argv);
 #endif
 
     // start logging


### PR DESCRIPTION
This also fixes an compile error when `UNIFYFSD_USE_MPI` is defined.

- configure.ac: adding the configure option
- server/src/unifyfs_global.h: include config.h
- server/src/unifyfs_server.c: fix MPI_Init error


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)
