### PR TITLE
Add unit test to reproduce issue #488

### DIFF
--- a/t/sys/sysio_suite.c
+++ b/t/sys/sysio_suite.c
@@ -84,6 +84,7 @@ int main(int argc, char* argv[])
     lseek_test(unifyfs_root);
 
     write_read_test(unifyfs_root);
+    write_pre_existing_file_test(unifyfs_root);
 
     write_read_hole_test(unifyfs_root);
 

--- a/t/sys/sysio_suite.h
+++ b/t/sys/sysio_suite.h
@@ -50,6 +50,8 @@ int lseek_test(char* unifyfs_root);
 
 int write_read_test(char* unifyfs_root);
 
+int write_pre_existing_file_test(char* unifyfs_root);
+
 /* test reading from file with holes */
 int write_read_hole_test(char* unifyfs_root);
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
This adds a unit test to reproduce issue #488. In particular, this is the self-contained version of the test that doesn't bring in any outside files.

The failing test is wrapped in a `todo()` to mark it as an XFAIL to allow the test suite to pass. Once the issue is fixed and the test is passing, the `todo()` and `end_todo` can be removed.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
