### PR TITLE
Fix Gitlab CI rules for pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,16 @@ stages:
   - test-unit
   - test-integ
 
+# Rules to determine when a pipeline will be generated. If none of these rules
+# match, no pipeline will be generated.
+workflow:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+    - if: '$CI_PIPELINE_SOURCE == "web"'
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME == "dev"'
+    - if: '$CI_PIPELINE_SOURCE == "external_pull_request_event" && $CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_NAME == "dev"'
+    - if: '$CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH == "dev"'
+
 ##### System Templates #####
 
 # Generic system templates used to contruct the final jobs on specific
@@ -17,10 +27,6 @@ stages:
 # Gitlab interface if/when the defaults need to be changed.
 
 .base-template:
-  rules:
-    - if: '$CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH == "dev"'
-    - if: '$CI_MERGE_REQUEST_TARGET_BRANCH_NAME == "dev" && $CI_PIPELINE_SOURCE == "merge_request_event"'
-    - if: '$CI_MERGE_REQUEST_TARGET_BRANCH_NAME == "dev" && $CI_PIPELINE_SOURCE == "external_pull_request_event"'
   retry:
     max: 1
     when:
@@ -28,22 +34,18 @@ stages:
       - stuck_or_timeout_failure
 
 .slurm-single-node-template:
-  extends: .base-template
   variables:
     LLNL_SLURM_SCHEDULER_PARAMETERS: "-N 1 -p pbatch -t $UNIT_WALL_TIME -J unifyfs-unit-tests"
 
 .slurm-multi-node-template:
-  extends: .base-template
   variables:
     LLNL_SLURM_SCHEDULER_PARAMETERS: "-N $NNODES -p pbatch -t $INTEG_WALL_TIME -J unifyfs-integ-tests"
 
 .lsf-single-node-template:
-  extends: .base-template
   variables:
     LLNL_LSF_SCHEDULER_PARAMETERS: "-nnodes 1 -q pbatch -W $UNIT_WALL_TIME -J unifyfs-unit-tests"
 
 .lsf-multi-node-template:
-  extends: .base-template
   variables:
     LLNL_LSF_SCHEDULER_PARAMETERS: "-nnodes $NNODES -stage storage=${STORAGE_SIZE} -q pbatch -W $INTEG_WALL_TIME -J unifyfs-integ-tests"
 

--- a/.gitlab/catalyst.yml
+++ b/.gitlab/catalyst.yml
@@ -3,9 +3,11 @@
 # The RUN_CATALYST variable can be toggled in the Gitlab interface to
 # toggle whether jobs should be run on this system.
 .catalyst-template:
+  extends: .base-template
   rules:
     - if: '$RUN_CATALYST != "ON"'
       when: never
+    - when: on_success
 
 .catalyst-shell-template:
   extends: .catalyst-template

--- a/.gitlab/lassen.yml
+++ b/.gitlab/lassen.yml
@@ -3,9 +3,11 @@
 # The RUN_LASSEN variable can be toggled in the Gitlab interface to
 # toggle whether jobs should be run on this system.
 .lassen-template:
+  extends: .base-template
   rules:
     - if: '$RUN_LASSEN != "ON"'
       when: never
+    - when: on_success
 
 .lassen-shell-template:
   extends: .lassen-template


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Current rules were not defined properly and end up preventing any pipeline creation from happening, even manually from the web interface.

This moves the rules to the workflow key to define when pipelines should be created, but not interfere with when jobs should run.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)