### PR TITLE
Fix strlcpy()

### DIFF
--- a/common/src/unifyfs_misc.c
+++ b/common/src/unifyfs_misc.c
@@ -28,12 +28,17 @@
  */
 size_t strlcpy(char* dest, const char* src, size_t size)
 {
-    size_t src_len = strnlen(src, size);
+    size_t src_len;
+
+    src_len = strnlen(src, size);
+    if (src_len == size) {
+            /* Our string is too long, have to truncate */
+            src_len = size - 1;
+    }
 
     memcpy(dest, src, src_len);
-    if (src_len == size) {
-        dest[size - 1] = '\0';
-    }
+    dest[src_len] = '\0';
+
     return strlen(dest);
 }
 


### PR DESCRIPTION
### Description
My "set -Wall by default" commit (feced6a) checked in a broken `strlcpy()` that wasn't NULL terminating.

Reproducer:
```
dst[] = "unifyfs"
strlcpy(dst, "client", 50)

// dst[] is now "clients" instead of "client".
```
This fixes the bug


### Motivation and Context
Fix `strlcpy()`

### How Has This Been Tested?
printf'd all `strcpy0()` src/dst arugments and compared results between pre-feced6a (working), post-feced6a (broken), and with my fix.  This also fixed an error where `unifyfs_mount()` would fail post-feced6a for me.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
