### PR TITLE
Fixes the problem of read becoming unresponsive

### DIFF
--- a/examples/src/Makefile.am
+++ b/examples/src/Makefile.am
@@ -25,7 +25,8 @@ if HAVE_LD_WRAP
   size-static \
   simul-static \
   chmod-static \
-  multi-write-static
+  multi-write-static \
+  read-data-static
 endif
 
 if HAVE_GOTCHA
@@ -46,9 +47,10 @@ if HAVE_GOTCHA
     app-tileio-gotcha \
     transfer-gotcha \
     size-gotcha \
-	simul-gotcha \
+    simul-gotcha \
     chmod-gotcha \
-	multi-write-gotcha
+    multi-write-gotcha \
+    read-data-gotcha
 endif
 
 if HAVE_FORTRAN
@@ -338,3 +340,12 @@ multi_write_static_CPPFLAGS = $(test_cppflags)
 multi_write_static_LDADD    = $(test_static_ldadd)
 multi_write_static_LDFLAGS  = $(test_static_ldflags)
 
+read_data_gotcha_SOURCES  = read-data.c
+read_data_gotcha_CPPFLAGS = $(test_cppflags)
+read_data_gotcha_LDADD    = $(test_gotcha_ldadd)
+read_data_gotcha_LDFLAGS  = $(test_gotcha_ldflags)
+
+read_data_static_SOURCES  = read-data.c
+read_data_static_CPPFLAGS = $(test_cppflags)
+read_data_static_LDADD    = $(test_static_ldadd)
+read_data_static_LDFLAGS  = $(test_static_ldflags)

--- a/examples/src/read-data.c
+++ b/examples/src/read-data.c
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) 2020, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2019, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyFS.
+ * For details, see https://github.com/LLNL/UnifyFS.
+ * Please read https://github.com/LLNL/UnifyFS/LICENSE for full license text.
+ */
+/* read-data: This program aims to test reading data from a file with arbitrary
+ * offset and length. This program can run either interactively (only
+ * specifying filename) or non-interactively (specifying filename with offset
+ * and length).
+ */
+#include <config.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <errno.h>
+#include <limits.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <libgen.h>
+#include <getopt.h>
+#include <unifyfs.h>
+
+#include "testutil.h"
+
+#define DEFAULT_MOUNTPOINT "/unifyfs"
+
+static char filename[PATH_MAX];
+static char mountpoint[PATH_MAX];
+
+static char* buf;
+static unsigned int bufsize;
+
+static int parse_line(char* line, unsigned long* offset, unsigned long* length)
+{
+    char* pos = NULL;
+
+    line[strlen(line)-1] = '\0';
+
+    if (strncmp("quit", line, strlen("quit")) == 0) {
+        return 1;
+    }
+
+    pos = strchr(line, ',');
+    if (!pos) {
+        return -1;
+    }
+
+    *pos = '\0';
+    pos++;
+
+    *offset = strtoul(line, NULL, 0);
+    *length = strtoul(pos, NULL, 0);
+
+    return 0;
+}
+
+static void alloc_buf(unsigned long length)
+{
+    if (!buf) {
+        bufsize = length;
+        buf = malloc(bufsize);
+    } else {
+        if (bufsize < length) {
+            buf = realloc(buf, length);
+        }
+    }
+
+    if (!buf) {
+        perror("failed to allocate buffer");
+        exit(1);
+    }
+}
+
+static void do_pread(int fd, size_t length, off_t offset)
+{
+    int ret = 0;
+
+    alloc_buf(length);
+
+    errno = 0;
+
+    ret = pread(fd, buf, length, offset);
+
+    printf(" -> pread(off=%lu, len=%lu) = %d", offset, length, ret);
+    if (errno) {
+        printf("  (err=%d, %s)\n", errno, strerror(errno));
+    } else {
+        printf("\n");
+    }
+}
+
+static void run_interactive(int fd)
+{
+    int ret = 0;
+    unsigned long offset = 0;
+    unsigned long length = 0;
+    char* line = NULL;
+    char linebuf[LINE_MAX];
+
+    while (1) {
+        printf("\nread (offset,length)> ");
+        fflush(stdout);
+        line = fgets(linebuf, LINE_MAX-1, stdin);
+        if (!line) {
+            continue;
+        }
+
+        ret = parse_line(line, &offset, &length);
+        if (ret < 0) {
+            continue;
+        } else if (1 == ret) {
+            printf("terminating..\n");
+            break;
+        }
+
+        do_pread(fd, length, offset);
+    }
+}
+
+static struct option long_opts[] = {
+    { "help", 0, 0, 'h' },
+    { "mount", 1, 0, 'm' },
+    { "offset", 1, 0, 'o' },
+    { "length", 1, 0, 'l' },
+    { 0, 0, 0, 0},
+};
+
+static char* short_opts = "hm:o:l:";
+
+static const char* usage_str =
+"\n"
+"Usage: %s [options...] <pathname>\n"
+"\n"
+"Test reading data from a file <pathname>. <pathname> should be a full\n"
+"pathname. If running without --offset and --length options, this will run\n"
+"in an interactive mode where the offset and length should be specified\n"
+"with a separating comma between them, e.g., '<offset>,<length>'.\n"
+"'quit' will terminate the program.\n"
+"\n"
+"Available options:\n"
+" -h, --help                help message\n"
+" -m, --mount=<mountpoint>  use <mountpoint> for unifyfs (default: /unifyfs)\n"
+" -o, --offset=<offset>     read from <offset>\n"
+" -l, --length=<length>     read <length> bytes\n"
+"\n";
+
+static char* program;
+
+static void print_usage(void)
+{
+    printf(usage_str, program);
+    exit(0);
+}
+
+int main(int argc, char** argv)
+{
+    int ret = 0;
+    int ch = 0;
+    int optidx = 0;
+    int unifyfs = 0;
+    int fd = -1;
+    unsigned long offset = 0;
+    unsigned long length = 0;
+    struct stat sb;
+    char* tmp_program = NULL;
+
+    tmp_program = strdup(argv[0]);
+    if (!tmp_program) {
+        perror("failed to allocate memory");
+        return -1;
+    }
+
+    program = basename(tmp_program);
+
+    while ((ch = getopt_long(argc, argv,
+                             short_opts, long_opts, &optidx)) >= 0) {
+        switch (ch) {
+        case 'm':
+            sprintf(mountpoint, "%s", optarg);
+            break;
+
+        case 'o':
+            offset = strtoul(optarg, NULL, 0);
+            break;
+
+        case 'l':
+            length = strtoul(optarg, NULL, 0);
+            break;
+
+        case 'h':
+        default:
+            print_usage();
+            break;
+        }
+    }
+
+    if (argc - optind != 1) {
+        print_usage();
+        return -1;
+    }
+
+    sprintf(filename, "%s", argv[optind]);
+
+    if (mountpoint[0] == '\0') {
+        sprintf(mountpoint, "%s", DEFAULT_MOUNTPOINT);
+    }
+
+    if (strncmp(filename, mountpoint, strlen(mountpoint)) == 0) {
+        printf("mounting unifyfs at %s ..\n", mountpoint);
+
+        ret = unifyfs_mount(mountpoint, 0, 1, 0);
+        if (ret) {
+            fprintf(stderr, "unifyfs_mount failed (return = %d)\n", ret);
+            return -1;
+        }
+
+        unifyfs = 1;
+    }
+
+    fd = open(filename, O_RDONLY);
+    if (fd < 0) {
+        perror("open failed");
+        return -1;
+    }
+
+    ret = stat(filename, &sb);
+    if (ret < 0) {
+        perror("stat failed");
+        goto out;
+    }
+
+    printf("%s (size = %lu)\n", filename, sb.st_size);
+
+    if (offset == 0 && length == 0) {
+        run_interactive(fd);
+    } else {
+        do_pread(fd, length, offset);
+    }
+
+    ret = 0;
+out:
+    close(fd);
+
+    if (buf) {
+        free(buf);
+    }
+
+    if (unifyfs) {
+        unifyfs_unmount();
+    }
+
+    if (tmp_program) {
+        free(tmp_program);
+    }
+
+    return ret;
+}

--- a/server/src/unifyfs_global.h
+++ b/server/src/unifyfs_global.h
@@ -91,8 +91,7 @@ typedef enum {
     READREQ_NULL = 0,          /* request not initialized */
     READREQ_READY,             /* request ready to be issued */
     READREQ_STARTED,           /* chunk requests issued */
-    READREQ_PARTIAL_COMPLETE,  /* some reads completed */
-    READREQ_COMPLETE           /* all reads completed */
+    READREQ_COMPLETE,          /* all reads completed */
 } readreq_status_e;
 
 typedef struct {

--- a/server/src/unifyfs_request_manager.c
+++ b/server/src/unifyfs_request_manager.c
@@ -1961,15 +1961,15 @@ int rm_handle_chunk_read_responses(reqmgr_thrd_t* thrd_ctrl,
             }
             data_buf += data_sz;
         }
+
         /* cleanup */
         free((void*)responses);
         del_reads->resp = NULL;
 
         /* update request status */
         del_reads->status = READREQ_COMPLETE;
-        if (rdreq->status == READREQ_STARTED) {
-            rdreq->status = READREQ_PARTIAL_COMPLETE;
-        }
+
+        /* if all remote reads are complete, mark the request as complete */
         int completed_remote_reads = 0;
         for (i = 0; i < rdreq->num_remote_reads; i++) {
             if (rdreq->remote_reads[i].status != READREQ_COMPLETE) {


### PR DESCRIPTION
Fixes the problem of request manager becoming unresponsive, when handling a read request that needs to fetch data from local and remote servers:

- Fix the request manager
- An example to examine the read operations

### Description

The request manager does not properly process when a read request from a client needs to fetch data both from local and remote servers. The problem does not happen if the data is fully fetched either locally or remotely. Therefore if an application reads data using the same block size while it's written (like most of our example do), the problem does not occur.

Specifically, in the `rm_process_remote_chunk_responses`:

https://github.com/LLNL/UnifyFS/blob/9ed0f1480882fd8a74e7277eaa17446c06c9049e/server/src/unifyfs_request_manager.c#L1732

```
 /* iterate over each active read request */
    for (i = 0; i < RM_MAX_ACTIVE_REQUESTS; i++) {
        server_read_req_t* req = thrd_ctrl->read_reqs + i;
        if ((req->num_remote_reads > 0) &&
            (req->status == READREQ_STARTED)) {
            /* iterate over each delegator we need to send requests to */
            remote_chunk_reads_t* rcr;
            for (j = 0; j < req->num_remote_reads; j++) {
                rcr = req->remote_reads + j;
                if (NULL == rcr->resp) {
                    continue;
                }
                LOGDBG("found read req %d responses from delegator %d",
                       i, rcr->rank);
                rc = rm_handle_chunk_read_responses(thrd_ctrl, req, rcr);
                if (rc != (int)UNIFYFS_SUCCESS) {
                    LOGERR("failed to handle chunk read responses");
                    ret = rc;
                }
            }
```

If the `req` status becomes `READREQ_PARTIAL_COMPLETE`, the request is not further processed by this function. This may fix the issue #525. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)
