### PR TITLE
logio fixes for empty shmem or spill

### DIFF
--- a/client/src/margo_client.c
+++ b/client/src/margo_client.c
@@ -229,15 +229,17 @@ int invoke_client_attach_rpc(void)
     hg_return_t hret = margo_forward(handle, &in);
     assert(hret == HG_SUCCESS);
 
-    /* free memory on input struct */
-    free((void*)in.logio_spill_dir);
-
     /* decode response */
     unifyfs_attach_out_t out;
     hret = margo_get_output(handle, &out);
     assert(hret == HG_SUCCESS);
     int32_t ret = out.ret;
     LOGDBG("Got response ret=%" PRIi32, ret);
+
+    /* free memory on input struct */
+    if (NULL != in.logio_spill_dir) {
+        free((void*)in.logio_spill_dir);
+    }
 
     /* free resources */
     margo_free_output(handle, &out);

--- a/client/src/unifyfs.c
+++ b/client/src/unifyfs.c
@@ -2456,9 +2456,19 @@ void fill_client_attach_info(unifyfs_attach_in_t* in)
     in->shmem_super_size  = shm_super_ctx->size;
     in->meta_offset       = meta_offset;
     in->meta_size         = meta_size;
-    in->logio_mem_size    = logio_ctx->shmem->size;
-    in->logio_spill_size  = logio_ctx->spill_sz;
-    in->logio_spill_dir   = strdup(client_cfg.logio_spill_dir);
+
+    if (NULL != logio_ctx->shmem) {
+        in->logio_mem_size = logio_ctx->shmem->size;
+    } else {
+        in->logio_mem_size = 0;
+    }
+
+    in->logio_spill_size = logio_ctx->spill_sz;
+    if (logio_ctx->spill_sz) {
+        in->logio_spill_dir = strdup(client_cfg.logio_spill_dir);
+    } else {
+        in->logio_spill_dir = NULL;
+    }
 }
 
 /**

--- a/server/src/unifyfs_server.c
+++ b/server/src/unifyfs_server.c
@@ -838,7 +838,7 @@ unifyfs_rc attach_app_client(app_client* client,
                              const size_t super_meta_offset,
                              const size_t super_meta_size)
 {
-    if ((NULL == client) || (NULL == logio_spill_dir)) {
+    if (NULL == client) {
         return EINVAL;
     }
 


### PR DESCRIPTION

### Description

Hyogi was testing with UNIFYFS_LOGIO_SHMEM_SIZE=0 and observed failures. I was able to reproduce the failures using dev branch on Summitdev. This PR fixes all the various ways things were going badly when either the shmem or spillover portions were disabled.

### How Has This Been Tested?

I tested all three valid combinations (spill-only, shmem-only, and both enabled) on Summitdev with the writeread example.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
