### PR TITLE
fixes for server shutdown errors

### DIFF
--- a/client/src/unifyfs.c
+++ b/client/src/unifyfs.c
@@ -298,7 +298,7 @@ inline int unifyfs_intercept_path(const char* path, char* upath)
     int intercept = 0;
     if (strncmp(target, unifyfs_mount_prefix, unifyfs_mount_prefixlen) == 0) {
         /* characters in target up through mount point match,
-         * assume we match */ 
+         * assume we match */
         intercept = 1;
 
         /* if we have another character, it must be '/' */
@@ -2215,7 +2215,7 @@ static int unifyfs_init(void)
             if (strncmp(unifyfs_cwd, unifyfs_mount_prefix,
                 unifyfs_mount_prefixlen) == 0) {
                 /* characters in target up through mount point match,
-                 * assume we match */ 
+                 * assume we match */
                 cwd_within_mount = 1;
 
                 /* if we have another character, it must be '/' */
@@ -2371,7 +2371,10 @@ static int unifyfs_finalize(void)
     }
 
     /* close spillover files */
-    unifyfs_logio_close(logio_ctx);
+    if (NULL != logio_ctx) {
+        unifyfs_logio_close(logio_ctx);
+        logio_ctx = NULL;
+    }
     if (unifyfs_spillmetablock != -1) {
         close(unifyfs_spillmetablock);
         unifyfs_spillmetablock = -1;

--- a/common/src/unifyfs_logio.c
+++ b/common/src/unifyfs_logio.c
@@ -396,6 +396,7 @@ int unifyfs_logio_close(logio_context* ctx)
                 LOGERR("Failed to unmap logio spill file header (errno=%s)",
                        strerror(err));
             }
+            ctx->spill_hdr = NULL;
         }
         if (-1 != ctx->spill_fd) {
             /* close spill file */
@@ -405,6 +406,7 @@ int unifyfs_logio_close(logio_context* ctx)
                 LOGERR("Failed to close logio spill file (errno=%s)",
                        strerror(err));
             }
+            ctx->spill_fd = -1;
         }
     }
 

--- a/server/src/unifyfs_request_manager.h
+++ b/server/src/unifyfs_request_manager.h
@@ -53,7 +53,7 @@ typedef struct reqmgr_thrd {
 
     /* condition variable to synchronize request manager thread
      * and main thread delivering work */
-    pthread_cond_t  thrd_cond;
+    pthread_cond_t thrd_cond;
 
     /* lock for shared data structures (variables below) */
     pthread_mutex_t thrd_lock;


### PR DESCRIPTION
### Description

Additional testing on Summitdev with latest dev branch and the read and write examples produced a couple different segfault errors during server shutdown. Both were caused by redundant attempts to clean up client state.

* reset logio context values in logio_close()
* reset logio_ctx to NULL after logio_close()
* avoid redundant client disconnect
* safer resource manager thread cleanup

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
