### PR TITLE
unifyfs utility to wait until all servers become ready.

### DIFF
--- a/common/src/unifyfs_configurator.h
+++ b/common/src/unifyfs_configurator.h
@@ -90,6 +90,7 @@
     UNIFYFS_CFG_CLI(runstate, dir, STRING, RUNDIR, "runstate file directory", configurator_directory_check, 'R', "specify full path to directory to contain server runstate file") \
     UNIFYFS_CFG_CLI(server, hostfile, STRING, NULLSTRING, "server hostfile name", NULL, 'H', "specify full path to server hostfile") \
     UNIFYFS_CFG_CLI(sharedfs, dir, STRING, NULLSTRING, "shared file system directory", configurator_directory_check, 'S', "specify full path to directory to contain server shared files") \
+    UNIFYFS_CFG_CLI(server, init_timeout, INT, UNIFYFS_DEFAULT_INIT_TIMEOUT, "timeout of waiting for server initialization", NULL, 't', "timeout in seconds to wait for servers to be ready for clients") \
 
 
 #ifdef __cplusplus

--- a/common/src/unifyfs_const.h
+++ b/common/src/unifyfs_const.h
@@ -65,6 +65,9 @@
 // Server - General
 #define MAX_NUM_APPS 64    /* max # apps supported by a single server */
 #define MAX_APP_CLIENTS 64 /* app processes per server */
+/* timeout (in seconds) of waiting for initialization of all servers */
+#define UNIFYFS_DEFAULT_INIT_TIMEOUT 120
+#define UNIFYFSD_PID_FILENAME "unifyfsd.pids"
 
 // Client
 #define UNIFYFS_MAX_FILES 128

--- a/common/src/unifyfs_server_rpcs.h
+++ b/common/src/unifyfs_server_rpcs.h
@@ -24,6 +24,16 @@ MERCURY_GEN_PROC(server_hello_out_t,
                  ((int32_t)(ret)))
 DECLARE_MARGO_RPC_HANDLER(server_hello_rpc)
 
+/* server_pid_rpc (server => server, n:1)
+ *
+ * notify readiness with pid to the master server (rank:0) */
+MERCURY_GEN_PROC(server_pid_in_t,
+                 ((int32_t)(rank))
+                 ((int32_t)(pid)))
+MERCURY_GEN_PROC(server_pid_out_t,
+                 ((int32_t)(ret)))
+DECLARE_MARGO_RPC_HANDLER(server_pid_handle_rpc)
+
 /* server_request_rpc (server => server)
  *
  * request from one server to another */

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -136,11 +136,12 @@ files.
 .. table:: ``[server]`` section - server settings
    :widths: auto
 
-   ==========  ======  ========================
-   Key         Type    Description
-   ==========  ======  ========================
-   hostfile    STRING  path to server hostfile
-   ==========  ======  ========================
+   ============  ======  =============================================================================
+   Key           Type    Description
+   ============  ======  =============================================================================
+   hostfile      STRING  path to server hostfile
+   init_timeout  INT     timeout in seconds to wait for servers to be ready for clients (default: 120)
+   ============  ======  =============================================================================
 
 .. table:: ``[sharedfs]`` section - server shared files settings
    :widths: auto

--- a/server/src/Makefile.am
+++ b/server/src/Makefile.am
@@ -12,7 +12,8 @@ libunifyfsd_a_SOURCES = \
     unifyfs_request_manager.c \
     unifyfs_request_manager.h \
     unifyfs_service_manager.c \
-    unifyfs_service_manager.h
+    unifyfs_service_manager.h \
+    unifyfs_server_pid.c
 
 bin_PROGRAMS = unifyfsd
 

--- a/server/src/margo_server.c
+++ b/server/src/margo_server.c
@@ -87,6 +87,11 @@ static void register_server_server_rpcs(margo_instance_id mid)
                        server_hello_in_t, server_hello_out_t,
                        server_hello_rpc);
 
+    unifyfsd_rpc_context->rpcs.server_pid_id =
+        MARGO_REGISTER(mid, "server_pid_rpc",
+                       server_pid_in_t, server_pid_out_t,
+                       server_pid_handle_rpc);
+
     unifyfsd_rpc_context->rpcs.request_id =
         MARGO_REGISTER(mid, "server_request_rpc",
                        server_request_in_t, server_request_out_t,

--- a/server/src/margo_server.h
+++ b/server/src/margo_server.h
@@ -17,6 +17,7 @@
 
 typedef struct ServerRpcIds {
     hg_id_t hello_id;
+    hg_id_t server_pid_id;
     hg_id_t request_id;
     hg_id_t chunk_read_request_id;
     hg_id_t chunk_read_response_id;

--- a/server/src/unifyfs_global.h
+++ b/server/src/unifyfs_global.h
@@ -64,6 +64,7 @@
 /* PMI server rank and server count */
 extern int glb_pmi_rank;
 extern int glb_pmi_size;
+extern int server_pid;
 
 /* hostname for this server */
 extern char glb_host[UNIFYFS_MAX_HOSTNAME];
@@ -196,6 +197,5 @@ unifyfs_rc attach_app_client(app_client* client,
 unifyfs_rc disconnect_app_client(app_client* clnt);
 
 unifyfs_rc cleanup_app_client(app_client* clnt);
-
 
 #endif // UNIFYFS_GLOBAL_H

--- a/server/src/unifyfs_server_pid.c
+++ b/server/src/unifyfs_server_pid.c
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2020, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2020, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyFS.
+ * For details, see https://github.com/LLNL/UnifyFS.
+ * Please read https://github.com/LLNL/UnifyFS/LICENSE for full license text.
+ */
+#include <stdio.h>
+#include <pthread.h>
+#include <time.h>
+#include <errno.h>
+#include <limits.h>
+
+#include "unifyfs_configurator.h"
+#include "unifyfs_global.h"
+#include "margo_server.h"
+#include "unifyfs_server_rpcs.h"
+
+extern unifyfs_cfg_t server_cfg;
+
+static pthread_cond_t server_pid_cond = PTHREAD_COND_INITIALIZER;
+static pthread_mutex_t server_pid_mutex = PTHREAD_MUTEX_INITIALIZER;
+static struct timespec server_pid_timeout;
+
+static int* server_pids;
+static pthread_mutex_t server_pid_alloc_lock = PTHREAD_MUTEX_INITIALIZER;
+
+static int alloc_server_pid(void)
+{
+    int ret = 0;
+
+    pthread_mutex_lock(&server_pid_alloc_lock);
+    {
+        if (!server_pids) {
+            server_pids = calloc(glb_pmi_size, sizeof(*server_pids));
+            if (!server_pids) {
+                LOGERR("failed to allocate memory (%s)", strerror(errno));
+                ret = ENOMEM;
+            }
+        }
+    }
+    pthread_mutex_unlock(&server_pid_alloc_lock);
+
+    return ret;
+}
+
+static int server_pid_invoke_rpc(void)
+{
+    int ret = 0;
+    hg_return_t hret = 0;
+    hg_handle_t handle;
+    server_pid_in_t in;
+    server_pid_out_t out;
+
+    in.rank = glb_pmi_rank;
+    in.pid = server_pid;
+
+    hret = margo_create(unifyfsd_rpc_context->svr_mid,
+                        glb_servers[0].margo_svr_addr,
+                        unifyfsd_rpc_context->rpcs.server_pid_id,
+                        &handle);
+    if (hret != HG_SUCCESS) {
+        LOGERR("failed to create rpc handle (ret=%d)", hret);
+        return UNIFYFS_ERROR_MARGO;
+    }
+
+    hret = margo_forward(handle, &in);
+    if (hret != HG_SUCCESS) {
+        LOGERR("failed to forward rpc (ret=%d)", hret);
+        return UNIFYFS_ERROR_MARGO;
+    }
+
+    hret = margo_get_output(handle, &out);
+    if (hret != HG_SUCCESS) {
+        LOGERR("failed to get rpc result (ret=%d)", hret);
+        return UNIFYFS_ERROR_MARGO;
+    }
+
+    ret = out.ret;
+
+    return ret;
+}
+
+static void server_pid_handle_rpc(hg_handle_t handle)
+{
+    int ret = 0;
+    int i = 0;
+    int count = 0;
+    hg_return_t hret = 0;
+    server_pid_in_t in;
+    server_pid_out_t out;
+
+    hret = margo_get_input(handle, &in);
+    if (hret != HG_SUCCESS) {
+        LOGERR("failed to get input (ret=%d)", hret);
+        return;
+    }
+
+    if (!server_pids) {
+        ret = alloc_server_pid();
+        if (ret) {
+            LOGERR("failed to allocate pid array");
+            return;
+        }
+    }
+
+    server_pids[in.rank] = in.pid;
+
+    out.ret = 0;
+    hret = margo_respond(handle, &out);
+    if (hret != HG_SUCCESS) {
+        LOGERR("failed to respond rpc (ret=%d)", hret);
+        return;
+    }
+
+    margo_free_input(handle, &in);
+    margo_destroy(handle);
+
+    for (i = 0; i < glb_pmi_size; i++) {
+        if (server_pids[i] > 0) {
+            count++;
+        }
+    }
+
+    if (count == glb_pmi_size) {
+        ret = pthread_cond_signal(&server_pid_cond);
+        if (ret) {
+            LOGERR("failed to signal condition (%s)", strerror(ret));
+        }
+    }
+}
+DEFINE_MARGO_RPC_HANDLER(server_pid_handle_rpc);
+
+static inline int set_timeout(void)
+{
+    int ret = 0;
+    long timeout_sec = 0;
+
+    if (server_cfg.server_init_timeout) {
+        ret = configurator_int_val(server_cfg.server_init_timeout,
+                                   &timeout_sec);
+        if (ret) {
+            LOGERR("failed to read configuration");
+            return ret;
+        }
+    }
+
+    clock_gettime(CLOCK_REALTIME, &server_pid_timeout);
+    server_pid_timeout.tv_sec += timeout_sec;
+
+    return 0;
+}
+
+static int create_server_pid_file(void)
+{
+    int i = 0;
+    int ret = 0;
+    char filename[PATH_MAX] = { 0, };
+    FILE* fp = NULL;
+
+    if (!server_pids) {
+        LOGERR("cannot access the server pids");
+        return EINVAL;
+    }
+
+    sprintf(filename, "%s/%s", server_cfg.sharedfs_dir, UNIFYFSD_PID_FILENAME);
+
+    fp = fopen(filename, "w");
+    if (!fp) {
+        LOGERR("failed to create file %s (%s)", filename, strerror(errno));
+        return errno;
+    }
+
+    for (i = 0; i < glb_pmi_size; i++) {
+        fprintf(fp, "[%d] %d\n", i, server_pids[i]);
+    }
+
+    fclose(fp);
+
+    return ret;
+}
+
+int unifyfs_publish_server_pids(void)
+{
+    int ret = UNIFYFS_SUCCESS;
+
+    if (glb_pmi_rank > 0) {
+        ret = server_pid_invoke_rpc();
+        if (ret) {
+            LOGERR("failed to invoke pid rpc (%s)", strerror(ret));
+        }
+    } else {
+        ret = set_timeout();
+        if (ret) {
+            return ret;
+        }
+
+        if (!server_pids) {
+            ret = alloc_server_pid();
+            if (ret) {
+                return ret;
+            }
+        }
+
+        server_pids[0] = server_pid;
+
+        if (glb_pmi_size > 1) {
+            ret = pthread_cond_timedwait(&server_pid_cond,
+                                         &server_pid_mutex,
+                                         &server_pid_timeout);
+            if (ETIMEDOUT == ret) {
+                LOGERR("some servers failed to initialize within timeout");
+                goto out;
+            } else if (ret) {
+                LOGERR("failed to wait on condition (err=%d, %s)",
+                       errno, strerror(errno));
+                goto out;
+            }
+        }
+
+        ret = create_server_pid_file();
+        if (UNIFYFS_SUCCESS == ret) {
+            LOGDBG("all servers are ready to accept client connection");
+        }
+    }
+out:
+    if (server_pids) {
+        free(server_pids);
+        server_pids = NULL;
+    }
+
+    return ret;
+}
+

--- a/util/unifyfs/src/unifyfs-rm.c
+++ b/util/unifyfs/src/unifyfs-rm.c
@@ -271,6 +271,20 @@ static int remove_server_pid_file(unifyfs_args_t* args)
     return ret;
 }
 
+static inline char* str_rtrim(char* str)
+{
+    if (str) {
+        char* pos = &str[strlen(str) - 1];
+
+        while (pos >= str && isspace(*pos)) {
+            *pos = '\0';
+            pos--;
+        }
+    }
+
+    return str;
+}
+
 /**
  * @brief Get node list from $LSB_HOSTS or $LSB_MCPU_HOSTS.
  *
@@ -303,7 +317,9 @@ static int lsf_read_resource(unifyfs_resource_t* resource)
         }
     }
 
-    lsb_hosts = strdup(val);
+    // LSB_MCPU_HOSTS string includes a space at the end, which causes extra
+    // node count (n_nodes).
+    lsb_hosts = str_rtrim(strdup(val));
 
     // get length of host string
     size_t hosts_len = strlen(lsb_hosts) + 1;

--- a/util/unifyfs/src/unifyfs.c
+++ b/util/unifyfs/src/unifyfs.c
@@ -75,11 +75,12 @@ static struct option const long_opts[] = {
     { "share-dir", required_argument, NULL, 'S' },
     { "stage-in", required_argument, NULL, 'i' },
     { "stage-out", required_argument, NULL, 'o' },
+    { "timeout", required_argument, NULL, 't' },
     { 0, 0, 0, 0 },
 };
 
 static char* program;
-static char* short_opts = ":cC:de:hi:m:o:s:S:";
+static char* short_opts = ":cC:de:hi:m:o:s:S:t:";
 static char* usage_str =
     "\n"
     "Usage: %s <command> [options...]\n"
@@ -97,6 +98,7 @@ static char* usage_str =
     "  -e, --exe=<path>          [OPTIONAL] <path> where unifyfsd is installed\n"
     "  -m, --mount=<path>        [OPTIONAL] mount UnifyFS at <path>\n"
     "  -s, --script=<path>       [OPTIONAL] <path> to custom launch script\n"
+    "  -t, --timeout=<sec>       [OPTIONAL] wait <sec> until all servers become ready\n"
     "  -S, --share-dir=<path>    [REQUIRED] shared file system <path> for use by servers\n"
     "  -c, --cleanup             [OPTIONAL] clean up the UnifyFS storage upon server exit\n"
     "  -i, --stage-in=<path>     [OPTIONAL, NOT YET SUPPORTED] stage in file(s) at <path>\n"
@@ -119,6 +121,7 @@ static void parse_cmd_arguments(int argc, char** argv)
     int ch = 0;
     int optidx = 2;
     int cleanup = 0;
+    int timeout = UNIFYFS_DEFAULT_INIT_TIMEOUT;
     unifyfs_cm_e consistency = UNIFYFS_CM_LAMINATED;
     char* mountpoint = NULL;
     char* script = NULL;
@@ -162,6 +165,10 @@ static void parse_cmd_arguments(int argc, char** argv)
             share_dir = strdup(optarg);
             break;
 
+        case 't':
+            timeout = atoi(optarg);
+            break;
+
         case 'i':
             printf("WARNING: stage-in not yet supported!\n");
             stage_in = strdup(optarg);
@@ -188,6 +195,7 @@ static void parse_cmd_arguments(int argc, char** argv)
     cli_args.share_dir = share_dir;
     cli_args.stage_in = stage_in;
     cli_args.stage_out = stage_out;
+    cli_args.timeout = timeout;
 }
 
 int main(int argc, char** argv)

--- a/util/unifyfs/src/unifyfs.h
+++ b/util/unifyfs/src/unifyfs.h
@@ -57,6 +57,7 @@
 struct _unifyfs_args {
     int debug;                 /* enable debug output */
     int cleanup;               /* cleanup on termination? (0 or 1) */
+    int timeout;               /* timeout of server initialization */
     unifyfs_cm_e consistency;  /* consistency model */
     char* mountpoint;          /* mountpoint */
     char* server_path;         /* full path to installed unifyfsd */


### PR DESCRIPTION
unifyfs utility to wait until all servers become ready.
- unifyfsd publishes a server pid file (unifyfsd.pids) under the shared
state state directory, indicating that all servers are ready
- unifyfs utility blocks until the pid file appears

Also, this includes an additional commit that fixes #505.

TEST_CHECKPATH_SKIP_FILES=common/src/unifyfs_configurator.h

<!--- Provide a general summary of your changes in the Title above -->

### Description
This addresses #499.



### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

