### PR TITLE
document manifest file format and usage

### DIFF
--- a/docs/start-stop.rst
+++ b/docs/start-stop.rst
@@ -117,3 +117,29 @@ with a README documenting the installation instructions, is available
 within the source repository at ``util/scripts/lsfcsm``.
 
 Support for the SLURM resource manager is under development.
+
+-----------------------------------------------
+  Stage-in and Stage-out Manifest File Format
+-----------------------------------------------
+
+The manifest file contains one or more file copy requests.
+Each line in the manifest corresponds to one file copy request,
+and contains both the source and destination file paths. Currently,
+directory copies are not supported.
+
+Each line is formatted as <source filename><whitespace><destination filename>.
+If either of the filenames
+contain whitespace or special characters, then both filenames should
+be surrounded by double-quote characters (") (ASCII character 34 decimal).
+The double-quote character and the linefeed end-of-line character are forbidden
+in any filenames used in a unifyfs manifest file, but any other
+characters are allowed, including control characters.
+If a filename contains any characters that might be misinterpreted, then
+enclosing the filename in double-quotes is always
+a safe thing to do.
+
+Here is an example of a valid stage-in manifest file:
+
+``/scratch/users/me/input_data/input_1.dat /unifyfs/input/input_1.dat``
+``/home/users/me/configuration/run_12345.conf /unifyfs/config/run_12345.conf``
+``"/home/users/me/file with space.dat" "/unifyfs/file with space.dat"``


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

This modifies the start-stop.rst file to document how the stage-in and 
stage-out manifest files are formatted and show examples both of 
manifest files and how they are invoked when using the unifyfs daemon 
launch and teardown.  

This documentation will be edited in this PR until it's ready to 
be checked in.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

These code changes are in the dev repository but their usage is not 
yet reflected in the documentation.  

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
