### PR TITLE
Sync pending writes to server before servicing reads

### DIFF
--- a/client/src/unifyfs-fixed.c
+++ b/client/src/unifyfs-fixed.c
@@ -166,7 +166,7 @@ static void add_index_entry_to_seg_tree(unifyfs_filemeta_t* meta,
     if (unifyfs_segment_count >= (unifyfs_max_index_entries - 2)) {
         /* this will flush our segments, sync them, and set the running
          * segment count back to 0 */
-        unifyfs_sync(meta->gfid);
+        unifyfs_sync();
     } else {
         /* increase the running global segment count by the number of
          * new entries we added to this tree */
@@ -222,7 +222,7 @@ static int add_write_meta_to_index(unifyfs_filemeta_t* meta,
         /* if we have filled the key/value buffer, flush it to server */
         if (0 == remaining_entries) {
             /* index buffer is full, flush it */
-            int ret = unifyfs_sync(cur_idx.gfid);
+            int ret = unifyfs_sync();
             if (ret != UNIFYFS_SUCCESS) {
                 /* something went wrong when trying to flush key/values */
                 LOGERR("failed to flush key/value index to server");
@@ -311,7 +311,7 @@ void unifyfs_rewrite_index_from_seg_tree(void)
  *
  * Returns 0 on success, nonzero otherwise.
  */
-int unifyfs_sync(int gfid)
+int unifyfs_sync(void)
 {
     /* NOTE: we currently ignore gfid and sync extents for all files in
      * the index. If we ever switch to storing extents in a per-file index,
@@ -349,7 +349,6 @@ int unifyfs_sync(int gfid)
 
     return UNIFYFS_SUCCESS;
 }
-
 
 /* ---------------------------------------
  * Operations on file storage

--- a/client/src/unifyfs-fixed.h
+++ b/client/src/unifyfs-fixed.h
@@ -49,7 +49,7 @@
 void unifyfs_rewrite_index_from_seg_tree(void);
 
 /* sync all writes from client's index with local server */
-int unifyfs_sync(int gfid);
+int unifyfs_sync(void);
 
 /* write data to file using log-based I/O */
 int unifyfs_fid_logio_write(

--- a/client/src/unifyfs-internal.h
+++ b/client/src/unifyfs-internal.h
@@ -404,9 +404,9 @@ int unifyfs_would_overflow_offt(off_t a, off_t b);
  * added together */
 int unifyfs_would_overflow_long(long a, long b);
 
-int unifyfs_stack_lock();
+int unifyfs_stack_lock(void);
 
-int unifyfs_stack_unlock();
+int unifyfs_stack_unlock(void);
 
 /* sets flag if the path is a special path */
 int unifyfs_intercept_path(const char* path);
@@ -495,7 +495,7 @@ int unifyfs_fid_update_file_meta(int fid, unifyfs_file_attr_t* gfattr);
 
 /* allocate a file id slot for a new file
  * return the fid or -1 on error */
-int unifyfs_fid_alloc();
+int unifyfs_fid_alloc(void);
 
 /* return the file id back to the free pool */
 int unifyfs_fid_free(int fid);
@@ -507,8 +507,6 @@ int unifyfs_fid_create_file(const char* path);
 /* add a new directory and initialize metadata
  * returns the new fid, or a negative value on error */
 int unifyfs_fid_create_directory(const char* path);
-
-int unifyfs_fid_read_reqs(read_req_t* in_reqs, int in_count);
 
 /* write count bytes from buf into file starting at offset pos */
 int unifyfs_fid_write(
@@ -524,6 +522,9 @@ int unifyfs_fid_write(
  * is more than size */
 int unifyfs_fid_truncate(int fid, off_t length);
 
+/* sync data for file id to server if needed */
+int unifyfs_fid_sync(int fid);
+
 /* opens a new file id with specified path, access flags, and permissions,
  * fills outfid with file id and outpos with position for current file pointer,
  * returns UNIFYFS error code */
@@ -537,6 +538,9 @@ int unifyfs_fid_unlink(int fid);
 
 
 /* functions used in UnifyFS */
+
+/* issue a set of read requests */
+int unifyfs_gfid_read_reqs(read_req_t* in_reqs, int in_count);
 
 int unifyfs_set_global_file_meta_from_fid(
     int fid,

--- a/client/src/unifyfs-stdio.c
+++ b/client/src/unifyfs-stdio.c
@@ -501,8 +501,7 @@ static int unifyfs_stream_flush(FILE* stream)
         }
 
         /* invoke fsync rpc to register index metadata with server */
-        int gfid = unifyfs_gfid_from_fid(fid);
-        int ret = unifyfs_sync(gfid);
+        int ret = unifyfs_fid_sync(fid);
         if (ret != UNIFYFS_SUCCESS) {
             /* sync failed for some reason, set errno and return error */
             s->err = 1;

--- a/t/sys/write-read-hole.c
+++ b/t/sys/write-read-hole.c
@@ -79,7 +79,7 @@ int write_read_hole_test(char* unifyfs_root)
 
     /* Check global size on our un-laminated file */
     testutil_get_size(path, &global);
-    ok(global == 0, "%s:%d global size is %d: %s",
+    ok(global == 3*bufsize, "%s:%d global size is %d: %s",
         __FILE__, __LINE__, global, strerror(errno));
 
     /* flush writes */

--- a/t/sys/write-read.c
+++ b/t/sys/write-read.c
@@ -66,7 +66,7 @@ int write_read_test(char* unifyfs_root)
 
     /* Check global size on our un-laminated and un-synced file */
     testutil_get_size(path, &global);
-    ok(global == 0, "%s:%d global size before fsync is %d: %s",
+    ok(global == 15, "%s:%d global size before fsync is %d: %s",
        __FILE__, __LINE__, global, strerror(errno));
 
     ok(fsync(fd) == 0, "%s:%d fsync() worked: %s",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
For a file that was opened as read/write, in order to read back data that was just written, it is necessary to sync updates to the server before executing the read.  Originally this required the user to explicitly call fsync in between the write and the read.  This adds support so that read now implies an fsync if there are pending writes that have not been sync'd.  It also updates stat to imply an fsync and it changes truncate and ftruncate to call a newly added unifyfs_fid_sync function that wraps the logic.

Aims to resolve https://github.com/LLNL/UnifyFS/issues/470

Depends on https://github.com/LLNL/UnifyFS/pull/481

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
