### PR TITLE
Handling large transfer between servers. 

### DIFF
--- a/client/src/unifyfs.c
+++ b/client/src/unifyfs.c
@@ -1107,7 +1107,7 @@ int unifyfs_gfid_read_reqs(read_req_t* in_reqs, int in_count)
     /*
      * ToDo: Exception handling when some of the requests
      * are missed
-     * */
+     */
 
     /* spin waiting for read data to come back from the server,
      * we process it in batches as it comes in, eventually the
@@ -1121,11 +1121,14 @@ int unifyfs_gfid_read_reqs(read_req_t* in_reqs, int in_count)
         } else {
             tmp_rc = process_read_data(read_reqs, count, &done);
             if (tmp_rc != UNIFYFS_SUCCESS) {
+                LOGERR("failed to process data from server");
                 rc = UNIFYFS_FAILURE;
             }
             delegator_signal();
         }
     }
+
+    LOGDBG("fetched all data from server for %d requests", count);
 
     /* got all of the data we'll get from the server,
      * check for short reads and whether those short

--- a/common/src/unifyfs_const.h
+++ b/common/src/unifyfs_const.h
@@ -54,6 +54,7 @@
 #define REQ_BUF_LEN (MAX_META_PER_SEND * 64) /* chunk read reqs buffer size */
 #define SHM_WAIT_INTERVAL 1000       /* unit: ns */
 #define RM_MAX_ACTIVE_REQUESTS 64    /* number of concurrent read requests */
+#define MAX_BULK_TX_SIZE (8 * MIB)   /* bulk transfer size */
 
 // Server - Service Manager
 #define LARGE_BURSTY_DATA (512 * MIB)

--- a/examples/src/read-data.c
+++ b/examples/src/read-data.c
@@ -85,7 +85,7 @@ static void alloc_buf(unsigned long length)
 
 static void do_pread(int fd, size_t length, off_t offset)
 {
-    int ret = 0;
+    ssize_t ret = 0;
 
     alloc_buf(length);
 
@@ -93,7 +93,7 @@ static void do_pread(int fd, size_t length, off_t offset)
 
     ret = pread(fd, buf, length, offset);
 
-    printf(" -> pread(off=%lu, len=%lu) = %d", offset, length, ret);
+    printf(" -> pread(off=%lu, len=%lu) = %zd", offset, length, ret);
     if (errno) {
         printf("  (err=%d, %s)\n", errno, strerror(errno));
     } else {


### PR DESCRIPTION
Handling large transfer between servers. This fixes the large data transfer failures (in the mercury tranport layer) between servers.

* `common/unifyfs_const.h`: defined `MAX_BULK_TX_SIZE` (8MB) for data transfer size.
* `src/server/unifyfs_request_manager.c`: fixed request manager to initiate multiple transfers for large bulk data.
* type fix in `examples/src/read-data.c`
* some relevant debugging messages.

### Description
One of the (so far identified) problems in handling a large I/O request is in the bulk data transfer in the RPC layer. The `margo_bulk_transfer` does not consider the size limitation of the underlying transport layer, and fails when the bulk transfer size exceeds the size the underlying transport layer can handle. Specifically, the following bulk transfer in the request manager fails when the transfer size (`in.bulk_size`) becomes larger than the transport layer can handle:

https://github.com/LLNL/UnifyFS/blob/cd0c9b45ea843b5af3e403526057488953bd092b/server/src/unifyfs_request_manager.c#L2313

```
            /* pass along address of buffer we want to transfer
             * data into to prepare it for a bulk write,
             * get resulting margo handle */
            hg_bulk_t bulk_handle;
            hret = margo_bulk_create(mid, 1, (void**)&resp_buf, &in.bulk_size,
                HG_BULK_WRITE_ONLY, &bulk_handle);
            assert(hret == HG_SUCCESS);

            /* execute the transfer to pull data from remote side
             * into our local bulk transfer buffer */
            hret = margo_bulk_transfer(mid, HG_BULK_PULL, hgi->addr,
                in.bulk_handle, 0, bulk_handle, 0, in.bulk_size);
            assert(hret == HG_SUCCESS);
```

Also, the use of `assert(3)` leads to the immediate termination of the server daemon (maybe we need to start remove `assert(3)` calls).

With this fix, the large file read works (e.g., `read(fd, buf, 2GB)`), as long as the request manager can allocate buffer for handling the request (`UNIFYFS_MAX_SPLIT_CNT`). It also looks like there are other problems when many clients (per server, i.,e., large `ppn`) are concurrently performing large read operations.

This patch partially fixes #532.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)
