### PR TITLE
client: drop function that counts ranks local to a node

### DIFF
--- a/client/src/unifyfs-internal.h
+++ b/client/src/unifyfs-internal.h
@@ -320,10 +320,6 @@ extern unsigned long unifyfs_max_index_entries;
 /* tracks total number of unsync'd segments for all files */
 extern unsigned long unifyfs_segment_count;
 
-extern int local_rank_cnt;
-extern int local_rank_idx;
-extern int local_del_cnt;
-
 /* shmem context for read-request replies data region */
 extern shm_context* shm_recv_ctx;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The client used to need to know how many client ranks were on the same node and be assigned a relative rank.  This function is no longer needed.

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
