### PR TITLE
fix client id assignment

### DIFF
--- a/client/src/margo_client.c
+++ b/client/src/margo_client.c
@@ -290,6 +290,7 @@ int invoke_client_mount_rpc(void)
         LOGWARN("mismatch on app_id - using %d, server returned %d",
                 unifyfs_app_id, srvr_app_id);
     }
+    LOGDBG("My client id is %d", unifyfs_client_id);
 
     /* free resources */
     margo_free_output(handle, &out);

--- a/client/src/unifyfs-fixed.c
+++ b/client/src/unifyfs-fixed.c
@@ -101,7 +101,7 @@ static int unifyfs_coalesce_index(
 
     /* determine number of bytes in next index that lie in current slice,
      * assume all bytes in the index will fit */
-    long length = next_idx->length;
+    size_t length = next_idx->length;
     if (next_end > slice_end) {
         /* current index writes beyond end of slice,
          * so we can only coalesce bytes that fall within slice */
@@ -400,8 +400,9 @@ int unifyfs_fid_logio_write(int fid,
         LOGWARN("partial logio_write() @ offset=%zu (%zu of %zu bytes)",
                 (size_t)log_off, *nwritten, count);
     } else {
-        LOGDBG("successful logio_write() @ log offset=%zu (%zu bytes)",
-               (size_t)log_off, count);
+        LOGDBG("fid=%d pos=%zu - successful logio_write() "
+               "@ log offset=%zu (%zu bytes)",
+               fid, (size_t)pos, (size_t)log_off, count);
     }
 
     /* update our write metadata for this write */

--- a/common/src/seg_tree.c
+++ b/common/src/seg_tree.c
@@ -27,12 +27,14 @@
   * segments in the tree are non-overlapping.  Added segments overwrite the old
   * segments in the tree.  This is used to coalesce writes before an fsync.
   */
+
 #include <stdio.h>
 #include <errno.h>
 #include <string.h>
 #include <stdlib.h>
 #include <assert.h>
 #include <pthread.h>
+
 #include "seg_tree.h"
 #include "tree.h"
 
@@ -277,7 +279,7 @@ int seg_tree_add(struct seg_tree* seg_tree, unsigned long start,
 
     /* Check whether we can coalesce new extent with any preceding extent. */
     prev = RB_PREV(inttree, &seg_tree->head, target);
-    if (prev != NULL && prev->end + 1 == target->start) {
+    if ((prev != NULL) && ((prev->end + 1) == target->start)) {
         /*
          * We found a extent that ends just before the new extent starts.
          * Check whether they are also contiguous in the log.
@@ -306,7 +308,7 @@ int seg_tree_add(struct seg_tree* seg_tree, unsigned long start,
 
     /* Check whether we can coalesce new extent with any trailing extent. */
     next = RB_NEXT(inttree, &seg_tree->head, target);
-    if (next != NULL && target->end + 1 == next->start) {
+    if ((next != NULL) && ((target->end + 1) == next->start)) {
         /*
          * We found a extent that starts just after the new extent ends.
          * Check whether they are also contiguous in the log.
@@ -415,6 +417,7 @@ struct seg_tree_node*
 seg_tree_iter(struct seg_tree* seg_tree, struct seg_tree_node* start)
 {
     struct seg_tree_node* next = NULL;
+    struct seg_tree_node* tmp = NULL;
     if (start == NULL) {
         /* Initial case, no starting node */
         next = RB_MIN(inttree, &seg_tree->head);
@@ -425,8 +428,8 @@ seg_tree_iter(struct seg_tree* seg_tree, struct seg_tree_node* start)
      * We were given a valid start node.  Look it up to start our traversal
      * from there.
      */
-    next = RB_FIND(inttree, &seg_tree->head, start);
-    if (!next) {
+    tmp = RB_FIND(inttree, &seg_tree->head, start);
+    if (!tmp) {
         /* Some kind of error */
         return NULL;
     }

--- a/examples/src/testutil.h
+++ b/examples/src/testutil.h
@@ -1157,6 +1157,7 @@ int test_init(int argc, char** argv,
         if (rc) {
             test_print(cfg, "ERROR: unifyfs_mount() failed (rc=%d)", rc);
             test_abort(cfg, rc);
+            return -1;
         }
 #endif
         test_barrier(cfg);

--- a/server/src/unifyfs_global.h
+++ b/server/src/unifyfs_global.h
@@ -138,7 +138,7 @@ struct reqmgr_thrd;
  * logio and shared memory contexts, margo rpc address, etc.
  */
 typedef struct app_client {
-    int app_id;              /* index of associated app in app_configs */
+    int app_id;              /* index of app in server app_configs array */
     int client_id;           /* this client's index in app's clients array */
     int dbg_rank;            /* client debug rank - NOT CURRENTLY USED */
     int connected;           /* is client currently connected? */
@@ -172,16 +172,16 @@ typedef struct app_config {
     app_client* clients[MAX_APP_CLIENTS];
 } app_config;
 
-extern app_config* app_configs[MAX_NUM_APPS]; /* list of apps */
-
 app_config* get_application(int app_id);
 
-unifyfs_rc new_application(app_config* new_app);
+app_config* new_application(int app_id);
+
+unifyfs_rc cleanup_application(app_config* app);
 
 app_client* get_app_client(int app_id,
                            int client_id);
 
-app_client* create_app_client(app_config* app,
+app_client* new_app_client(app_config* app,
                               const char* margo_addr_str,
                               const int dbg_rank);
 


### PR DESCRIPTION
### Description

Occasionally, when running many clients per server, two (or more) clients could mount at the exact same time, leading to a duplicate client id assignment. This results in the duplicate clients
both trying to use the same logio and shmem contexts, which leads to various problems, including read hangs.

This PR fixes the problem by synchronizing updates to application state using a pthread mutex. Also included is a testutil fix to make sure unifyfs_mount() failures in the example programs are
properly handled.

### How Has This Been Tested?

Tested on Summitdev with 8 ranks per node on up to 48 nodes.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
