### PR TITLE
build fix for gcc 4.8.5

### DIFF
--- a/client/src/unifyfs-stdio.c
+++ b/client/src/unifyfs-stdio.c
@@ -2632,6 +2632,7 @@ __svfscanf(unifyfs_stream_t* fp, const char* fmt0, va_list ap)
     char ccltab[256];   /* character class table for %[...] */
     char buf[BUF];      /* buffer for numeric conversions */
 
+    base = 0;
     nassigned = 0;
     nconversions = 0;
     nread = 0;


### PR DESCRIPTION
### Description
On Summitdev, gcc 4.8.5 reports a possible uninitialized variable warning. This results in a compile error due to `-Werror`. This fixes the code to pacify the (old and dumb) compiler.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)
