### PR TITLE
Update bootstrap.sh to build on power9 systems

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -70,15 +70,18 @@ cd ..
 
 echo "### building mercury ###"
 cd mercury
+git checkout v1.0.1
+git submodule update --init
 mkdir -p build && cd build
 cmake -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" \
+      -DMERCURY_USE_SELF_FORWARD=ON \
       -DMERCURY_USE_BOOST_PP=ON \
       -DMERCURY_USE_CHECKSUMS=ON \
       -DMERCURY_USE_EAGER_BULK=ON \
       -DMERCURY_USE_SYSTEM_MCHECKSUM=OFF \
       -DNA_USE_BMI=ON \
       -DMERCURY_USE_XDR=OFF \
-      -DBUILD_SHARED_LIBS=on ..
+      -DBUILD_SHARED_LIBS=ON ..
 make -j $(nproc) && make install
 cd ..
 cd ..
@@ -88,7 +91,7 @@ cd margo
 git checkout v0.4.3
 export PKG_CONFIG_PATH="$INSTALL_DIR/lib/pkgconfig"
 ./prepare.sh
-./configure --prefix="$INSTALL_DIR"
+./configure --prefix="$INSTALL_DIR" --enable-shared
 make -j $(nproc) && make install
 cd ..
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
This changes bootstrap.sh to checkout a stable version of mercury in order to build on power9 systems.

Also required adding the `git submodule update --init` command since using checksum, per the mercury build instructions.

Fixes: #527

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Get _bootstrap.sh_ working on power9 systems in order to use for building dependencies for our Gitlab CI.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Built from start to finish on power9 system.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
