### PR TITLE
Update bootstrap.sh to use GOTCHA 1.0.3

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -54,7 +54,7 @@ cd ..
 echo "### building GOTCHA ###"
 cd GOTCHA
 # Unify won't build against latest GOTCHA, so use a known compatible version.
-git checkout 0.0.2
+git checkout 1.0.3
 mkdir -p build && cd build
 cmake -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" ..
 make -j $(nproc) && make install


### PR DESCRIPTION
### Description
Update bootstrap.sh to use GOTCHA 1.0.3

### Motivation and Context
Spack builds were already updated to use GOTCHA 1.0.3.  We need to do the same for bootstrap.sh.

### How Has This Been Tested?
Test built

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
