### PR TITLE
fix server application cleanup deadlock

### DIFF
--- a/server/src/unifyfs_global.h
+++ b/server/src/unifyfs_global.h
@@ -182,8 +182,8 @@ app_client* get_app_client(int app_id,
                            int client_id);
 
 app_client* new_app_client(app_config* app,
-                              const char* margo_addr_str,
-                              const int dbg_rank);
+                           const char* margo_addr_str,
+                           const int dbg_rank);
 
 unifyfs_rc attach_app_client(app_client* client,
                              const char* logio_spill_dir,
@@ -196,6 +196,6 @@ unifyfs_rc attach_app_client(app_client* client,
 
 unifyfs_rc disconnect_app_client(app_client* clnt);
 
-unifyfs_rc cleanup_app_client(app_client* clnt);
+unifyfs_rc cleanup_app_client(app_config* app, app_client* clnt);
 
 #endif // UNIFYFS_GLOBAL_H

--- a/server/src/unifyfs_request_manager.c
+++ b/server/src/unifyfs_request_manager.c
@@ -1907,9 +1907,8 @@ int rm_handle_chunk_read_responses(reqmgr_thrd_t* thrd_ctrl,
            (NULL != del_reads->resp));
 
     /* look up client shared memory region */
-    app_config* app_cfg = get_application(rdreq->app_id);
     app_client* clnt = get_app_client(rdreq->app_id, rdreq->client_id);
-    if ((NULL == app_cfg) || (NULL == clnt)) {
+    if (NULL == clnt) {
         return (int)UNIFYFS_FAILURE;
     }
     client_shm = clnt->shmem_data;


### PR DESCRIPTION
### Description

The recent change to use an Argobots mutex for protecting the server's application state led to a deadlock on mutex acquisition during the server's normal shutdown sequence, since the Argobots mutex is not recursive like the pthread mutex we used before. This fixes the code to avoid the recursive acquisition.

### Motivation and Context

See Issue #519 

### How Has This Been Tested?

Verified that all servers in a 16-node job on Summitdev were shutdown cleanly.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
