### PR TITLE
client: add UNIFYFS_CLIENT_CWD for current working dir

### DIFF
--- a/client/src/unifyfs-dirops.c
+++ b/client/src/unifyfs-dirops.c
@@ -89,7 +89,8 @@ DIR* UNIFYFS_WRAP(opendir)(const char* name)
 {
     /* call real opendir and return early if this is
      * not one of our paths */
-    if (!unifyfs_intercept_path(name)) {
+    char upath[UNIFYFS_MAX_FILENAME];
+    if (!unifyfs_intercept_path(name, upath)) {
         MAP_OR_FAIL(opendir);
         return UNIFYFS_REAL(opendir)(name);
     }
@@ -99,8 +100,8 @@ DIR* UNIFYFS_WRAP(opendir)(const char* name)
      * if valid, populate the local file meta cache accordingly.
      */
 
-    int fid  = unifyfs_get_fid_from_path(name);
-    int gfid = unifyfs_generate_gfid(name);
+    int fid  = unifyfs_get_fid_from_path(upath);
+    int gfid = unifyfs_generate_gfid(upath);
 
     unifyfs_file_attr_t gfattr = { 0, };
     int ret = unifyfs_get_global_file_meta(gfid, &gfattr);
@@ -132,7 +133,7 @@ DIR* UNIFYFS_WRAP(opendir)(const char* name)
             return NULL;
         }
     } else {
-        fid = unifyfs_fid_create_file(name);
+        fid = unifyfs_fid_create_file(upath);
         if (fid < 0) {
             errno = EIO;
             return NULL;
@@ -235,7 +236,8 @@ int UNIFYFS_WRAP(scandir)(const char* path, struct dirent** namelist,
                           int (*compar)(const struct dirent**,
                                         const struct dirent**))
 {
-    if (unifyfs_intercept_path(path)) {
+    char upath[UNIFYFS_MAX_FILENAME];
+    if (unifyfs_intercept_path(path, upath)) {
         fprintf(stderr, "Function not yet supported @ %s:%d\n",
                 __FILE__, __LINE__);
         errno = ENOSYS;

--- a/client/src/unifyfs-internal.h
+++ b/client/src/unifyfs-internal.h
@@ -359,6 +359,9 @@ extern unifyfs_filename_t* unifyfs_filelist;
 extern char*  unifyfs_mount_prefix;
 extern size_t unifyfs_mount_prefixlen;
 
+/* tracks current working directory within unifyfs directory namespace */
+extern char* unifyfs_cwd;
+
 /* array of file descriptors */
 extern unifyfs_fd_t unifyfs_fds[UNIFYFS_MAX_FILEDESCS];
 extern rlim_t unifyfs_fd_limit;

--- a/client/src/unifyfs-internal.h
+++ b/client/src/unifyfs-internal.h
@@ -411,8 +411,10 @@ int unifyfs_stack_lock(void);
 
 int unifyfs_stack_unlock(void);
 
-/* sets flag if the path is a special path */
-int unifyfs_intercept_path(const char* path);
+/* sets flag if the path should be intercept as a unifyfs path,
+ * and if so, writes normalized path in upath, which should
+ * be a buffer of size UNIFYFS_MAX_FILENAME */
+int unifyfs_intercept_path(const char* path, char* upath);
 
 /* given an fd, return 1 if we should intercept this file, 0 otherwise,
  * convert fd to new fd value if needed */

--- a/client/src/unifyfs-stdio.c
+++ b/client/src/unifyfs-stdio.c
@@ -980,9 +980,10 @@ static int unifyfs_fseek(FILE* stream, off_t offset, int whence)
 FILE* UNIFYFS_WRAP(fopen)(const char* path, const char* mode)
 {
     /* check whether we should intercept this path */
-    if (unifyfs_intercept_path(path)) {
+    char upath[UNIFYFS_MAX_FILENAME];
+    if (unifyfs_intercept_path(path, upath)) {
         FILE* stream;
-        int rc = unifyfs_fopen(path, mode, &stream);
+        int rc = unifyfs_fopen(upath, mode, &stream);
         if (rc != UNIFYFS_SUCCESS) {
             errno = unifyfs_rc_errno(rc);
             return NULL;

--- a/client/src/unifyfs.c
+++ b/client/src/unifyfs.c
@@ -279,7 +279,7 @@ inline int unifyfs_stack_unlock(void)
     return 0;
 }
 
-inline void unifyfs_normalize_path(const char* path, char* normalized)
+static void unifyfs_normalize_path(const char* path, char* normalized)
 {
     /* if we have a relative path, prepend the current working directory */
     if (path[0] != '/' && unifyfs_cwd != NULL) {
@@ -2376,6 +2376,13 @@ static int unifyfs_init(void)
         cfgval = client_cfg.client_cwd;
         if (cfgval != NULL) {
             unifyfs_cwd = strdup(cfgval);
+
+            /* check that cwd falls somewhere under the mount point */
+            if (strncmp(unifyfs_cwd, unifyfs_mount_prefix,
+                unifyfs_mount_prefixlen) != 0) {
+                LOGERR("UNIFYFS_CLIENT_CWD '%s' must be within the mount '%s'",
+                    unifyfs_cwd, unifyfs_mount_prefix);
+            }
         }
 
         /* determine max number of files to store in file system */

--- a/client/src/unifyfs.c
+++ b/client/src/unifyfs.c
@@ -294,7 +294,7 @@ static void unifyfs_normalize_path(const char* path, char* normalized)
 }
 
 /* sets flag if the path is a special path */
-inline int unifyfs_intercept_path(const char* path)
+inline int unifyfs_intercept_path(const char* path, char* upath)
 {
     /* don't intecept anything until we're initialized */
     if (!unifyfs_initialized) {
@@ -318,6 +318,12 @@ inline int unifyfs_intercept_path(const char* path)
             intercept = 0;
         }
     }
+
+    /* copy normalized path into upath */
+    if (intercept) {
+        strncpy(upath, target, UNIFYFS_MAX_FILENAME);
+    }
+
     return intercept;
 }
 
@@ -3038,7 +3044,8 @@ int unifyfs_transfer_file(const char* src, const char* dst, int parallel)
         return -ENOMEM;
     }
 
-    if (unifyfs_intercept_path(src)) {
+    char src_upath[UNIFYFS_MAX_FILENAME];
+    if (unifyfs_intercept_path(src, src_upath)) {
         dir = UNIFYFS_TX_STAGE_OUT;
         unify_src = 1;
     }
@@ -3050,7 +3057,8 @@ int unifyfs_transfer_file(const char* src, const char* dst, int parallel)
 
     pos += sprintf(pos, "%s", dst);
 
-    if (unifyfs_intercept_path(dst)) {
+    char dst_upath[UNIFYFS_MAX_FILENAME];
+    if (unifyfs_intercept_path(dst, dst_upath)) {
         dir = UNIFYFS_TX_STAGE_IN;
         unify_dst = 1;
     }

--- a/client/src/unifyfs.c
+++ b/client/src/unifyfs.c
@@ -153,6 +153,9 @@ void* unifyfs_dirstream_stack;
 char*  unifyfs_mount_prefix;
 size_t unifyfs_mount_prefixlen = 0;
 
+/* to track current working directory within unifyfs namespace */
+char* unifyfs_cwd;
+
 /* mutex to lock stack operations */
 pthread_mutex_t unifyfs_stack_mutex = PTHREAD_MUTEX_INITIALIZER;
 
@@ -276,6 +279,20 @@ inline int unifyfs_stack_unlock(void)
     return 0;
 }
 
+inline void unifyfs_normalize_path(const char* path, char* normalized)
+{
+    /* if we have a relative path, prepend the current working directory */
+    if (path[0] != '/' && unifyfs_cwd != NULL) {
+        /* got a relative path, add our cwd */
+        snprintf(normalized, UNIFYFS_MAX_FILENAME, "%s/%s", unifyfs_cwd, path);
+    } else {
+        snprintf(normalized, UNIFYFS_MAX_FILENAME, "%s", path);
+    }
+
+    /* TODO: normalize path to handle '.', '..',
+     * and extra or trailing '/' characters */
+}
+
 /* sets flag if the path is a special path */
 inline int unifyfs_intercept_path(const char* path)
 {
@@ -284,8 +301,12 @@ inline int unifyfs_intercept_path(const char* path)
         return 0;
     }
 
+    /* if we have a relative path, prepend the current working directory */
+    char target[UNIFYFS_MAX_FILENAME];
+    unifyfs_normalize_path(path, target);
+
     /* if the path starts with our mount point, intercept it */
-    if (strncmp(path, unifyfs_mount_prefix, unifyfs_mount_prefixlen) == 0) {
+    if (strncmp(target, unifyfs_mount_prefix, unifyfs_mount_prefixlen) == 0) {
         return 1;
     }
     return 0;
@@ -2351,6 +2372,12 @@ static int unifyfs_init(void)
         unifyfs_max_long = LONG_MAX;
         unifyfs_min_long = LONG_MIN;
 
+        /* set our current working directory if user gave us one */
+        cfgval = client_cfg.client_cwd;
+        if (cfgval != NULL) {
+            unifyfs_cwd = strdup(cfgval);
+        }
+
         /* determine max number of files to store in file system */
         unifyfs_max_files = UNIFYFS_MAX_FILES;
         cfgval = client_cfg.client_max_files;
@@ -2754,6 +2781,11 @@ int unifyfs_unmount(void)
     /************************
      * free configuration values
      ************************/
+
+    /* free global holding current working directory */
+    if (unifyfs_cwd != NULL) {
+        free(unifyfs_cwd);
+    }
 
     /* clean up configuration */
     rc = unifyfs_config_fini(&client_cfg);

--- a/client/src/unifyfs.c
+++ b/client/src/unifyfs.c
@@ -306,10 +306,19 @@ inline int unifyfs_intercept_path(const char* path)
     unifyfs_normalize_path(path, target);
 
     /* if the path starts with our mount point, intercept it */
+    int intercept = 0;
     if (strncmp(target, unifyfs_mount_prefix, unifyfs_mount_prefixlen) == 0) {
-        return 1;
+        /* characters in target up through mount point match,
+         * assume we match */ 
+        intercept = 1;
+
+        /* if we have another character, it must be '/' */
+        if (strlen(target) > unifyfs_mount_prefixlen &&
+            target[unifyfs_mount_prefixlen] != '/') {
+            intercept = 0;
+        }
     }
-    return 0;
+    return intercept;
 }
 
 /* given an fd, return 1 if we should intercept this file, 0 otherwise,
@@ -2378,10 +2387,27 @@ static int unifyfs_init(void)
             unifyfs_cwd = strdup(cfgval);
 
             /* check that cwd falls somewhere under the mount point */
+            int cwd_within_mount = 0;
             if (strncmp(unifyfs_cwd, unifyfs_mount_prefix,
-                unifyfs_mount_prefixlen) != 0) {
+                unifyfs_mount_prefixlen) == 0) {
+                /* characters in target up through mount point match,
+                 * assume we match */ 
+                cwd_within_mount = 1;
+
+                /* if we have another character, it must be '/' */
+                if (strlen(unifyfs_cwd) > unifyfs_mount_prefixlen &&
+                    unifyfs_cwd[unifyfs_mount_prefixlen] != '/') {
+                    cwd_within_mount = 0;
+                }
+            }
+            if (!cwd_within_mount) {
+                /* path given in CWD is outside of the UnifyFS mount point */
                 LOGERR("UNIFYFS_CLIENT_CWD '%s' must be within the mount '%s'",
                     unifyfs_cwd, unifyfs_mount_prefix);
+
+                /* ignore setting and set back to NULL */
+                free(unifyfs_cwd);
+                unifyfs_cwd = NULL;
             }
         }
 

--- a/common/src/unifyfs_configurator.h
+++ b/common/src/unifyfs_configurator.h
@@ -74,6 +74,7 @@
     UNIFYFS_CFG(client, local_extents, BOOL, off, "track extents to service reads of local data", NULL) \
     UNIFYFS_CFG(client, recv_data_size, INT, UNIFYFS_DATA_RECV_SIZE, "shared memory segment size in bytes for receiving data from server", NULL) \
     UNIFYFS_CFG(client, write_index_size, INT, UNIFYFS_INDEX_BUF_SIZE, "write metadata index buffer size", NULL) \
+    UNIFYFS_CFG(client, cwd, STRING, NULLSTRING, "current working directory", NULL) \
     UNIFYFS_CFG_CLI(log, verbosity, INT, 0, "log verbosity level", NULL, 'v', "specify logging verbosity level") \
     UNIFYFS_CFG_CLI(log, file, STRING, unifyfsd.log, "log file name", NULL, 'l', "specify log file name") \
     UNIFYFS_CFG_CLI(log, dir, STRING, LOGDIR, "log file directory", configurator_directory_check, 'L', "specify full path to directory to contain log file") \

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -79,8 +79,9 @@ expects when changing into a working directory before starting a job
 and then using relative file names within the application.
 If set, the value specified in ``cwd`` is prepended to any
 relative path name when determining whether UnifyFS will intercept
-a path.  The value specified in ``cwd`` must match the UnifyFS mount point.
-It does not modify the job's current working directory.
+a path.  The value specified in ``cwd`` must be within the directory space
+of the UnifyFS mount point.
+Setting ``cwd`` does not modify the job's actual current working directory.
 
 Enabling the ``local_extents`` optimization may significantly improve read
 performance.  However, it should not be used by applications

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -66,12 +66,21 @@ a given section and key.
    ================  ======  =================================================================
    Key               Type    Description
    ================  ======  =================================================================
+   cwd               STRING  effective starting current working directory
    max_files         INT     maximum number of open files per client process (default: 128)
    flatten_writes    BOOL    enable flattening writes (optimization for overwrite-heavy codes)
    local_extents     BOOL    service reads from local data if possible (default: off)
    recv_data_size    INT     maximum size (B) of memory buffer for receiving data from server
    write_index_size  INT     maximum size (B) of memory buffer for storing write log metadata
    ================  ======  =================================================================
+
+The ``cwd`` setting is used to emulate the behavior one
+expects when changing into a working directory before starting a job
+and then using relative file names within the application.
+If set, the value specified in ``cwd`` is prepended to any
+relative path name when determining whether UnifyFS will intercept
+a path.  The value specified in ``cwd`` must match the UnifyFS mount point.
+It does not modify the job's current working directory.
 
 Enabling the ``local_extents`` optimization may significantly improve read
 performance.  However, it should not be used by applications


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Some applications ```cd``` into a working directory before starting the job, and then use relative path names for files within the run.  Since one cannot ```cd``` into a UnifyFS directory, we add a UNIFYFS_CLIENT_CWD configuration option.  When set, UnifyFS will prepend this string to any relative file name to act as a current working directory when determining whether to intercept a given path.

Resolves: https://github.com/LLNL/UnifyFS/issues/474

Related but separate to this topic:
- need to add wrappers for chdir/getcwd: https://github.com/LLNL/UnifyFS/issues/436
- need to add logic to normalize paths as in ```/unifyfs/foo/.././/bar --> /unifyfs/bar```

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
