### PR TITLE
Fixing the race condition between server and client during mread.

### DIFF
--- a/client/src/margo_client.h
+++ b/client/src/margo_client.h
@@ -61,6 +61,32 @@ int invoke_client_sync_rpc(void);
 
 int invoke_client_read_rpc(int gfid, size_t offset, size_t length);
 
-int invoke_client_mread_rpc(int read_count, size_t size, void* buffer);
+/*
+ * mread rpc function is non-blocking (using margo_iforward), and the response
+ * from the server should be checked by the caller manually using
+ * the unifyfs_mread_rpc_status_check function.
+ */
+struct unifyfs_mread_rpc_ctx {
+    margo_request req;      /* margo request for track iforward result */
+    hg_handle_t handle;     /* rpc handle */
+    int rpc_ret;            /* rpc response from the server */
+};
+
+typedef struct unifyfs_mread_rpc_ctx unifyfs_mread_rpc_ctx_t;
+
+/**
+ * @brief track the progress of the submitted rpc. if the rpc is done, this
+ * funtcion returns 1 with the server response being stored in @ctx->rpc_ret.
+ *
+ * @param ctx pointer to the rpc ctx
+ *
+ * @return 1 if rpc is done (received response from the server), 0 if still in
+ * progress. -EINVAL if the @ctx is invalid.
+ */
+int unifyfs_mread_rpc_status_check(unifyfs_mread_rpc_ctx_t* ctx);
+
+
+int invoke_client_mread_rpc(int read_count, size_t size, void* buffer,
+                            unifyfs_mread_rpc_ctx_t* ctx);
 
 #endif // MARGO_CLIENT_H

--- a/client/src/unifyfs-internal.h
+++ b/client/src/unifyfs-internal.h
@@ -318,6 +318,7 @@ typedef struct {
     size_t length; /* number of bytes to read */
     size_t nread;  /* number of bytes actually read */
     char* buf;     /* pointer to user buffer to place data */
+    struct aiocb* aiocbp; /* the original request from application */
 } read_req_t;
 
 typedef struct {

--- a/client/src/unifyfs-sysio.c
+++ b/client/src/unifyfs-sysio.c
@@ -1581,6 +1581,7 @@ int UNIFYFS_WRAP(lio_listio)(int mode, struct aiocb* const aiocb_list[],
                     reqs[reqcnt].nread   = 0;
                     reqs[reqcnt].errcode = EINPROGRESS;
                     reqs[reqcnt].buf     = (char*)(cbp->aio_buf);
+                    reqs[reqcnt].aiocbp  = cbp;
                     reqcnt++;
                 }
             } else {
@@ -1609,12 +1610,10 @@ int UNIFYFS_WRAP(lio_listio)(int mode, struct aiocb* const aiocb_list[],
         }
 
         /* update aiocb fields to record error status and return value */
-        ndx = 0;
         for (i = 0; i < reqcnt; i++) {
-            char* buf = reqs[i].buf;
-            for (; ndx < nitems; ndx++) {
+            for (ndx = 0; ndx < nitems; ndx++) {
                 cbp = aiocb_list[ndx];
-                if ((char*)(cbp->aio_buf) == buf) {
+                if (cbp == reqs[i].aiocbp) {
                     AIOCB_ERROR_CODE(cbp) = reqs[i].errcode;
                     if (0 == reqs[i].errcode) {
                         AIOCB_RETURN_VAL(cbp) = reqs[i].length;

--- a/server/src/unifyfs_global.h
+++ b/server/src/unifyfs_global.h
@@ -95,6 +95,7 @@ typedef enum {
 } readreq_status_e;
 
 typedef struct {
+    int gfid;           /* gfid */
     size_t nbytes;      /* size of data chunk */
     size_t offset;      /* file offset */
     size_t log_offset;  /* remote log offset */
@@ -103,6 +104,7 @@ typedef struct {
 } chunk_read_req_t;
 
 typedef struct {
+    int gfid;         /* gfid */
     size_t offset;    /* file offset */
     size_t nbytes;    /* requested read size */
     ssize_t read_rc;  /* bytes read (or negative error code) */

--- a/server/src/unifyfs_request_manager.h
+++ b/server/src/unifyfs_request_manager.h
@@ -38,7 +38,7 @@ typedef struct {
     int app_id;                /* app id of requesting client process */
     int client_id;             /* client id of requesting client process */
     int num_remote_reads;      /* size of remote_reads array */
-    client_read_req_t extent;  /* client read extent, includes gfid */
+    int in_use;                /* occupied by a thread */
     chunk_read_req_t* chunks;  /* array of chunk-reads */
     remote_chunk_reads_t* remote_reads; /* per-delegator remote reads array */
 } server_read_req_t;

--- a/server/src/unifyfs_service_manager.c
+++ b/server/src/unifyfs_service_manager.c
@@ -172,6 +172,7 @@ int sm_issue_chunk_reads(int src_rank,
         size_t log_offset = rreq->log_offset;
 
         /* record request metadata in response */
+        rresp->gfid    = rreq->gfid;
         rresp->read_rc = 0;
         rresp->nbytes  = nbytes;
         rresp->offset  = rreq->offset;


### PR DESCRIPTION
When multiple file descriptors/files are involved in a single lio_listio call,
UnifyFS hangs due to incorrect coordination for exchanging data between
server and client. This patch fixes it.

- client side (unifyfs-sysio.c and unifyfs.c): correctly identify the
request completion of individual files.
- server side (unifyfs_cmd_handler.c) : send mread rpc response before
handling the request.
- also removing some extra global lock statements in the request manager
(unifyfs_request_manager.c).
- some extra debugging messages

### Description
When `lio_listio(3)` is requested with multiple files, UnifyFS becomes unresponsive as described in #538. This happens primarily for two reasons:

1. upon receiving the mread RPC, the server thread may send data before it replies to the client:

https://github.com/LLNL/UnifyFS/blob/b4ea3eeceac1c9bf4dffc95ac7479ae3003bd3e3/server/src/unifyfs_cmd_handler.c#L453

```
    /* get list of read requests */
    hret = margo_bulk_transfer(mid, HG_BULK_PULL, hgi->addr,
                               in.bulk_handle, 0, bulk_handle, 0, size);
    assert(hret == HG_SUCCESS);

    /* initiate read operations to fetch data for read requests */
    int ret = rm_cmd_mread(in.app_id, in.client_id,
                           in.read_count, buffer);

    /* build our output values */
    unifyfs_mread_out_t out;
    out.ret = ret;

    /* return to caller */
    hret = margo_respond(handle, &out);
    assert(hret == HG_SUCCESS);
```

Specifically, the execution of `rm_cmd_mread` may cause the request manager thread to send data (before margo handler thread responding to this rpc). This blocks the progress in the request manager (waiting for client to consume the shm data while holding the global lock, while the client is waiting for the server response).

As @MichaelBrim  suggested, a fundamental fix would be letting other thread (instead of this margo handler thread) execute the code of `rm_cmd_mread`, which is quite heavy/complex for a rpc handler thread.

2. the client does not correctly account the 'data completion' notice from the server:

The server sends the data completion message (via shmem buffer), when handling a request for a file completes. The current client code of fetching the data does not correctly detect the data completion. 

https://github.com/LLNL/UnifyFS/blob/b4ea3eeceac1c9bf4dffc95ac7479ae3003bd3e3/client/src/unifyfs.c#L1115

```
    /* spin waiting for read data to come back from the server,
     * we process it in batches as it comes in, eventually the
     * server will tell us it's sent us everything it can */
    int done = 0;
    while (!done) {
        int tmp_rc = delegator_wait();
        if (tmp_rc != UNIFYFS_SUCCESS) {
            rc = UNIFYFS_FAILURE;
            done = 1;
        } else {
            tmp_rc = process_read_data(read_reqs, count, &done);
            if (tmp_rc != UNIFYFS_SUCCESS) {
                LOGERR("failed to process data from server");
                rc = UNIFYFS_FAILURE;
            }
            delegator_signal();
        }
    }
```

When multiples files are involved in a single `lio_listio`, this loop terminates before receiving all data.

This patch primarily addresses those issues.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)