### PR TITLE
unifyfs-stage utility for data staging. 

### DIFF
--- a/common/src/unifyfs_const.h
+++ b/common/src/unifyfs_const.h
@@ -68,6 +68,7 @@
 /* timeout (in seconds) of waiting for initialization of all servers */
 #define UNIFYFS_DEFAULT_INIT_TIMEOUT 120
 #define UNIFYFSD_PID_FILENAME "unifyfsd.pids"
+#define UNIFYFS_STAGE_STATUS_FILENAME "unifyfs-stage.status"
 
 // Client
 #define UNIFYFS_MAX_FILES 128

--- a/configure.ac
+++ b/configure.ac
@@ -66,9 +66,6 @@ AC_CHECK_HEADERS([wchar.h wctype.h])
 AC_CHECK_HEADERS([sys/mount.h sys/socket.h sys/statfs.h sys/time.h])
 AC_CHECK_HEADERS([arpa/inet.h netdb.h netinet/in.h])
 
-AC_CHECK_HEADER([openssl/md5.h], [],
-                [AC_MSG_FAILURE([*** openssl/md5.h missing, openssl-devel package required])])
-
 # Checks for library functions.
 AC_FUNC_MALLOC
 AC_FUNC_MMAP
@@ -167,6 +164,9 @@ UNIFYFS_AC_SPATH
 
 UNIFYFS_AC_MARGO
 UNIFYFS_AC_FLATCC
+
+# openssl for md5 checksum
+UNIFYFS_AC_OPENSSL
 
 # checks to see how we can print 64 bit values on this architecture
 gt_INTTYPES_PRI
@@ -389,7 +389,9 @@ AC_CONFIG_FILES([Makefile
                  util/scripts/Makefile
                  util/scripts/lsfcsm/Makefile
                  util/unifyfs/Makefile
-                 util/unifyfs/src/Makefile])
+                 util/unifyfs/src/Makefile
+                 util/unifyfs-stage/Makefile
+                 util/unifyfs-stage/src/Makefile])
 
 AC_CONFIG_FILES([client/unifyfs-config], [chmod +x client/unifyfs-config])
 AC_CONFIG_FILES([util/scripts/lsfcsm/unifyfs_lsfcsm_prolog], [chmod +x util/scripts/lsfcsm/unifyfs_lsfcsm_prolog])

--- a/m4/openssl.m4
+++ b/m4/openssl.m4
@@ -1,0 +1,20 @@
+AC_DEFUN([UNIFYFS_AC_OPENSSL], [
+  # preserve state of flags
+  OPENSSL_OLD_CFLAGS=$CFLAGS
+  OPENSSL_OLD_CXXFLAGS=$CXXFLAGS
+  OPENSSL_OLD_LDFLAGS=$LDFLAGS
+
+  PKG_CHECK_MODULES([OPENSSL],[openssl],
+   [
+    AC_SUBST(OPENSSL_CFLAGS)
+    AC_SUBST(OPENSSL_LIBS)
+   ],
+   [AC_MSG_ERROR(m4_normalize([
+     couldn't find a suitable openssl-devel
+   ]))])
+
+  # restore flags
+  CFLAGS=$OPENSSL_OLD_CFLAGS
+  CXXFLAGS=$OPENSSL_OLD_CXXFLAGS
+  LDFLAGS=$OPENSSL_OLD_LDFLAGS
+])

--- a/t/0700-unifyfs-stage-full.t
+++ b/t/0700-unifyfs-stage-full.t
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# Test unifyfs-stage executable for basic functionality
+#
+
+test_description="Test basic functionality of unifyfs-stage executable"
+
+. $(dirname $0)/sharness.sh
+
+test_expect_success "unifyfs-stage exists" '
+    test_path_is_file ${SHARNESS_BUILD_DIRECTORY}/util/unifyfs-stage/src/unifyfs-stage
+'
+test_expect_success "testing temp dir exists" '
+    test_path_is_dir  ${UNIFYFS_TEST_TMPDIR}
+'
+
+mkdir -p ${UNIFYFS_TEST_TMPDIR}/config_0700
+mkdir -p ${UNIFYFS_TEST_TMPDIR}/stage_source
+mkdir -p ${UNIFYFS_TEST_TMPDIR}/stage_destination_0700
+
+test_expect_success "stage testing dirs exist" '
+    test_path_is_dir  ${UNIFYFS_TEST_TMPDIR}/config_0700
+    test_path_is_dir  ${UNIFYFS_TEST_TMPDIR}/stage_source
+    test_path_is_dir  ${UNIFYFS_TEST_TMPDIR}/stage_destination_0700
+'
+
+dd if=/dev/urandom bs=4M count=1 of=${UNIFYFS_TEST_TMPDIR}/stage_source/source_0700.file
+
+test_expect_success "source.file exists" '
+    test_path_is_file ${UNIFYFS_TEST_TMPDIR}/stage_source/source_0700.file
+'
+
+rm -f ${UNIFYFS_TEST_TMPDIR}/config_0700/*
+rm -f ${UNIFYFS_TEST_TMPDIR}/stage_destination_0700/*
+
+test_expect_success "config_0700 directory is empty" '
+    test_dir_is_empty ${UNIFYFS_TEST_TMPDIR}/config_0700
+'
+
+echo "\"${UNIFYFS_TEST_TMPDIR}/stage_source/source_0700.file\" \"${UNIFYFS_TEST_MOUNT}/intermediate.file\""  > ${UNIFYFS_TEST_TMPDIR}/config_0700/test_IN.manifest
+echo "\"${UNIFYFS_TEST_MOUNT}/intermediate.file\" \"${UNIFYFS_TEST_TMPDIR}/stage_destination_0700/destination_0700.file\"" > ${UNIFYFS_TEST_TMPDIR}/config_0700/test_OUT.manifest
+
+test_expect_success "config_0700 directory now has manifest files" '
+    test_path_is_file  ${UNIFYFS_TEST_TMPDIR}/config_0700/test_IN.manifest
+    test_path_is_file  ${UNIFYFS_TEST_TMPDIR}/config_0700/test_OUT.manifest
+'
+
+test_expect_success "target directory is empty" '
+    test_dir_is_empty ${UNIFYFS_TEST_TMPDIR}/stage_destination_0700
+'
+
+${SHARNESS_BUILD_DIRECTORY}/util/unifyfs-stage/src/unifyfs-stage -m ${UNIFYFS_TEST_MOUNT} ${UNIFYFS_TEST_TMPDIR}/config_0700/test_IN.manifest > ${UNIFYFS_TEST_TMPDIR}/config_0700/stage_IN_output.OUT 2>&1
+
+${SHARNESS_BUILD_DIRECTORY}/util/unifyfs-stage/src/unifyfs-stage -m ${UNIFYFS_TEST_MOUNT} ${UNIFYFS_TEST_TMPDIR}/config_0700/test_OUT.manifest > ${UNIFYFS_TEST_TMPDIR}/config_0700/stage_OUT_output.OUT 2>&1
+
+test_expect_success "input file has been staged to output" '
+    test_path_is_file ${UNIFYFS_TEST_TMPDIR}/stage_destination_0700/destination_0700.file
+'
+
+test_expect_success "final output is identical to initial input" '
+    test_might_fail test_cmp ${UNIFYFS_TEST_TMPDIR}/stage_source/source_0700.file ${UNIFYFS_TEST_TMPDIR}/stage_destination_0700/destination_0700.file
+'
+
+test_done

--- a/t/9300-unifyfs-stage-isolated.t
+++ b/t/9300-unifyfs-stage-isolated.t
@@ -1,0 +1,62 @@
+#!/bin/bash
+#
+# Test unifyfs-stage executable for basic functionality
+#
+
+test_description="Test basic functionality of unifyfs-stage executable"
+
+. $(dirname $0)/sharness.sh
+
+test_expect_success "unifyfs-stage exists" '
+    test_path_is_file ${SHARNESS_BUILD_DIRECTORY}/util/unifyfs-stage/src/unifyfs-stage
+'
+test_expect_success "testing temp dir exists" '
+    test_path_is_dir  ${UNIFYFS_TEST_TMPDIR}
+'
+
+mkdir -p ${UNIFYFS_TEST_TMPDIR}/config_9300
+mkdir -p ${UNIFYFS_TEST_TMPDIR}/stage_source
+mkdir -p ${UNIFYFS_TEST_TMPDIR}/stage_destination_9300
+
+test_expect_success "stage testing dirs exist" '
+    test_path_is_dir  ${UNIFYFS_TEST_TMPDIR}/config_9300
+    test_path_is_dir  ${UNIFYFS_TEST_TMPDIR}/stage_source
+    test_path_is_dir  ${UNIFYFS_TEST_TMPDIR}/stage_destination_9300
+'
+
+# NOTE: we're using the unifyfs-stage binary as its own transfer data target
+# because we know it's there and it's filled with non-zero data.
+cp ${SHARNESS_BUILD_DIRECTORY}/util/unifyfs-stage/src/unifyfs-stage ${UNIFYFS_TEST_TMPDIR}/stage_source/source_9300.file
+
+test_expect_success "source.file exists" '
+    test_path_is_file ${UNIFYFS_TEST_TMPDIR}/stage_source/source_9300.file
+'
+
+rm - f $ {UNIFYFS_TEST_TMPDIR} / config_9300/*
+rm -f ${UNIFYFS_TEST_TMPDIR}/stage_destination_9300/*
+
+test_expect_success "config_9300 directory is empty" '
+    test_dir_is_empty ${UNIFYFS_TEST_TMPDIR}/config_9300
+'
+
+echo "\"${UNIFYFS_TEST_TMPDIR}/stage_source/source_9300.file\" \"${UNIFYFS_TEST_TMPDIR}/stage_destination_9300/destination_9300.file\""  > ${UNIFYFS_TEST_TMPDIR}/config_9300/test_INOUT.manifest
+
+test_expect_success "config_9300 directory now has manifest files" '
+    test_path_is_file  ${UNIFYFS_TEST_TMPDIR}/config_9300/test_INOUT.manifest
+'
+
+test_expect_success "target directory is empty" '
+    test_dir_is_empty ${UNIFYFS_TEST_TMPDIR}/stage_destination_9300
+'
+
+${SHARNESS_BUILD_DIRECTORY}/util/unifyfs-stage/src/unifyfs-stage -N ${UNIFYFS_TEST_TMPDIR}/config_9300/test_INOUT.manifest > ${UNIFYFS_TEST_TMPDIR}/config_9300/stage_INOUT_output.OUT 2>&1
+
+test_expect_success "input file has been staged to output" '
+    test_path_is_file ${UNIFYFS_TEST_TMPDIR}/stage_destination_9300/destination_9300.file
+'
+
+test_expect_success "final output is identical to initial input" '
+    test_cmp ${UNIFYFS_TEST_TMPDIR}/stage_source/source_9300.file ${UNIFYFS_TEST_TMPDIR}/stage_destination_9300/destination_9300.file
+'
+
+test_done

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -9,12 +9,14 @@ TESTS = \
 	0200-stdio-gotcha.t \
 	0500-sysio-static.t \
 	0600-stdio-static.t \
+	0700-unifyfs-stage-full.t \
 	9005-unifyfs-unmount.t \
 	9010-stop-unifyfsd.t \
 	9020-mountpoint-empty.t \
 	9100-metadata-api.t \
 	9200-seg-tree-test.t \
 	9201-slotmap-test.t \
+	9300-unifyfs-stage-isolated.t \
 	9999-cleanup.t
 
 check_SCRIPTS = \
@@ -23,12 +25,14 @@ check_SCRIPTS = \
 	0200-stdio-gotcha.t \
 	0500-sysio-static.t \
 	0600-stdio-static.t \
+	0700-unifyfs-stage-full.t \
 	9005-unifyfs-unmount.t \
 	9010-stop-unifyfsd.t \
 	9020-mountpoint-empty.t \
 	9100-metadata-api.t \
 	9200-seg-tree-test.t \
 	9201-slotmap-test.t \
+	9300-unifyfs-stage-isolated.t \
 	9999-cleanup.t
 
 EXTRA_DIST = \

--- a/util/Makefile.am
+++ b/util/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = scripts unifyfs
+SUBDIRS = scripts unifyfs unifyfs-stage

--- a/util/unifyfs-stage/Makefile.am
+++ b/util/unifyfs-stage/Makefile.am
@@ -1,0 +1,1 @@
+SUBDIRS = src

--- a/util/unifyfs-stage/src/Makefile.am
+++ b/util/unifyfs-stage/src/Makefile.am
@@ -1,0 +1,21 @@
+libexec_PROGRAMS = unifyfs-stage
+
+unifyfs_stage_SOURCES = unifyfs-stage.c \
+                        unifyfs-stage-transfer.c
+
+noinst_HEADERS = unifyfs-stage.h
+
+unifyfs_stage_CPPFLAGS = $(AM_CPPFLAGS) $(MPI_CFLAGS) \
+                         $(OPENSSL_CFLAGS) \
+                         -I$(top_srcdir)/client/src \
+                         -I$(top_srcdir)/common/src
+
+unifyfs_stage_LDADD = $(top_builddir)/client/src/libunifyfs.la -lrt -lm
+
+unifyfs_stage_LDFLAGS = -static $(CP_WRAPPERS) $(AM_LDFLAGS) \
+                        $(MPI_CLDFLAGS) $(FLATCC_LDFLAGS) $(FLATCC_LIBS) \
+                        $(OPENSSL_LIBS)
+
+AM_CFLAGS = -Wall -Werror
+
+CLEANFILES = $(libexec_PROGRAMS)

--- a/util/unifyfs-stage/src/unifyfs-stage-transfer.c
+++ b/util/unifyfs-stage/src/unifyfs-stage-transfer.c
@@ -1,0 +1,403 @@
+/*
+ * Copyright (c) 2020, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2020, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyFS.
+ * For details, see https://github.com/LLNL/UnifyFS.
+ * Please read https://github.com/LLNL/UnifyFS/LICENSE for full license text.
+ */
+#include <config.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <errno.h>
+#include <ctype.h>
+#include <limits.h>
+#include <sys/time.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <dirent.h>
+#include <libgen.h>
+#include <getopt.h>
+#include <time.h>
+#include <mpi.h>
+#include <openssl/md5.h>
+
+#include "unifyfs-stage.h"
+
+/**
+ * @brief Run md5 checksum on specified file, send back
+ *        digest.
+ *
+ * @param path      path to the target file
+ * @param digest    hash of the file
+ *
+ * @return 0 on success, errno otherwise
+ */
+static int md5_checksum(const char* path, unsigned char* digest)
+{
+    int ret = 0;
+    size_t len = 0;
+    int fd = -1;
+    unsigned char data[UNIFYFS_STAGE_MD5_BLOCKSIZE] = { 0, };
+    MD5_CTX md5;
+
+    fd = open(path, O_RDONLY);
+    if (fd < 0) {
+        perror("open");
+        return errno;
+    }
+
+    ret = MD5_Init(&md5);
+    if (!ret) {
+        fprintf(stderr, "failed to create md5 context\n");
+        goto out;
+    }
+
+    while ((len = read(fd, (void*) data, UNIFYFS_STAGE_MD5_BLOCKSIZE)) != 0) {
+        ret = MD5_Update(&md5, data, len);
+        if (!ret) {
+            fprintf(stderr, "failed to update checksum\n");
+            goto out;
+        }
+    }
+
+    ret = MD5_Final(digest, &md5);
+    if (!ret) {
+        fprintf(stderr, "failed to finalize md5\n");
+    }
+
+out:
+    /* MD5_xx returns 1 for success */
+    ret = ret == 1 ? 0 : EIO;
+    close(fd);
+
+    return ret;
+}
+
+/**
+ * @brief prints md5 checksum into string
+ *
+ * @param buf       buffer to print into
+ * @param digest    hash of the file
+ *
+ * @return buffer that has been printed to
+ */
+static char* checksum_str(char* buf, unsigned char* digest)
+{
+    int i = 0;
+    char* pos = buf;
+
+    for (i = 0; i < MD5_DIGEST_LENGTH; i++) {
+        pos += sprintf(pos, "%02x", digest[i]);
+    }
+
+    pos[0] = '\0';
+
+    return buf;
+}
+
+/**
+ * @brief takes check sums of two files and compares
+ *
+ * @param src     path to one file
+ * @param dst     path to the other file
+ *
+ * @return 0 if files are identical, non-zero if not, or other error
+ */
+static int verify_checksum(const char* src, const char* dst)
+{
+    int ret = 0;
+    int i = 0;
+    char md5src[2 * MD5_DIGEST_LENGTH + 1] = { 0, };
+    char md5dst[2 * MD5_DIGEST_LENGTH + 1] = { 0, };
+    unsigned char src_digest[MD5_DIGEST_LENGTH + 1] = { 0, };
+    unsigned char dst_digest[MD5_DIGEST_LENGTH + 1] = { 0, };
+
+    src_digest[MD5_DIGEST_LENGTH] = '\0';
+    dst_digest[MD5_DIGEST_LENGTH] = '\0';
+
+    ret = md5_checksum(src, src_digest);
+    if (ret) {
+        fprintf(stderr, "failed to calculate checksum for %s (%s)\n",
+                        src, strerror(ret));
+        return ret;
+    }
+
+    ret = md5_checksum(dst, dst_digest);
+    if (ret) {
+        fprintf(stderr, "failed to calculate checksum for %s (%s)\n",
+                        dst, strerror(ret));
+        return ret;
+    }
+
+    if (verbose) {
+        printf("[%d] src: %s, dst: %s\n", rank,
+               checksum_str(md5src, src_digest),
+               checksum_str(md5dst, dst_digest));
+    }
+
+    for (i = 0; i < MD5_DIGEST_LENGTH; i++) {
+        if (src_digest[i] != dst_digest[i]) {
+            fprintf(stderr, "[%d] checksum verification failed: "
+                            "(src=%s, dst=%s)\n", rank,
+                            checksum_str(md5src, src_digest),
+                            checksum_str(md5dst, dst_digest));
+            ret = EIO;
+        }
+    }
+
+    return ret;
+}
+
+/*
+ * Parse a line from the manifest in the form of:
+ *
+ * <src path> <whitespace separator> <dest path>
+ *
+ * If the paths have spaces, they must be quoted.
+ *
+ * On success, return 0 along with allocated src and dest strings.  These
+ * must be freed when you're finished with them.  On failure return non-zero,
+ * and set src and dest to NULL.
+ *
+ * Note, leading and tailing whitespace are ok.  They just get ignored.
+ * Lines with only whitespace are ignored.  A line of all whitespace will
+ * return 0, with src and dest being NULL, so users should not check for
+ * 'if (*src == NULL)' to see if the function failed.  They should be looking
+ * at the return code.
+ */
+/**
+ * @brief parses manifest file line, passes back src and dst strings
+ *
+ * @param line    input manifest file line
+ * @param src     return val of src filename
+ * @param dst     return val of dst filename
+ *
+ * @return 0 if all was well, or there was nothing; non-zero on error
+ */
+int
+unifyfs_parse_manifest_line(char* line, char** src, char** dest)
+{
+    char* new_src = NULL;
+    char* new_dest = NULL;
+    char* copy;
+    char* tmp;
+    unsigned long copy_len;
+    int i;
+    unsigned int tmp_count;
+    int in_quotes = 0;
+    int rc = 0;
+
+    copy = strdup(line);
+    copy_len = strlen(copy) + 1;/* +1 for '\0' */
+
+    /* Replace quotes and separator with '\0' */
+    for (i = 0; i < copy_len; i++) {
+        if (copy[i] == '"') {
+            in_quotes ^= 1;/* toggle */
+            copy[i] = '\0';
+        } else if (isspace(copy[i]) && !in_quotes) {
+            /*
+             * Allow any whitespace for our separator
+             */
+            copy[i] = '\0';
+        }
+    }
+
+    /*
+     * copy[] now contains a series of strings, one after the other
+     * (possibly containing some NULL strings, which we ignore)
+     */
+    tmp = copy;
+    while (tmp < copy + copy_len) {
+        tmp_count = strlen(tmp);
+        if (tmp_count > 0) {
+            /* We have a real string */
+            if (!new_src) {
+                new_src = strdup(tmp);
+            } else {
+                if (!new_dest) {
+                    new_dest = strdup(tmp);
+                } else {
+                    /* Error: a third file name */
+                    rc = 1;
+                    break;
+                }
+            }
+        }
+        tmp += tmp_count + 1;
+    }
+
+    /* Some kind of error parsing a line */
+    if (rc != 0 || (new_src && !new_dest)) {
+        fprintf(stderr, "manifest file line >>%s<< is invalid!\n",
+                line);
+        free(new_src);
+        free(new_dest);
+        new_src = NULL;
+        new_dest = NULL;
+        if (rc == 0) {
+            rc = 1;
+        }
+    }
+
+    *src = new_src;
+    *dest = new_dest;
+
+    free(copy);
+    return rc;
+}
+
+/**
+ * @brief controls the action of the stage-in or stage-out.  Opens up
+ *        the manifest file, sends each line to be parsed, and fires
+ *        each source/destination to be staged.
+ *
+ * @param ctx     stage context and instructions
+ *
+ * @return 0 indicates success, non-zero is error
+ */
+int unifyfs_stage_transfer(unifyfs_stage_t* ctx)
+{
+    int ret = 0;
+    int count = 0;
+    FILE* fp = NULL;
+    char* src = NULL;
+    char* dst = NULL;
+    char linebuf[LINE_MAX] = { 0, };
+    struct stat sb = { 0, };
+
+    if (!ctx) {
+        return EINVAL;
+    }
+
+    fp = fopen(ctx->manifest_file, "r");
+    if (!fp) {
+        fprintf(stderr, "failed to open file %s: %s\n",
+		ctx->manifest_file, strerror(errno));
+        ret = errno;
+        goto out;
+    }
+
+    while (NULL != fgets(linebuf, LINE_MAX-1, fp)) {
+        if (strlen(linebuf) < 5) {
+	    // the manifest file perhaps ends with a couple of characters
+	    // and/or a newline not meant to be a transfer spec.
+            if (linebuf[0] == '\n') {
+	        goto out;
+            } else{
+	        fprintf(stderr, "Short (bad) manifest file line: >%s<\n",
+			linebuf);
+		ret = -EINVAL;
+                goto out;
+            }
+	}
+	ret = unifyfs_parse_manifest_line(linebuf, &src, &dst);
+	if (ret < 0) {
+	    fprintf(stderr, "failed to parse %s (%s)\n",
+		    linebuf, strerror(ret));
+            goto out;
+	}
+        if (ctx->mode == UNIFYFS_STAGE_SERIAL) {
+            if (count % total_ranks == rank) {
+                if (verbose) {
+                    fprintf(stdout, "[%d] serial transfer: src=%s, dst=%s\n",
+                                    rank, src, dst);
+                }
+
+                ret = unifyfs_transfer_file_serial(src, dst);
+                if (ret) {
+                    goto out;
+                }
+
+                if (ret < 0) {
+                    fprintf(stderr, "stat on %s failed (err=%d, %s)\n",
+                                    dst, errno, strerror(errno));
+                    ret = errno;
+                    goto out;
+                }
+
+                if (ctx->checksum) {
+                    ret = verify_checksum(src, dst);
+                    if (ret) {
+                        fprintf(stderr, "checksums for >%s< and >%s< differ!\n",
+                                src, dst);
+                        goto out;
+                    }
+                }
+            }
+        } else {
+            if (0 == rank) {
+                int fd = -1;
+
+                if (verbose) {
+                    fprintf(stdout, "[%d] parallel transfer: src=%s, dst=%s\n",
+                                    rank, src, dst);
+                }
+
+                /* FIXME: Since we cannot use the mpi barrier inside the
+                 * unifyfs_transfer_file_parallel(), we need to create the file
+                 * here before others start to access. It would be better if we
+                 * can skip this step.
+                 */
+                fd = open(dst, O_WRONLY|O_CREAT|O_TRUNC, 0600);
+                if (fd < 0) {
+                    fprintf(stderr, "[%d] failed to create the file %s\n",
+                                    rank, dst);
+                    goto out;
+                }
+
+                close(fd);
+            }
+
+            MPI_Barrier(MPI_COMM_WORLD);
+
+            ret = unifyfs_transfer_file_parallel(src, dst);
+            if (ret) {
+                goto out;
+            }
+
+            MPI_Barrier(MPI_COMM_WORLD);
+
+            ret = stat(dst, &sb);
+            if (ret < 0) {
+                fprintf(stderr, "stat on %s failed (err=%d, %s)\n",
+                                dst, errno, strerror(errno));
+                ret = errno;
+                goto out;
+            }
+
+            if (ctx->checksum && 0 == rank) {
+                ret = verify_checksum(src, dst);
+                if (ret) {
+                    goto out;
+                }
+            }
+        }
+
+        count++;
+    }
+out:
+    if (ret) {
+        fprintf(stderr, "failed to transfer file (src=%s, dst=%s): %s\n",
+                        src, dst, strerror(ret));
+    }
+
+    if (fp) {
+        fclose(fp);
+        fp = NULL;
+    }
+
+    return ret;
+}
+

--- a/util/unifyfs-stage/src/unifyfs-stage-transfer.c
+++ b/util/unifyfs-stage/src/unifyfs-stage-transfer.c
@@ -129,14 +129,14 @@ static int verify_checksum(const char* src, const char* dst)
     ret = md5_checksum(src, src_digest);
     if (ret) {
         fprintf(stderr, "failed to calculate checksum for %s (%s)\n",
-                        src, strerror(ret));
+                src, strerror(ret));
         return ret;
     }
 
     ret = md5_checksum(dst, dst_digest);
     if (ret) {
         fprintf(stderr, "failed to calculate checksum for %s (%s)\n",
-                        dst, strerror(ret));
+                dst, strerror(ret));
         return ret;
     }
 
@@ -149,9 +149,9 @@ static int verify_checksum(const char* src, const char* dst)
     for (i = 0; i < MD5_DIGEST_LENGTH; i++) {
         if (src_digest[i] != dst_digest[i]) {
             fprintf(stderr, "[%d] checksum verification failed: "
-                            "(src=%s, dst=%s)\n", rank,
-                            checksum_str(md5src, src_digest),
-                            checksum_str(md5dst, dst_digest));
+                    "(src=%s, dst=%s)\n", rank,
+                    checksum_str(md5src, src_digest),
+                    checksum_str(md5dst, dst_digest));
             ret = EIO;
         }
     }
@@ -275,7 +275,6 @@ int unifyfs_stage_transfer(unifyfs_stage_t* ctx)
     char* src = NULL;
     char* dst = NULL;
     char linebuf[LINE_MAX] = { 0, };
-    struct stat sb = { 0, };
 
     if (!ctx) {
         return EINVAL;
@@ -284,35 +283,34 @@ int unifyfs_stage_transfer(unifyfs_stage_t* ctx)
     fp = fopen(ctx->manifest_file, "r");
     if (!fp) {
         fprintf(stderr, "failed to open file %s: %s\n",
-		ctx->manifest_file, strerror(errno));
+                ctx->manifest_file, strerror(errno));
         ret = errno;
         goto out;
     }
 
-    while (NULL != fgets(linebuf, LINE_MAX-1, fp)) {
+    while (NULL != fgets(linebuf, LINE_MAX - 1, fp)) {
         if (strlen(linebuf) < 5) {
-	    // the manifest file perhaps ends with a couple of characters
-	    // and/or a newline not meant to be a transfer spec.
             if (linebuf[0] == '\n') {
-	        goto out;
-            } else{
-	        fprintf(stderr, "Short (bad) manifest file line: >%s<\n",
-			linebuf);
-		ret = -EINVAL;
+                // manifest file ends in a blank line
+                goto out;
+            } else {
+                fprintf(stderr, "Short (bad) manifest file line: >%s<\n",
+                        linebuf);
+                ret = -EINVAL;
                 goto out;
             }
-	}
-	ret = unifyfs_parse_manifest_line(linebuf, &src, &dst);
-	if (ret < 0) {
-	    fprintf(stderr, "failed to parse %s (%s)\n",
-		    linebuf, strerror(ret));
+        }
+        ret = unifyfs_parse_manifest_line(linebuf, &src, &dst);
+        if (ret < 0) {
+            fprintf(stderr, "failed to parse %s (%s)\n",
+                    linebuf, strerror(ret));
             goto out;
-	}
+        }
         if (ctx->mode == UNIFYFS_STAGE_SERIAL) {
             if (count % total_ranks == rank) {
                 if (verbose) {
                     fprintf(stdout, "[%d] serial transfer: src=%s, dst=%s\n",
-                                    rank, src, dst);
+                            rank, src, dst);
                 }
 
                 ret = unifyfs_transfer_file_serial(src, dst);
@@ -322,7 +320,7 @@ int unifyfs_stage_transfer(unifyfs_stage_t* ctx)
 
                 if (ret < 0) {
                     fprintf(stderr, "stat on %s failed (err=%d, %s)\n",
-                                    dst, errno, strerror(errno));
+                            dst, errno, strerror(errno));
                     ret = errno;
                     goto out;
                 }
@@ -342,21 +340,15 @@ int unifyfs_stage_transfer(unifyfs_stage_t* ctx)
 
                 if (verbose) {
                     fprintf(stdout, "[%d] parallel transfer: src=%s, dst=%s\n",
-                                    rank, src, dst);
+                            rank, src, dst);
                 }
 
-                /* FIXME: Since we cannot use the mpi barrier inside the
-                 * unifyfs_transfer_file_parallel(), we need to create the file
-                 * here before others start to access. It would be better if we
-                 * can skip this step.
-                 */
-                fd = open(dst, O_WRONLY|O_CREAT|O_TRUNC, 0600);
+                fd = open(dst, O_WRONLY | O_CREAT | O_TRUNC, 0600);
                 if (fd < 0) {
                     fprintf(stderr, "[%d] failed to create the file %s\n",
-                                    rank, dst);
+                            rank, dst);
                     goto out;
                 }
-
                 close(fd);
             }
 
@@ -369,13 +361,8 @@ int unifyfs_stage_transfer(unifyfs_stage_t* ctx)
 
             MPI_Barrier(MPI_COMM_WORLD);
 
-            ret = stat(dst, &sb);
-            if (ret < 0) {
-                fprintf(stderr, "stat on %s failed (err=%d, %s)\n",
-                                dst, errno, strerror(errno));
-                ret = errno;
-                goto out;
-            }
+            // possible lamination check or force lamination
+            // may need to go here
 
             if (ctx->checksum && 0 == rank) {
                 ret = verify_checksum(src, dst);
@@ -390,7 +377,7 @@ int unifyfs_stage_transfer(unifyfs_stage_t* ctx)
 out:
     if (ret) {
         fprintf(stderr, "failed to transfer file (src=%s, dst=%s): %s\n",
-                        src, dst, strerror(ret));
+                src, dst, strerror(ret));
     }
 
     if (fp) {

--- a/util/unifyfs-stage/src/unifyfs-stage.c
+++ b/util/unifyfs-stage/src/unifyfs-stage.c
@@ -1,0 +1,300 @@
+/*
+ * Copyright (c) 2020, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2020, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyFS.
+ * For details, see https://github.com/LLNL/UnifyFS.
+ * Please read https://github.com/LLNL/UnifyFS/LICENSE for full license text.
+ */
+/* unifyfs-stage: this application is supposed to excuted by the unifyfs
+ * command line utility for:
+ * - stage in: moving files in pfs to unifyfs volume before user starts
+ *   application,
+ *   e.g., unifyfs start --stage-in=<manifest file>
+ * - stage out: moving files in the unifyfs volume to parallel file system
+ *   after user application completes,
+ *   e.g., unifyfs terminate --stage-out=<manifest file>
+ *
+ * Currently, we request users to pass the <manifest file> to specify target
+ * files to be transferred. The <manifest file> should list all target files
+ * and their destinations, line by line.
+ *
+ * This supports two transfer modes (although both are technically parallel):
+ *
+ * - serial: Each process will transfer a file. Data of a single file will
+ *   reside in a single compute node.
+ * - parallel (-p, --parallel): Each file will be split and transferred by all
+ *   processes. Data of a single file will be spread evenly across all
+ *   available compute nodes.
+ *
+ * TODO:
+ * Maybe later on, it would be better to have a size threshold. Based on the
+ * threshold, we can determine whether a file needs to transferred serially (if
+ * smaller than threshold), or parallelly.
+ */
+#include <config.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <getopt.h>
+#include <errno.h>
+#include <limits.h>
+#include <libgen.h>
+#include <mpi.h>
+#include <unifyfs_misc.h>
+
+#include "unifyfs_const.h"
+#include "unifyfs-stage.h"
+
+int rank;
+int total_ranks;
+int verbose;
+
+static int debug;
+static int checksum;
+static int mode;
+static char* manifest_file;
+static char* mountpoint = "/unifyfs";
+static char* share_dir;
+
+static unifyfs_stage_t _ctx;
+
+/**
+ * @brief create a status (lock) file to notify the unifyfs executable
+ * when the staging is finished
+ *
+ * @param status 0 indicates success
+ *
+ * @return 0 on success, errno otherwise
+ */
+static int create_status_file(int status)
+{
+    char filename[PATH_MAX];
+    FILE* fp = NULL;
+    const char* msg = status ? "fail" : "success";
+    int return_val_from_scnprintf;
+
+    return_val_from_scnprintf =
+        scnprintf(filename, PATH_MAX,
+		  "%s/%s", share_dir, UNIFYFS_STAGE_STATUS_FILENAME);
+    if (return_val_from_scnprintf > (PATH_MAX-1)) {
+        fprintf(stderr, "Stage status file is too long!\n");
+        return -ENOMEM;
+    }
+
+    fp = fopen(filename, "w");
+    if (!fp) {
+        fprintf(stderr, "failed to create %s (%s)\n",
+                        filename, strerror(errno));
+        return errno;
+    }
+
+    fprintf(fp, "%s\n", msg);
+
+    fclose(fp);
+
+    return 0;
+}
+
+static struct option long_opts[] = {
+    { "checksum", 0, 0, 'c' },
+    { "debug", 0, 0, 'd' },
+    { "help", 0, 0, 'h' },
+    { "mountpoint", 1, 0, 'm' },
+    { "parallel", 0, 0, 'p' },
+    { "share-dir", 1, 0, 's' },
+    { "verbose", 0, 0, 'v' },
+    { 0, 0, 0, 0 },
+};
+
+static char* short_opts = "cdhm:ps:v";
+
+static const char* usage_str =
+    "\n"
+    "Usage: %s [OPTION]... <manifest file>\n"
+    "\n"
+    "Transfer files between unifyfs volume and external file system.\n"
+    "The <manifest file> should contain list of files to be transferred,\n"
+    "and each line should be formatted as\n"
+    "\n"
+    "  /source/file/path,/destination/file/path\n"
+    "\n"
+    "Specifying directories is not supported.\n"
+    "\n"
+    "Available options:\n"
+    "\n"
+    "  -c, --checksum           verify md5 checksum for each transfer\n"
+    "  -h, --help               print this usage\n"
+    "  -m, --mountpoint=<mnt>   use <mnt> as unifyfs mountpoint\n"
+    "                           (default: /unifyfs)\n"
+    "  -p, --parallel           transfer each file in parallel\n"
+    "                           (experimental)\n"
+    "  -s, --share-dir=<path>   directory path for creating status file\n"
+    "  -v, --verbose            print noisy outputs\n"
+    "\n"
+    "Without the '-p, --parallel' option, a file is transferred by a single\n"
+    "process. If the '-p, --parallel' option is specified, each file will be\n"
+    "divided by multiple processes and transferred in parallel.\n"
+    "\n";
+
+static char* program;
+
+static void print_usage(void)
+{
+    if (0 == rank) {
+        fprintf(stdout, usage_str, program);
+    }
+}
+
+static inline
+void debug_pause(int rank, const char* fmt, ...)
+{
+    if (rank == 0) {
+        va_list args;
+
+        va_start(args, fmt);
+        vfprintf(stderr, fmt, args);
+        va_end(args);
+
+        fprintf(stderr, " ENTER to continue ... ");
+
+        (void) getchar();
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    /* internal accept() call from mpi may set errno */
+    errno = 0;
+}
+
+static int parse_option(int argc, char** argv)
+{
+    int ch = 0;
+    int optidx = 0;
+    char* filepath = NULL;
+
+    if (argc < 2) {
+        return EINVAL;
+    }
+
+    while ((ch = getopt_long(argc, argv,
+                             short_opts, long_opts, &optidx)) >= 0) {
+        switch (ch) {
+        case 'c':
+            checksum = 1;
+            break;
+
+        case 'd':
+            debug = 1;
+            break;
+
+        case 'm':
+            mountpoint = strdup(optarg);
+            break;
+
+        case 'p':
+            mode = UNIFYFS_STAGE_PARALLEL;
+            break;
+
+        case 's':
+            share_dir = strdup(optarg);
+            break;
+
+        case 'v':
+            verbose = 1;
+            break;
+
+        case 'h':
+        default:
+            break;
+        }
+    }
+
+    if (argc - optind != 1) {
+        return EINVAL;
+    }
+
+    filepath = argv[optind];
+
+    manifest_file = realpath(filepath, NULL);
+    if (!manifest_file) {
+        fprintf(stderr, "problem with accessing file %s: %s\n",
+                        filepath, strerror(errno));
+        return errno;
+    }
+
+    return 0;
+}
+
+int main(int argc, char** argv)
+{
+    int ret = 0;
+    unifyfs_stage_t* ctx = &_ctx;
+
+    program = basename(strdup(argv[0]));
+
+    MPI_Init(&argc, &argv);
+    MPI_Comm_size(MPI_COMM_WORLD, &total_ranks);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    ret = parse_option(argc, argv);
+    if (ret) {
+        if (EINVAL == ret) {
+            print_usage();
+        }
+        goto out;
+    }
+
+    ctx->rank = rank;
+    ctx->total_ranks = total_ranks;
+    ctx->checksum = checksum;
+    ctx->mode = mode;
+    ctx->mountpoint = mountpoint;
+    ctx->manifest_file = manifest_file;
+
+    if (verbose) {
+        unifyfs_stage_print(ctx);
+    }
+
+    if (debug) {
+        debug_pause(rank, "About to mount unifyfs.. ");
+    }
+
+    ret = unifyfs_mount(mountpoint, rank, total_ranks, 0);
+    if (ret) {
+        fprintf(stderr, "failed to mount unifyfs at %s (%s)",
+                        ctx->mountpoint, strerror(ret));
+        goto out;
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    ret = unifyfs_stage_transfer(ctx);
+    if (ret) {
+        fprintf(stderr, "data transfer failed (%s)\n", strerror(errno));
+    }
+
+    if (share_dir) {
+        ret = create_status_file(ret);
+        if (ret) {
+            fprintf(stderr, "failed to create the status file (%s)\n",
+                            strerror(errno));
+        }
+    }
+
+    ret = unifyfs_unmount();
+    if (ret) {
+        fprintf(stderr, "unmounting unifyfs failed (ret=%d)\n", ret);
+    }
+out:
+    MPI_Finalize();
+
+    return ret;
+}
+

--- a/util/unifyfs-stage/src/unifyfs-stage.h
+++ b/util/unifyfs-stage/src/unifyfs-stage.h
@@ -22,6 +22,7 @@ struct _unifyfs_stage {
 
     int checksum;           /* perform checksum? 0:no, 1:yes */
     int mode;               /* transfer mode? 0:serial, 1:parallel */
+    int should_we_mount_unifyfs;  /* mount? 0:no (for testing), 1: yes */
     char* mountpoint;       /* unifyfs mountpoint */
     char* manifest_file;    /* manifest file containing the transfer list */
 };
@@ -35,12 +36,14 @@ static inline void unifyfs_stage_print(unifyfs_stage_t* ctx)
            "total ranks = %d\n"
            "checksum = %d\n"
            "mode = %d\n"
+           "should_we_mount_unifyfs = %d\n"
            "mountpoint = %s\n"
            "manifest file = %s\n",
            ctx->rank,
            ctx->total_ranks,
            ctx->checksum,
            ctx->mode,
+           ctx->should_we_mount_unifyfs,
            ctx->mountpoint,
            ctx->manifest_file);
 }

--- a/util/unifyfs-stage/src/unifyfs-stage.h
+++ b/util/unifyfs-stage/src/unifyfs-stage.h
@@ -1,0 +1,61 @@
+#ifndef __UNIFYFS_STAGE_H
+#define __UNIFYFS_STAGE_H
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <unifyfs.h>
+
+#define UNIFYFS_STAGE_MD5_BLOCKSIZE    (1048576)
+
+/*
+ * serial: each file is tranferred by a process.
+ * parallel: a file is transferred by all processes.
+ */
+enum {
+    UNIFYFS_STAGE_SERIAL = 0,
+    UNIFYFS_STAGE_PARALLEL = 1,
+};
+
+struct _unifyfs_stage {
+    int rank;               /* my rank */
+    int total_ranks;        /* mpi world size */
+
+    int checksum;           /* perform checksum? 0:no, 1:yes */
+    int mode;               /* transfer mode? 0:serial, 1:parallel */
+    char* mountpoint;       /* unifyfs mountpoint */
+    char* manifest_file;    /* manifest file containing the transfer list */
+};
+
+typedef struct _unifyfs_stage unifyfs_stage_t;
+
+static inline void unifyfs_stage_print(unifyfs_stage_t* ctx)
+{
+    printf("== unifyfs stage context ==\n"
+           "rank = %d\n"
+           "total ranks = %d\n"
+           "checksum = %d\n"
+           "mode = %d\n"
+           "mountpoint = %s\n"
+           "manifest file = %s\n",
+           ctx->rank,
+           ctx->total_ranks,
+           ctx->checksum,
+           ctx->mode,
+           ctx->mountpoint,
+           ctx->manifest_file);
+}
+
+/**
+ * @brief transfer files specified in @ctx
+ *
+ * @param ctx unifyfs_stage_t data transfer context
+ *
+ * @return 0 on success, errno otherwise
+ */
+int unifyfs_stage_transfer(unifyfs_stage_t* ctx);
+
+extern int verbose;
+extern int rank;
+extern int total_ranks;
+
+#endif /* __UNIFYFS_STAGE_H */

--- a/util/unifyfs/src/Makefile.am
+++ b/util/unifyfs/src/Makefile.am
@@ -9,7 +9,8 @@ unifyfs_LDADD = $(top_builddir)/common/src/libunifyfs_common.la
 
 AM_CPPFLAGS = -I$(top_srcdir)/common/src \
               -DBINDIR=\"$(bindir)\" \
-              -DSBINDIR=\"$(sbindir)\"
+              -DSBINDIR=\"$(sbindir)\" \
+              -DLIBEXECDIR=\"$(libexecdir)\"
 
 AM_CFLAGS = -Wall -Werror
 

--- a/util/unifyfs/src/unifyfs.c
+++ b/util/unifyfs/src/unifyfs.c
@@ -279,8 +279,8 @@ int main(int argc, char** argv)
         if (cli_args.stage_in != NULL) {
             if (cli_args.script) {
                 fprintf(stderr,
-                        "WARNING! You are using a script with --stage-in.\n");
-                fprintf(stderr, "This is won't work.\n");
+                        "WARNING! You are using a script with --stage-in.\n"
+                        "This will not work.\n");
                 return -EINVAL;
             }
             if (access(cli_args.stage_in, R_OK)) {
@@ -304,8 +304,8 @@ int main(int argc, char** argv)
             }
             if (cli_args.script) {
                 fprintf(stderr,
-                        "WARNING! You are using a script with --stage-out.\n");
-                fprintf(stderr, "This won't work.\n");
+                        "WARNING! You are using a script with --stage-out.\n"
+                        "This will not work.\n");
                 return -EINVAL;
             }
             if (access(cli_args.stage_out, R_OK)) {

--- a/util/unifyfs/src/unifyfs.h
+++ b/util/unifyfs/src/unifyfs.h
@@ -65,6 +65,7 @@ struct _unifyfs_args {
     char* share_hostfile;      /* full path to shared server hostfile */
     char* stage_in;            /* data path to stage-in */
     char* stage_out;           /* data path to stage-out (drain) */
+    int stage_timeout;         /* timeout of (in or out) file staging*/
     char* script;              /* path to custom launch/terminate script */
 };
 typedef struct _unifyfs_args unifyfs_args_t;


### PR DESCRIPTION
this utility is expected to be used by unifyfs cli to handle --stage-in and --stage-out options.

- util/unifyfs-stage: unifyfs-stage utility
- unifyfs.c: some fix on unifyfs_transfer_parallel
- configure update for checking openssl-devel package (for md5sum)

### Motivation and Context
`unifyfs-stage` is a new utility that will be internally used for supporting data stage-in and stage-out. #504 depends on this.

EDIT: I've added a commit which modifies the `unifyfs` utility.

### How Has This Been Tested?
Tested on Summit (GPFS) and some x86 cluster with NFS. The serial transfer (file per process, each process transfers a whole file) works fine (including checksum verification).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

