### PR TITLE
placement nomination for stagein/stageout

### DIFF
--- a/util/unifyfs/src/unifyfs-rm.c
+++ b/util/unifyfs/src/unifyfs-rm.c
@@ -554,14 +554,20 @@ static size_t construct_server_argv(unifyfs_args_t* args,
 	        return -1;
             }
 
-	    //	    if (args->server_path != NULL) {
+	    //  The commented-out code lines will be uncommented once the
+	    //  transfer-stage infrastructure is stable enough that we can
+	    //  count on it being in the right place in the install.  For
+	    //  now, while we're rolling it out, we're requiring the user
+	    //  to explicitly supply the location of the transfer-stage
+	    //  binary.
+	    //	    if (args->transfer_exe != NULL) {
 	    server_argv[0] = strdup(args->transfer_exe);
 	    //    } else {
-	    //	        server_argv[0] = strdup(BINDIR "/unifyfsd");
+	    //	        server_argv[0] = strdup(LIBEXECDIR "/transfer-stage");
 	    //	    }
 	    argc = 1;
 
-	    // if we need to add arguments betwen the command and the
+	    // if we need to add arguments between the command and the
 	    // manifest file name they get added here.
 
 	    server_argv[argc] = strdup(args->stage_in);
@@ -581,14 +587,20 @@ static size_t construct_server_argv(unifyfs_args_t* args,
 	        return -1;
             }
 
-	    //	    if (args->server_path != NULL) {
+	    //  The commented-out code lines will be uncommented once the
+	    //  transfer-stage infrastructure is stable enough that we can
+	    //  count on it being in the right place in the install.  For
+	    //  now, while we're rolling it out, we're requiring the user
+	    //  to explicitly supply the location of the transfer-stage
+	    //  binary.
+	    //	    if (args->transfer_exe != NULL) {
 	    server_argv[0] = strdup(args->transfer_exe);
 	    //    } else {
-	    //	        server_argv[0] = strdup(BINDIR "/unifyfsd");
+	    //	        server_argv[0] = strdup(LIBEXECDIR "/transfer-stage");
 	    //	    }
 	    argc = 1;
 
-	    // if we need to add arguments betwen the command and the
+	    // if we need to add arguments between the command and the
 	    // manifest file name they get added here.
 
 	    server_argv[argc] = strdup(args->stage_out);

--- a/util/unifyfs/src/unifyfs-rm.c
+++ b/util/unifyfs/src/unifyfs-rm.c
@@ -975,8 +975,8 @@ int unifyfs_start_servers(unifyfs_resource_t* resource,
                           unifyfs_args_t* args)
 {
     pid_t pid;
-    int unifyfsd_return_val;
-    int transfer_return_val;
+    int unifyfsd_return_val = 0;
+    int transfer_return_val = 0;
     int rc;
 
     if ((resource == NULL) || (args == NULL)) {
@@ -1038,10 +1038,7 @@ int unifyfs_start_servers(unifyfs_resource_t* resource,
 	// here's where we would put the check to wait until it was all done.
     }
 
-    // Possibly we should combine the two return values in the future?
-    transfer_return_val++;
-    transfer_return_val--;
-    return unifyfsd_return_val;
+    return unifyfsd_return_val + transfer_return_val;
 }
 
 int unifyfs_stop_servers(unifyfs_resource_t* resource,

--- a/util/unifyfs/src/unifyfs.c
+++ b/util/unifyfs/src/unifyfs.c
@@ -84,7 +84,7 @@ static struct option const long_opts[] = {
 };
 
 static char* program;
-static char* short_opts = ":cC:de:hi:m:o:s:S:t:";
+static char* short_opts = ":cC:de:hi:m:o:s:S:t:x:";
 static char* usage_str =
     "\n"
     "Usage: %s <command> [options...]\n"
@@ -383,7 +383,6 @@ int main(int argc, char** argv)
         return -1;
     }
 } // int main(...
-
 
 // validates that the named manifest file exists and is readable
 // and returns the number of lines in it.

--- a/util/unifyfs/src/unifyfs.h
+++ b/util/unifyfs/src/unifyfs.h
@@ -54,10 +54,19 @@
 /**
  * @brief The requested command-line options
  */
+
+#define UNIFYFS_CONSTRUCT_ARGS_UNIFYFSD         0
+#define UNIFYFS_CONSTRUCT_ARGS_STAGE_IN         1
+#define UNIFYFS_CONSTRUCT_ARGS_STAGE_OUT        2
+
+
 struct _unifyfs_args {
     int debug;                 /* enable debug output */
     int cleanup;               /* cleanup on termination? (0 or 1) */
     int timeout;               /* timeout of server initialization */
+    int arg_type;              /* signals to construct_server_argv who it's
+				* constructing arguments for.
+				* values #define-ed above.  */
     unifyfs_cm_e consistency;  /* consistency model */
     char* mountpoint;          /* mountpoint */
     char* server_path;         /* full path to installed unifyfsd */
@@ -65,6 +74,7 @@ struct _unifyfs_args {
     char* share_hostfile;      /* full path to shared server hostfile */
     char* stage_in;            /* data path to stage-in */
     char* stage_out;           /* data path to stage-out (drain) */
+    char* transfer_exe;        /* full path to transfer executable */
     char* script;              /* path to custom launch/terminate script */
 };
 typedef struct _unifyfs_args unifyfs_args_t;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Beginning of the PR to integrate file stage-in and stage-out
capability to the unifyfs command.  

### Description
<!--- Describe your changes in detail -->
This branch/PR will add calls in the unifyfs command to the 
transfer API to bring files into the UnifyFS file space during 
unifyfs launch, and stage files out when calling teardown but
before the servers are actually stopped.  

All the check lists will be filled in when this becomes a PR 
that's ready to integrate.  Until then this PR is a draft (as 
noted by the "WIP" tag).  

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR is to fulfill the stage-in/stage-out ECP Milestone for the 
end of May 2020.  

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
This commit is just comments where the hooks will go.  

Testing will be implemented and documented as the patch gets put together.  


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
