### PR TITLE
support per-file sync

### DIFF
--- a/client/src/margo_client.c
+++ b/client/src/margo_client.c
@@ -15,65 +15,31 @@ static void register_client_rpcs(client_rpc_context_t* ctx)
     /* shorter name for our margo instance id */
     margo_instance_id mid = ctx->mid;
 
-    ctx->rpcs.attach_id = MARGO_REGISTER(mid, "unifyfs_attach_rpc",
-                       unifyfs_attach_in_t,
-                       unifyfs_attach_out_t,
-                       NULL);
+    hg_id_t hgid;
 
-    ctx->rpcs.mount_id = MARGO_REGISTER(mid, "unifyfs_mount_rpc",
-                       unifyfs_mount_in_t,
-                       unifyfs_mount_out_t,
-                       NULL);
+#define CLIENT_REGISTER_RPC(name) \
+    do { \
+        hgid = MARGO_REGISTER(mid, "unifyfs_" #name "_rpc", \
+                              unifyfs_##name##_in_t, \
+                              unifyfs_##name##_out_t, \
+                              NULL); \
+        ctx->rpcs.name##_id = hgid; \
+    } while (0)
 
-    ctx->rpcs.unmount_id = MARGO_REGISTER(mid, "unifyfs_unmount_rpc",
-                       unifyfs_unmount_in_t,
-                       unifyfs_unmount_out_t,
-                       NULL);
+    CLIENT_REGISTER_RPC(attach);
+    CLIENT_REGISTER_RPC(mount);
+    CLIENT_REGISTER_RPC(unmount);
+    CLIENT_REGISTER_RPC(metaset);
+    CLIENT_REGISTER_RPC(metaget);
+    CLIENT_REGISTER_RPC(filesize);
+    CLIENT_REGISTER_RPC(truncate);
+    CLIENT_REGISTER_RPC(unlink);
+    CLIENT_REGISTER_RPC(laminate);
+    CLIENT_REGISTER_RPC(sync);
+    CLIENT_REGISTER_RPC(read);
+    CLIENT_REGISTER_RPC(mread);
 
-    ctx->rpcs.metaset_id = MARGO_REGISTER(mid, "unifyfs_metaset_rpc",
-                       unifyfs_metaset_in_t,
-                       unifyfs_metaset_out_t,
-                       NULL);
-
-    ctx->rpcs.metaget_id = MARGO_REGISTER(mid, "unifyfs_metaget_rpc",
-                       unifyfs_metaget_in_t,
-                       unifyfs_metaget_out_t,
-                       NULL);
-
-    ctx->rpcs.filesize_id = MARGO_REGISTER(mid, "unifyfs_filesize_rpc",
-                       unifyfs_filesize_in_t,
-                       unifyfs_filesize_out_t,
-                       NULL);
-
-    ctx->rpcs.truncate_id = MARGO_REGISTER(mid, "unifyfs_truncate_rpc",
-                       unifyfs_truncate_in_t,
-                       unifyfs_truncate_out_t,
-                       NULL);
-
-    ctx->rpcs.unlink_id = MARGO_REGISTER(mid, "unifyfs_unlink_rpc",
-                       unifyfs_unlink_in_t,
-                       unifyfs_unlink_out_t,
-                       NULL);
-
-    ctx->rpcs.laminate_id = MARGO_REGISTER(mid, "unifyfs_laminate_rpc",
-                       unifyfs_laminate_in_t,
-                       unifyfs_laminate_out_t,
-                       NULL);
-
-    ctx->rpcs.sync_id = MARGO_REGISTER(mid, "unifyfs_sync_rpc",
-                       unifyfs_sync_in_t,
-                       unifyfs_sync_out_t,
-                       NULL);
-
-    ctx->rpcs.read_id = MARGO_REGISTER(mid, "unifyfs_read_rpc",
-                       unifyfs_read_in_t,
-                       unifyfs_read_out_t,
-                       NULL);
-
-    ctx->rpcs.mread_id = MARGO_REGISTER(mid, "unifyfs_mread_rpc",
-                       unifyfs_mread_in_t,
-                       unifyfs_mread_out_t,
-                       NULL);
+#undef CLIENT_REGISTER_RPC
 }
 
 /* initialize margo client-server rpc */
@@ -278,10 +244,6 @@ int invoke_client_mount_rpc(void)
     assert(hret == HG_SUCCESS);
     int32_t ret = out.ret;
     LOGDBG("Got response ret=%" PRIi32, ret);
-
-    /* get slice size for write index key/value store */
-    unifyfs_key_slice_range = out.meta_slice_sz;
-    LOGDBG("set unifyfs_key_slice_range=%zu", unifyfs_key_slice_range);
 
     /* get assigned client id, and verify app_id */
     unifyfs_client_id = (int) out.client_id;
@@ -495,7 +457,7 @@ int invoke_client_truncate_rpc(int gfid, size_t filesize)
     assert(hret == HG_SUCCESS);
 
     /* decode response */
-    unifyfs_filesize_out_t out;
+    unifyfs_truncate_out_t out;
     hret = margo_get_output(handle, &out);
     assert(hret == HG_SUCCESS);
     int32_t ret = out.ret;
@@ -530,7 +492,7 @@ int invoke_client_unlink_rpc(int gfid)
     assert(hret == HG_SUCCESS);
 
     /* decode response */
-    unifyfs_filesize_out_t out;
+    unifyfs_unlink_out_t out;
     hret = margo_get_output(handle, &out);
     assert(hret == HG_SUCCESS);
     int32_t ret = out.ret;
@@ -554,7 +516,7 @@ int invoke_client_laminate_rpc(int gfid)
     hg_handle_t handle = create_handle(client_rpc_context->rpcs.laminate_id);
 
     /* fill in input struct */
-    unifyfs_unlink_in_t in;
+    unifyfs_laminate_in_t in;
     in.app_id    = (int32_t) unifyfs_app_id;
     in.client_id = (int32_t) unifyfs_client_id;
     in.gfid      = (int32_t) gfid;
@@ -565,7 +527,7 @@ int invoke_client_laminate_rpc(int gfid)
     assert(hret == HG_SUCCESS);
 
     /* decode response */
-    unifyfs_filesize_out_t out;
+    unifyfs_laminate_out_t out;
     hret = margo_get_output(handle, &out);
     assert(hret == HG_SUCCESS);
     int32_t ret = out.ret;

--- a/client/src/unifyfs-dirops.c
+++ b/client/src/unifyfs-dirops.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+ * Copyright (c) 2020, Lawrence Livermore National Security, LLC.
  * Produced at the Lawrence Livermore National Laboratory.
  *
- * Copyright 2017, UT-Battelle, LLC.
+ * Copyright 2020, UT-Battelle, LLC.
  *
  * LLNL-CODE-741539
  * All rights reserved.
@@ -121,6 +121,7 @@ DIR* UNIFYFS_WRAP(opendir)(const char* name)
     unifyfs_filemeta_t* meta = NULL;
     if (fid >= 0) {
         meta = unifyfs_get_meta_from_fid(fid);
+        assert(meta != NULL);
 
         /*
          * FIXME: We found an inconsistent status between local cache and
@@ -139,6 +140,7 @@ DIR* UNIFYFS_WRAP(opendir)(const char* name)
         }
 
         meta = unifyfs_get_meta_from_fid(fid);
+        assert(meta != NULL);
         meta->mode = (meta->mode & ~S_IFREG) | S_IFDIR; /* set as directory */
     }
 

--- a/client/src/unifyfs-fixed.c
+++ b/client/src/unifyfs-fixed.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+ * Copyright (c) 2020, Lawrence Livermore National Security, LLC.
  * Produced at the Lawrence Livermore National Laboratory.
  *
- * Copyright 2017, UT-Battelle, LLC.
+ * Copyright 2020, UT-Battelle, LLC.
  *
  * LLNL-CODE-741539
  * All rights reserved.
@@ -50,76 +50,6 @@
  * Operations on client write index
  * --------------------------------------- */
 
-/* Merges write at next_idx into prev_idx if possible.
- * Updates both prev_idx and next_idx leaving any
- * portion that could not be merged in next_idx */
-static int unifyfs_coalesce_index(
-    unifyfs_index_t* prev_idx, /* existing index entry to coalesce into */
-    unifyfs_index_t* next_idx, /* new index entry we'd like to add */
-    long slice_size)           /* byte size of slice of key-value store */
-{
-    /* check whether last index and next index refer to same file */
-    if (prev_idx->gfid != next_idx->gfid) {
-        /* two index values are for different files, can't combine */
-        return UNIFYFS_SUCCESS;
-    }
-
-    /* got same file,
-     * check whether last index and next index refer to
-     * contiguous bytes */
-    off_t prev_offset = prev_idx->file_pos + prev_idx->length;
-    off_t next_offset = next_idx->file_pos;
-    if (prev_offset != next_offset) {
-        /* index values are not contiguous, can't combine */
-        return UNIFYFS_SUCCESS;
-    }
-
-    /* got contiguous bytes in the same file,
-     * check whether both index values fall in the same slice */
-    off_t prev_slice = prev_idx->file_pos / slice_size;
-    off_t next_slice = next_idx->file_pos / slice_size;
-    if (prev_slice != next_slice) {
-        /* index values refer to different slices, can't combine */
-        return UNIFYFS_SUCCESS;
-    }
-
-    /* check whether last index and next index refer to
-     * contiguous bytes in the log */
-    off_t prev_log = prev_idx->log_pos + prev_idx->length;
-    off_t next_log = next_idx->log_pos;
-    if (prev_log != next_log) {
-        /* index values are not contiguous in log, can't combine */
-        return UNIFYFS_SUCCESS;
-    }
-
-    /* if we get here, we can coalesce next index value into previous */
-
-    /* get ending offset of write in next index,
-     * and ending offset of current slice */
-    off_t next_end  = next_idx->file_pos + next_idx->length;
-    off_t slice_end = (next_slice * slice_size) + slice_size;
-
-    /* determine number of bytes in next index that lie in current slice,
-     * assume all bytes in the index will fit */
-    size_t length = next_idx->length;
-    if (next_end > slice_end) {
-        /* current index writes beyond end of slice,
-         * so we can only coalesce bytes that fall within slice */
-        length = slice_end - next_offset;
-    }
-
-    /* extend length of last index to include beginning portion
-     * of current index */
-    prev_idx->length += length;
-
-    /* adjust current index to subtract off those bytes */
-    next_idx->file_pos += length;
-    next_idx->log_pos  += length;
-    next_idx->length   -= length;
-
-    return UNIFYFS_SUCCESS;
-}
-
 /*
  * Clear all entries in the log index.  This only clears the metadata,
  * not the data itself.
@@ -129,137 +59,58 @@ static void clear_index(void)
     *unifyfs_indices.ptr_num_entries = 0;
 }
 
-static void add_index_entry_to_seg_tree(unifyfs_filemeta_t* meta,
-                                        unifyfs_index_t* index)
-{
-    /* add index to our local log */
-    if (unifyfs_local_extents) {
-        seg_tree_add(&meta->extents, index->file_pos,
-            index->file_pos + index->length - 1,
-            index->log_pos);
-    }
-
-    if (!unifyfs_flatten_writes) {
-        /* We're not flattening writes.  Nothing to do */
-        return;
-    }
-
-    /* to update the global running segment count, we need to capture
-     * the count in this tree before adding and the count after to
-     * add the difference */
-    unsigned long count_before = seg_tree_count(&meta->extents_sync);
-
-    /*
-     * Store the write in our segment tree.  We will later use this for
-     * flattening writes.
-     */
-    seg_tree_add(&meta->extents_sync, index->file_pos,
-        index->file_pos + index->length - 1,
-        index->log_pos);
-
-    /*
-     * We want to make sure the next write following this wont overflow the
-     * max number of index entries (if it were synced).  A write can at most
-     * create two new nodes in the seg_tree.  If we're close to potentially
-     * filling up the index, sync it out.
-     */
-    if (unifyfs_segment_count >= (unifyfs_max_index_entries - 2)) {
-        /* this will flush our segments, sync them, and set the running
-         * segment count back to 0 */
-        unifyfs_sync();
-    } else {
-        /* increase the running global segment count by the number of
-         * new entries we added to this tree */
-        unsigned long count_after = seg_tree_count(&meta->extents_sync);
-        unifyfs_segment_count += (count_after - count_before);
-    }
-}
-
 /* Add the metadata for a single write to the index */
 static int add_write_meta_to_index(unifyfs_filemeta_t* meta,
                                    off_t file_pos,
                                    off_t log_pos,
                                    size_t length)
 {
-    /* global file id for this entry */
-    int gfid = meta->gfid;
-
-    /* define an new index entry for this write operation */
-    unifyfs_index_t cur_idx;
-    cur_idx.gfid     = gfid;
-    cur_idx.file_pos = file_pos;
-    cur_idx.log_pos  = log_pos;
-    cur_idx.length   = length;
-
-    /* lookup number of existing index entries */
-    off_t num_entries = *(unifyfs_indices.ptr_num_entries);
-
-    /* get pointer to index array */
-    unifyfs_index_t* idxs = unifyfs_indices.index_entry;
-
-    /* attempt to coalesce contiguous index entries if we
-     * have an existing index in the buffer */
-    if (num_entries > 0) {
-        /* get pointer to last element in index array */
-        unifyfs_index_t* prev_idx = &idxs[num_entries - 1];
-
-        /* attempt to coalesce current index with last index,
-         * updates fields in last index and current index
-         * accordingly */
-        unifyfs_coalesce_index(prev_idx, &cur_idx,
-            unifyfs_key_slice_range);
-        if (cur_idx.length == 0) {
-            /* We were able to coalesce this write into prev_idx */
-            add_index_entry_to_seg_tree(meta, prev_idx);
-        }
+    /* add write extent to our segment trees */
+    if (unifyfs_local_extents) {
+        /* record write extent in our local cache */
+        seg_tree_add(&meta->extents,
+                     file_pos,
+                     file_pos + length - 1,
+                     log_pos);
     }
 
-    /* add new index entry if needed */
-    if (cur_idx.length > 0) {
-        /* remaining entries we can fit in the shared memory region */
-        off_t remaining_entries = unifyfs_max_index_entries - num_entries;
-
-        /* if we have filled the key/value buffer, flush it to server */
-        if (0 == remaining_entries) {
-            /* index buffer is full, flush it */
-            int ret = unifyfs_sync();
-            if (ret != UNIFYFS_SUCCESS) {
-                /* something went wrong when trying to flush key/values */
-                LOGERR("failed to flush key/value index to server");
-                return EIO;
-            }
-        }
-
-        /* copy entry into index buffer */
-        idxs[num_entries] = cur_idx;
-
-        /* Add index entry to our seg_tree */
-        add_index_entry_to_seg_tree(meta, &idxs[num_entries]);
-
-        /* account for entries we just added */
-        num_entries += 1;
-
-        /* update number of entries in index array */
-        (*unifyfs_indices.ptr_num_entries) = num_entries;
+    /*
+     * We want to make sure this write will not overflow the maximum
+     * number of index entries we can sync with server. A write can at most
+     * create two new nodes in the seg_tree. If we're close to potentially
+     * filling up the index, sync it out.
+     */
+    unsigned long count_before = seg_tree_count(&meta->extents_sync);
+    if (count_before >= (unifyfs_max_index_entries - 2)) {
+        /* this will flush our segments, sync them, and set the running
+         * segment count back to 0 */
+        unifyfs_sync(meta->fid);
     }
+
+    /* store the write in our segment tree used for syncing with server. */
+    seg_tree_add(&meta->extents_sync,
+                 file_pos,
+                 file_pos + length - 1,
+                 log_pos);
 
     return UNIFYFS_SUCCESS;
 }
 
 /*
  * Remove all entries in the current index and re-write it using the write
- * metadata stored in all the file's seg_trees.  This only re-writes the
- * metadata in the index.  All the actual data is still kept in the log and
- * will be referenced correctly by the new metadata.
+ * metadata stored in the target file's extents_sync segment tree. This only
+ * re-writes the metadata in the index. All the actual data is still kept
+ * in the write log and will be referenced correctly by the new metadata.
  *
- * After this function is done 'unifyfs_indices' will have been totally
- * re-written.  The writes in the index will be flattened, non-overlapping,
- * and sequential, for each file, one after another.  All seg_trees will be
- * cleared.
+ * After this function is done, 'unifyfs_indices' will have been totally
+ * re-written. The writes in the index will be flattened, non-overlapping,
+ * and sequential. The extents_sync segment tree will be cleared.
  *
- * This function is called when we sync our extents.
+ * This function is called when we sync our extents with the server.
+ *
+ * Returns maximum write log offset for synced extents.
  */
-void unifyfs_rewrite_index_from_seg_tree(void)
+off_t unifyfs_rewrite_index_from_seg_tree(unifyfs_filemeta_t* meta)
 {
     /* get pointer to index buffer */
     unifyfs_index_t* indexes = unifyfs_indices.index_entry;
@@ -270,84 +121,114 @@ void unifyfs_rewrite_index_from_seg_tree(void)
     /* count up number of entries we wrote to buffer */
     unsigned long idx = 0;
 
-    /* For each fid .. */
-    for (int i = 0; i < UNIFYFS_MAX_FILEDESCS; i++) {
-        /* get file id for each file descriptor */
-        int fid = unifyfs_fds[i].fid;
-        unifyfs_filemeta_t* meta = unifyfs_get_meta_from_fid(fid);
-        if (!meta) {
-            continue;
+    /* record maximum write log offset */
+    off_t max_log_offset = 0;
+
+    int gfid = meta->gfid;
+
+    seg_tree_rdlock(&meta->extents_sync);
+    /* For each write in this file's seg_tree ... */
+    struct seg_tree_node* node = NULL;
+    while ((node = seg_tree_iter(&meta->extents_sync, node))) {
+        indexes[idx].file_pos = node->start;
+        indexes[idx].log_pos  = node->ptr;
+        indexes[idx].length   = node->end - node->start + 1;
+        indexes[idx].gfid     = gfid;
+        idx++;
+        if ((off_t)(node->end) > max_log_offset) {
+            max_log_offset = (off_t) node->end;
         }
-
-        int gfid = unifyfs_gfid_from_fid(fid);
-
-        seg_tree_rdlock(&meta->extents_sync);
-
-        /* For each write in this file's seg_tree ... */
-        struct seg_tree_node* node = NULL;
-        while ((node = seg_tree_iter(&meta->extents_sync, node))) {
-            indexes[idx].file_pos = node->start;
-            indexes[idx].log_pos  = node->ptr;
-            indexes[idx].length   = node->end - node->start + 1;
-            indexes[idx].gfid     = gfid;
-            idx++;
-        }
-
-        seg_tree_unlock(&meta->extents_sync);
-
-        /* All done processing this files writes.  Clear its seg_tree */
-        seg_tree_clear(&meta->extents_sync);
     }
-
-    /* reset our segment count since we just dumped them all */
-    unifyfs_segment_count = 0;
+    seg_tree_unlock(&meta->extents_sync);
+    /* All done processing this files writes.  Clear its seg_tree */
+    seg_tree_clear(&meta->extents_sync);
 
     /* record total number of entries in index buffer */
     *unifyfs_indices.ptr_num_entries = idx;
+
+    return max_log_offset;
 }
 
 /*
- * Sync all the extents to the server.  Clears the metadata index afterwards.
+ * Sync all the write extents for the target file(s) to the server.
+ * The target_fid identifies a specific file, or all files (-1).
+ * Clears the metadata index afterwards.
  *
  * Returns 0 on success, nonzero otherwise.
  */
-int unifyfs_sync(void)
+int unifyfs_sync(int target_fid)
 {
-    /* NOTE: we currently ignore gfid and sync extents for all files in
-     * the index. If we ever switch to storing extents in a per-file index,
-     * we can support per-file sync. */
+    int ret = UNIFYFS_SUCCESS;
+    off_t max_log_offset = 0;
 
-    /* write contents from segment tree to index buffer
-     * if we're using that optimization */
-    if (unifyfs_flatten_writes) {
-        unifyfs_rewrite_index_from_seg_tree();
+    /* For each open file descriptor .. */
+    for (int i = 0; i < UNIFYFS_MAX_FILEDESCS; i++) {
+        /* get file id for each file descriptor */
+        int fid = unifyfs_fds[i].fid;
+        if (-1 == fid) {
+            /* file descriptor is not currently in use */
+            continue;
+        }
+
+        /* is this the target file? */
+        if ((target_fid != -1) && (fid != target_fid)) {
+            continue;
+        }
+
+        unifyfs_filemeta_t* meta = unifyfs_get_meta_from_fid(fid);
+        if ((NULL == meta) || (meta->fid != fid)) {
+            LOGERR("missing filemeta for fid=%d", fid);
+            if (fid == target_fid) {
+                return UNIFYFS_FAILURE;
+            }
+            continue;
+        }
+
+        if (meta->needs_sync) {
+            /* write contents from segment tree to index buffer */
+            off_t max_log_off = unifyfs_rewrite_index_from_seg_tree(meta);
+            if (max_log_off > max_log_offset) {
+                max_log_offset = max_log_off;
+            }
+
+            /* if there are no index entries, we've got nothing to sync */
+            if (*unifyfs_indices.ptr_num_entries == 0) {
+                if (fid == target_fid) {
+                    return UNIFYFS_SUCCESS;
+                }
+            }
+
+            /* tell the server to grab our new extents */
+            ret = invoke_client_sync_rpc();
+            if (ret != UNIFYFS_SUCCESS) {
+                /* something went wrong when trying to flush extents */
+                LOGERR("failed to flush write index to server for gfid=%d",
+                       meta->gfid);
+            }
+            meta->needs_sync = 0;
+
+            /* flushed, clear buffer and refresh number of entries
+             * and number remaining */
+            clear_index();
+        }
+
+        /* break out of loop when targeting a specific file */
+        if (fid == target_fid) {
+            break;
+        }
     }
 
-    /* if there are no index entries, we've got nothing to sync */
-    if (*unifyfs_indices.ptr_num_entries == 0) {
-        return UNIFYFS_SUCCESS;
+    /* ensure any data written to the spillover file is flushed */
+    off_t logio_shmem_size;
+    unifyfs_logio_get_sizes(logio_ctx, &logio_shmem_size, NULL);
+    if (max_log_offset >= logio_shmem_size) {
+        ret = unifyfs_logio_sync(logio_ctx);
+        if (ret != UNIFYFS_SUCCESS) {
+            LOGERR("failed to sync logio data");
+        }
     }
 
-    /* ensure any data written to the spill over file is flushed */
-    int ret = unifyfs_logio_sync(logio_ctx);
-    if (ret != UNIFYFS_SUCCESS) {
-        LOGERR("failed to sync logio data");
-        return EIO;
-    }
-
-    /* tell the server to grab our new extents */
-    ret = invoke_client_sync_rpc();
-    if (ret != UNIFYFS_SUCCESS) {
-        /* something went wrong when trying to flush key/values */
-        LOGERR("failed to flush key/value index to server");
-        return EIO;
-    }
-
-    /* flushed, clear buffer and refresh number of entries
-     * and number remaining */
-    clear_index();
-
-    return UNIFYFS_SUCCESS;
+    return ret;
 }
 
 /* ---------------------------------------

--- a/client/src/unifyfs-fixed.h
+++ b/client/src/unifyfs-fixed.h
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+ * Copyright (c) 2020, Lawrence Livermore National Security, LLC.
  * Produced at the Lawrence Livermore National Laboratory.
  *
- * Copyright 2017, UT-Battelle, LLC.
+ * Copyright 2020, UT-Battelle, LLC.
  *
  * LLNL-CODE-741539
  * All rights reserved.
@@ -45,11 +45,11 @@
 
 #include "unifyfs-internal.h"
 
-/* rewrite client's index of all file write extents */
-void unifyfs_rewrite_index_from_seg_tree(void);
+/* rewrite client's shared memory index of file write extents */
+off_t unifyfs_rewrite_index_from_seg_tree(unifyfs_filemeta_t* meta);
 
-/* sync all writes from client's index with local server */
-int unifyfs_sync(void);
+/* sync all writes for target file(s) with the server */
+int unifyfs_sync(int target_fid);
 
 /* write data to file using log-based I/O */
 int unifyfs_fid_logio_write(

--- a/client/src/unifyfs-internal.h
+++ b/client/src/unifyfs-internal.h
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+ * Copyright (c) 2020, Lawrence Livermore National Security, LLC.
  * Produced at the Lawrence Livermore National Laboratory.
  *
- * Copyright 2017, UT-Battelle, LLC.
+ * Copyright 2020, UT-Battelle, LLC.
  *
  * LLNL-CODE-741539
  * All rights reserved.
@@ -276,6 +276,7 @@ typedef struct {
 
     int storage;                  /* FILE_STORAGE type */
 
+    int fid;                      /* local file index in filemetas array */
     int gfid;                     /* global file id for this file */
     int needs_sync;               /* have unsynced writes */
 
@@ -327,9 +328,6 @@ typedef struct {
 extern unifyfs_index_buf_t unifyfs_indices;
 extern unsigned long unifyfs_max_index_entries;
 
-/* tracks total number of unsync'd segments for all files */
-extern unsigned long unifyfs_segment_count;
-
 /* shmem context for read-request replies data region */
 extern shm_context* shm_recv_ctx;
 
@@ -338,7 +336,6 @@ extern logio_context* logio_ctx;
 
 extern int unifyfs_app_id;
 extern int unifyfs_client_id;
-extern size_t unifyfs_key_slice_range;
 
 /* -------------------------------
  * Global varaible declarations
@@ -394,7 +391,6 @@ extern void* unifyfs_dirstream_stack;
 extern pthread_mutex_t unifyfs_stack_mutex;
 
 extern int    unifyfs_max_files;  /* maximum number of files to store */
-extern bool   unifyfs_flatten_writes; /* enable write flattening */
 extern bool   unifyfs_local_extents;  /* enable tracking of local extents */
 
 /* -------------------------------

--- a/client/src/unifyfs-sysio.c
+++ b/client/src/unifyfs-sysio.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2017, Lawrence Livermore National Security, LLC.
+ * Copyright (c) 2020, Lawrence Livermore National Security, LLC.
  * Produced at the Lawrence Livermore National Laboratory.
  *
- * Copyright 2017, UT-Battelle, LLC.
+ * Copyright 2020, UT-Battelle, LLC.
  *
  * LLNL-CODE-741539
  * All rights reserved.
@@ -2113,15 +2113,15 @@ static int __chmod(int fid, mode_t mode)
 
     /* lookup metadata for this file */
     unifyfs_filemeta_t* meta = unifyfs_get_meta_from_fid(fid);
-    if (!meta) {
-        LOGDBG("chmod: %s no metadata info", path);
+    if (NULL == meta) {
+        LOGDBG("no metadata info for %s", path);
         errno = ENOENT;
         return -1;
     }
 
     /* Once a file is laminated, you can't modify it in any way */
     if (meta->is_laminated) {
-        LOGDBG("chmod: %s is already laminated", path);
+        LOGDBG("%s is already laminated", path);
         errno = EROFS;
         return -1;
     }

--- a/client/src/unifyfs.c
+++ b/client/src/unifyfs.c
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2019, Lawrence Livermore National Security, LLC.
+ * Copyright (c) 2020, Lawrence Livermore National Security, LLC.
  * Produced at the Lawrence Livermore National Laboratory.
  *
- * Copyright 2019, UT-Battelle, LLC.
+ * Copyright 2020, UT-Battelle, LLC.
  *
  * LLNL-CODE-741539
  * All rights reserved.
@@ -68,9 +68,6 @@ unifyfs_index_buf_t unifyfs_indices;
 static size_t unifyfs_index_buf_size;    /* size of metadata log */
 unsigned long unifyfs_max_index_entries; /* max metadata log entries */
 
-/* tracks total number of unsync'd segments for all files */
-unsigned long unifyfs_segment_count;
-
 int global_rank_cnt;  /* count of world ranks */
 int client_rank;      /* client-provided rank (for debugging) */
 
@@ -80,7 +77,6 @@ shm_context* shm_recv_ctx; // = NULL
 
 int unifyfs_app_id;
 int unifyfs_client_id;
-size_t unifyfs_key_slice_range;
 
 static int unifyfs_use_single_shm = 0;
 static int unifyfs_page_size      = 0;
@@ -92,7 +88,6 @@ static off_t unifyfs_min_long;
 
 /* TODO: moved these to fixed file */
 int    unifyfs_max_files;  /* maximum number of files to store */
-bool   unifyfs_flatten_writes; /* flatten our writes (true = enabled) */
 bool   unifyfs_local_extents;  /* track data extents in client to read local */
 
 /* log-based I/O context */
@@ -505,7 +500,10 @@ unifyfs_filemeta_t* unifyfs_get_meta_from_fid(int fid)
 int unifyfs_fid_is_laminated(int fid)
 {
     unifyfs_filemeta_t* meta = unifyfs_get_meta_from_fid(fid);
-    return meta->is_laminated;
+    if ((meta != NULL) && (meta->fid == fid)) {
+        return meta->is_laminated;
+    }
+    return 0;
 }
 
 int unifyfs_fd_is_laminated(int fd)
@@ -523,11 +521,28 @@ static int fid_store_alloc(int fid)
 {
     /* get meta data for this file */
     unifyfs_filemeta_t* meta = unifyfs_get_meta_from_fid(fid);
+    if ((meta != NULL) && (meta->fid == fid)) {
+        /* indicate that we're using LOGIO to store data for this file */
+        meta->storage = FILE_STORAGE_LOGIO;
 
-    /* indicate that we're using LOGIO to store data for this file */
-    meta->storage = FILE_STORAGE_LOGIO;
+        /* Initialize our segment tree that will record our writes */
+        int rc = seg_tree_init(&meta->extents_sync);
+        if (rc != 0) {
+            return rc;
+        }
 
-    return UNIFYFS_SUCCESS;
+        /* Initialize our segment tree to track extents for all writes
+         * by this process, can be used to read back local data */
+        if (unifyfs_local_extents) {
+            rc = seg_tree_init(&meta->extents);
+            if (rc != 0) {
+                return rc;
+            }
+        }
+
+        return UNIFYFS_SUCCESS;
+    }
+    return UNIFYFS_FAILURE;
 }
 
 /* free data management resource for file */
@@ -535,21 +550,21 @@ static int fid_store_free(int fid)
 {
     /* get meta data for this file */
     unifyfs_filemeta_t* meta = unifyfs_get_meta_from_fid(fid);
+    if ((meta != NULL) && (meta->fid == fid)) {
+        /* set storage type back to NULL */
+        meta->storage = FILE_STORAGE_NULL;
 
-    /* set storage type back to NULL */
-    meta->storage = FILE_STORAGE_NULL;
-
-    /* Free our write seg_tree */
-    if (unifyfs_flatten_writes) {
+        /* Free our write seg_tree */
         seg_tree_destroy(&meta->extents_sync);
-    }
 
-    /* Free our extent seg_tree */
-    if (unifyfs_local_extents) {
-        seg_tree_destroy(&meta->extents);
-    }
+        /* Free our extent seg_tree */
+        if (unifyfs_local_extents) {
+            seg_tree_destroy(&meta->extents);
+        }
 
-    return UNIFYFS_SUCCESS;
+        return UNIFYFS_SUCCESS;
+    }
+    return UNIFYFS_FAILURE;
 }
 
 /* =======================================
@@ -803,6 +818,7 @@ static void service_local_reqs(
 
         /* get pointer to extents for this file */
         unifyfs_filemeta_t* meta = unifyfs_get_meta_from_fid(fid);
+        assert(meta != NULL);
         struct seg_tree* extents = &meta->extents;
 
         /* lock the extent tree for reading */
@@ -1208,7 +1224,7 @@ int unifyfs_gfid_read_reqs(read_req_t* in_reqs, int in_count)
 int unifyfs_fid_is_dir(int fid)
 {
     unifyfs_filemeta_t* meta = unifyfs_get_meta_from_fid(fid);
-    if (meta && meta->mode & S_IFDIR) {
+    if ((meta != NULL) && (meta->mode & S_IFDIR)) {
         return 1;
     } else {
         /* if it doesn't exist, then it's not a directory? */
@@ -1225,7 +1241,11 @@ int unifyfs_gfid_from_fid(const int fid)
 
     /* return global file id, cached in file meta struct */
     unifyfs_filemeta_t* meta = unifyfs_get_meta_from_fid(fid);
-    return meta->gfid;
+    if (meta != NULL) {
+        return meta->gfid;
+    } else {
+        return -1;
+    }
 }
 
 /* scan list of files and return fid corresponding to target gfid,
@@ -1291,7 +1311,7 @@ off_t unifyfs_fid_global_size(int fid)
 {
     /* get meta data for this file */
     unifyfs_filemeta_t* meta = unifyfs_get_meta_from_fid(fid);
-    if (NULL != meta) {
+    if (meta != NULL) {
         return meta->global_size;
     }
     return (off_t)-1;
@@ -1361,7 +1381,7 @@ int unifyfs_fid_update_file_meta(int fid, unifyfs_file_attr_t* gfattr)
 
     /* lookup local metadata for file */
     unifyfs_filemeta_t* meta = unifyfs_get_meta_from_fid(fid);
-    if (NULL != meta) {
+    if (meta != NULL) {
         /* update lamination state */
         meta->is_laminated = gfattr->is_laminated;
         if (meta->is_laminated) {
@@ -1443,6 +1463,7 @@ int unifyfs_set_global_file_meta_from_fid(int fid, int create)
 
     /* lookup local metadata for file */
     unifyfs_filemeta_t* meta = unifyfs_get_meta_from_fid(fid);
+    assert(meta != NULL);
 
     /* copy our file name */
     const char* path = unifyfs_path_from_fid(fid);
@@ -1525,37 +1546,20 @@ int unifyfs_fid_create_file(const char* path)
 
     /* copy file name into slot */
     strcpy((void*)&unifyfs_filelist[fid].filename, path);
-    LOGDBG("Filename %s got unifyfs fd %d",
+    LOGDBG("Filename %s got unifyfs fid %d",
            unifyfs_filelist[fid].filename, fid);
 
     /* initialize meta data */
     unifyfs_filemeta_t* meta = unifyfs_get_meta_from_fid(fid);
+    assert(meta != NULL);
     meta->global_size  = 0;
     meta->flock_status = UNLOCKED;
     meta->storage      = FILE_STORAGE_NULL;
+    meta->fid          = fid;
     meta->gfid         = unifyfs_generate_gfid(path);
     meta->needs_sync   = 0;
     meta->is_laminated = 0;
     meta->mode         = UNIFYFS_STAT_DEFAULT_FILE_MODE;
-
-    if (unifyfs_flatten_writes) {
-        /* Initialize our segment tree that will record our writes */
-        rc = seg_tree_init(&meta->extents_sync);
-        if (rc != 0) {
-            errno = rc;
-            fid = -1;
-        }
-    }
-
-    /* Initialize our segment tree to track extents for all writes
-     * by this process, can be used to read back local data */
-    if (unifyfs_local_extents) {
-        rc = seg_tree_init(&meta->extents);
-        if (rc != 0) {
-            errno = rc;
-            fid = -1;
-        }
-    }
 
     /* PTHREAD_PROCESS_SHARED allows Process-Shared Synchronization */
     pthread_spin_init(&meta->fspinlock, PTHREAD_PROCESS_SHARED);
@@ -1619,6 +1623,7 @@ int unifyfs_fid_create_directory(const char* path)
 
     /* Set as directory */
     unifyfs_filemeta_t* meta = unifyfs_get_meta_from_fid(fid);
+    assert(meta != NULL);
     meta->mode = (meta->mode & ~S_IFREG) | S_IFDIR;
 
     /* insert global meta data for directory */
@@ -1655,6 +1660,7 @@ int unifyfs_fid_write(
 
     /* get meta for this file id */
     unifyfs_filemeta_t* meta = unifyfs_get_meta_from_fid(fid);
+    assert(meta != NULL);
 
     /* determine storage type to write file data */
     if (meta->storage == FILE_STORAGE_LOGIO) {
@@ -1680,6 +1686,7 @@ int unifyfs_fid_truncate(int fid, off_t length)
 {
     /* get meta data for this file */
     unifyfs_filemeta_t* meta = unifyfs_get_meta_from_fid(fid);
+    assert(meta != NULL);
     if (meta->is_laminated) {
         /* Can't truncate a laminated file */
         return EINVAL;
@@ -1713,16 +1720,10 @@ int unifyfs_fid_sync(int fid)
 
     /* sync any writes to disk */
     unifyfs_filemeta_t* meta = unifyfs_get_meta_from_fid(fid);
+    assert(meta != NULL);
     if (meta->needs_sync) {
-        /* TODO: no way to just sync data for this file,
-         * so we sync every file for now */
         /* sync data with server */
-        ret = unifyfs_sync();
-
-        /* just synced writes for this file */
-        if (ret == UNIFYFS_SUCCESS) {
-            meta->needs_sync = 0;
-        }
+        ret = unifyfs_sync(fid);
     }
 
     return ret;
@@ -2124,11 +2125,10 @@ static int init_superblock_shm(size_t super_sz)
             if (unifyfs_filelist[i].in_use) {
                 /* got a live file, get pointer to its metadata */
                 unifyfs_filemeta_t* meta = unifyfs_get_meta_from_fid(i);
+                assert(meta != NULL);
 
                 /* Reset our segment tree that will record our writes */
-                if (unifyfs_flatten_writes) {
-                    seg_tree_init(&meta->extents_sync);
-                }
+                seg_tree_init(&meta->extents_sync);
 
                 /* Reset our segment tree to track extents for all writes
                  * by this process, can be used to read back local data */
@@ -2260,16 +2260,6 @@ static int unifyfs_init(void)
             rc = configurator_int_val(cfgval, &l);
             if (rc == 0) {
                 unifyfs_max_files = (int)l;
-            }
-        }
-
-        /* Determine if we should flatten writes or not */
-        unifyfs_flatten_writes = 1;
-        cfgval = client_cfg.client_flatten_writes;
-        if (cfgval != NULL) {
-            rc = configurator_bool_val(cfgval, &b);
-            if (rc == 0) {
-                unifyfs_flatten_writes = (bool)b;
             }
         }
 
@@ -2615,6 +2605,14 @@ int unifyfs_unmount(void)
 
     if (-1 == unifyfs_mounted) {
         return UNIFYFS_SUCCESS;
+    }
+
+    /* sync any outstanding writes */
+    LOGDBG("syncing data");
+    rc = unifyfs_sync(-1);
+    if (rc) {
+        LOGERR("client sync failed");
+        ret = UNIFYFS_FAILURE;
     }
 
     /************************

--- a/common/src/unifyfs_client_rpcs.h
+++ b/common/src/unifyfs_client_rpcs.h
@@ -1,5 +1,19 @@
-#ifndef __UNIFYFS_CLIENT_RPCS_H
-#define __UNIFYFS_CLIENT_RPCS_H
+/*
+ * Copyright (c) 2020, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2020, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyFS.
+ * For details, see https://github.com/LLNL/UnifyFS.
+ * Please read https://github.com/LLNL/UnifyFS/LICENSE for full license text.
+ */
+
+#ifndef UNIFYFS_CLIENT_RPCS_H
+#define UNIFYFS_CLIENT_RPCS_H
 
 /*
  * Declarations for client-server margo RPCs (shared-memory)
@@ -40,7 +54,6 @@ MERCURY_GEN_PROC(unifyfs_mount_in_t,
                  ((hg_const_string_t)(mount_prefix))
                  ((hg_const_string_t)(client_addr_str)))
 MERCURY_GEN_PROC(unifyfs_mount_out_t,
-                 ((hg_size_t)(meta_slice_sz))
                  ((int32_t)(app_id))
                  ((int32_t)(client_id))
                  ((int32_t)(ret)))
@@ -102,9 +115,9 @@ DECLARE_MARGO_RPC_HANDLER(unifyfs_metaget_rpc)
 
 /* unifyfs_sync_rpc (client => server)
  *
- * given app_id and client_id as input, read all write extents
- * from client index in shared memory and insert corresponding
- * key/value pairs into our global metadata */
+ * given a client identified by (app_id, client_id) as input, read the write
+ * extents for one or more of the client's files from the shared memory index
+ * and update the global metadata for the file(s) */
 MERCURY_GEN_PROC(unifyfs_sync_in_t,
                  ((int32_t)(app_id))
                  ((int32_t)(client_id)))

--- a/common/src/unifyfs_configurator.h
+++ b/common/src/unifyfs_configurator.h
@@ -70,7 +70,6 @@
     UNIFYFS_CFG_CLI(unifyfs, daemonize, BOOL, on, "enable server daemonization", NULL, 'D', "on|off") \
     UNIFYFS_CFG_CLI(unifyfs, mountpoint, STRING, /unifyfs, "mountpoint directory", NULL, 'm', "specify full path to desired mountpoint") \
     UNIFYFS_CFG(client, max_files, INT, UNIFYFS_MAX_FILES, "client max file count", NULL) \
-    UNIFYFS_CFG(client, flatten_writes, BOOL, on, "flatten writes", NULL) \
     UNIFYFS_CFG(client, local_extents, BOOL, off, "track extents to service reads of local data", NULL) \
     UNIFYFS_CFG(client, recv_data_size, INT, UNIFYFS_DATA_RECV_SIZE, "shared memory segment size in bytes for receiving data from server", NULL) \
     UNIFYFS_CFG(client, write_index_size, INT, UNIFYFS_INDEX_BUF_SIZE, "write metadata index buffer size", NULL) \

--- a/common/src/unifyfs_logio.c
+++ b/common/src/unifyfs_logio.c
@@ -805,3 +805,31 @@ int unifyfs_logio_sync(logio_context* ctx)
     }
     return UNIFYFS_SUCCESS;
 }
+
+/* Get the shmem and spill data sizes */
+int unifyfs_logio_get_sizes(logio_context* ctx,
+                            off_t* shmem_sz,
+                            off_t* spill_sz)
+{
+    if (NULL == ctx) {
+        return EINVAL;
+    }
+
+    if (NULL != shmem_sz) {
+        *shmem_sz = 0;
+        if (NULL != ctx->shmem) {
+            log_header* shmem_hdr = (log_header*) ctx->shmem->addr;
+            *shmem_sz = (off_t) shmem_hdr->data_sz;
+        }
+    }
+
+    if (NULL != spill_sz) {
+        *spill_sz = 0;
+        if (NULL != ctx->spill_hdr) {
+            log_header* spill_hdr = (log_header*) ctx->spill_hdr;
+            *spill_sz = (off_t) spill_hdr->data_sz;
+        }
+    }
+
+    return UNIFYFS_SUCCESS;
+}

--- a/common/src/unifyfs_logio.h
+++ b/common/src/unifyfs_logio.h
@@ -136,6 +136,18 @@ int unifyfs_logio_write(logio_context* ctx,
  */
 int unifyfs_logio_sync(logio_context* ctx);
 
+/**
+ * Get the shmem and spill data sizes.
+ *
+ * @param ctx pointer to logio context
+ * @param[out] shmem_sz if non-NULL, set to size of shmem data storage
+ * @param[out] spill_sz if non-NULL, set to size of spillover data storage
+ * @return UNIFYFS_SUCCESS, or error code
+ */
+int unifyfs_logio_get_sizes(logio_context* ctx,
+                            off_t* shmem_sz,
+                            off_t* spill_sz);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/docs/add-rpcs.rst
+++ b/docs/add-rpcs.rst
@@ -30,19 +30,10 @@ Common
 
 .. code-block:: C
   MERCURY_GEN_PROC(unifyfs_mount_in_t,
-                   ((int32_t)(client_id))
                    ((int32_t)(dbg_rank))
-                   ((hg_size_t)(shmem_data_size))
-                   ((hg_size_t)(shmem_super_size))
-                   ((hg_size_t)(meta_offset))
-                   ((hg_size_t)(meta_size))
-                   ((hg_size_t)(logio_mem_size))
-                   ((hg_size_t)(logio_spill_size))
-                   ((hg_const_string_t)(logio_spill_dir))
                    ((hg_const_string_t)(mount_prefix))
                    ((hg_const_string_t)(client_addr_str)))
   MERCURY_GEN_PROC(unifyfs_mount_out_t,
-                   ((hg_size_t)(meta_slice_sz))
                    ((int32_t)(app_id))
                    ((int32_t)(client_id))
                    ((int32_t)(ret)))

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -68,7 +68,6 @@ a given section and key.
    ================  ======  =================================================================
    cwd               STRING  effective starting current working directory
    max_files         INT     maximum number of open files per client process (default: 128)
-   flatten_writes    BOOL    enable flattening writes (optimization for overwrite-heavy codes)
    local_extents     BOOL    service reads from local data if possible (default: off)
    recv_data_size    INT     maximum size (B) of memory buffer for receiving data from server
    write_index_size  INT     maximum size (B) of memory buffer for storing write log metadata

--- a/server/src/unifyfs_cmd_handler.c
+++ b/server/src/unifyfs_cmd_handler.c
@@ -99,7 +99,6 @@ static void unifyfs_mount_rpc(hg_handle_t handle)
 
     /* build output structure to return to caller */
     unifyfs_mount_out_t out;
-    out.meta_slice_sz = meta_slice_sz;
     out.app_id = (int32_t) app_id;
     out.client_id = (int32_t) client_id;
     out.ret = ret;
@@ -279,9 +278,9 @@ static void unifyfs_metaset_rpc(hg_handle_t handle)
 }
 DEFINE_MARGO_RPC_HANDLER(unifyfs_metaset_rpc)
 
-/* given app_id and client_id as input, read all extents from client
- * write index in shared memory and insert corresponding key/value pairs
- * into the global metadata */
+/* given a client identified by (app_id, client_id) as input, read the write
+ * extents for one or more of the client's files from the shared memory index
+ * and update the global metadata for the file(s) */
 static void unifyfs_sync_rpc(hg_handle_t handle)
 {
     /* get input params */
@@ -289,12 +288,12 @@ static void unifyfs_sync_rpc(hg_handle_t handle)
     hg_return_t hret = margo_get_input(handle, &in);
     assert(hret == HG_SUCCESS);
 
-    /* given global file id, read index metadata from client and
-     * insert into global index key/value store */
+    /* read the write indices for all client files from shmem and
+     * propagate their extents to our global metadata */
     int ret = rm_cmd_sync(in.app_id, in.client_id);
 
     /* build our output values */
-    unifyfs_metaset_out_t out;
+    unifyfs_sync_out_t out;
     out.ret = ret;
 
     /* return to caller */
@@ -306,7 +305,6 @@ static void unifyfs_sync_rpc(hg_handle_t handle)
     margo_destroy(handle);
 }
 DEFINE_MARGO_RPC_HANDLER(unifyfs_sync_rpc)
-
 
 /* given an app_id, client_id, global file id,
  * return current file size */
@@ -370,7 +368,7 @@ DEFINE_MARGO_RPC_HANDLER(unifyfs_truncate_rpc)
 static void unifyfs_unlink_rpc(hg_handle_t handle)
 {
     /* get input params */
-    unifyfs_truncate_in_t in;
+    unifyfs_unlink_in_t in;
     hg_return_t hret = margo_get_input(handle, &in);
     assert(hret == HG_SUCCESS);
 
@@ -378,7 +376,7 @@ static void unifyfs_unlink_rpc(hg_handle_t handle)
     int ret = rm_cmd_unlink(in.app_id, in.client_id, in.gfid);
 
     /* build our output values */
-    unifyfs_truncate_out_t out;
+    unifyfs_unlink_out_t out;
     out.ret = (int32_t) ret;
 
     /* return to caller */
@@ -396,7 +394,7 @@ DEFINE_MARGO_RPC_HANDLER(unifyfs_unlink_rpc)
 static void unifyfs_laminate_rpc(hg_handle_t handle)
 {
     /* get input params */
-    unifyfs_truncate_in_t in;
+    unifyfs_laminate_in_t in;
     hg_return_t hret = margo_get_input(handle, &in);
     assert(hret == HG_SUCCESS);
 
@@ -404,7 +402,7 @@ static void unifyfs_laminate_rpc(hg_handle_t handle)
     int ret = rm_cmd_laminate(in.app_id, in.client_id, in.gfid);
 
     /* build our output values */
-    unifyfs_truncate_out_t out;
+    unifyfs_laminate_out_t out;
     out.ret = (int32_t) ret;
 
     /* return to caller */

--- a/server/src/unifyfs_request_manager.c
+++ b/server/src/unifyfs_request_manager.c
@@ -1550,7 +1550,7 @@ int rm_cmd_sync(int app_id, int client_id)
         (NULL == val_lens)) {
         LOGERR("failed to allocate memory for file extents");
         ret = ENOMEM;
-        goto rm_cmd_fsync_exit;
+        goto rm_cmd_sync_exit;
     }
 
     /* create file extent key/values for insertion into MDHIM */
@@ -1579,10 +1579,10 @@ int rm_cmd_sync(int app_id, int client_id)
     if (ret != UNIFYFS_SUCCESS) {
         /* TODO: need proper error handling */
         LOGERR("unifyfs_set_file_extents() failed");
-        goto rm_cmd_fsync_exit;
+        goto rm_cmd_sync_exit;
     }
 
-rm_cmd_fsync_exit:
+rm_cmd_sync_exit:
     /* clean up memory */
 
     if (NULL != keys) {


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

### Description

This updates the `unifyfs_sync()` method in the client to support sync of either all outstanding writes or writes to a specific file. The server rpc handler did not require any modifications to accommodate this change.

The biggest change to how the client operates is that we no longer put writes in the shmem index as they happen. This avoids any interleaving of writes to different files. Instead, each sync rpc only handles the writes for a single file, and we always generate the contents of the shmem write index from each file's `extents_sync` segment tree at the time of the sync. This behavior matches what we were doing before when `UNIFYFS_FLATTEN_WRITES` was enabled (which was the default mode of operation).

Also included were fixes for several places where the wrong in/out structure types were used in the rpc invokers and handlers.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
