### PR TITLE
Fixing bugs in the unifyfs-transfer:

### DIFF
--- a/client/src/unifyfs.c
+++ b/client/src/unifyfs.c
@@ -2675,7 +2675,7 @@ int unifyfs_unmount(void)
     return ret;
 }
 
-#define UNIFYFS_TX_BUFSIZE (1<<20)
+#define UNIFYFS_TX_BUFSIZE (8*(1<<20))
 
 enum {
     UNIFYFS_TX_STAGE_OUT = 0,
@@ -2693,7 +2693,13 @@ ssize_t do_transfer_data(int fd_src, int fd_dst, off_t offset, size_t count)
     ssize_t n_left = 0;
     ssize_t n_processed = 0;
     size_t len = UNIFYFS_TX_BUFSIZE;
-    char buf[UNIFYFS_TX_BUFSIZE] = { 0, };
+    char* buf = NULL;
+
+    buf = malloc(UNIFYFS_TX_BUFSIZE);
+    if (!buf) {
+        LOGERR("failed to allocate transfer buffer");
+        return ENOMEM;
+    }
 
     pos = lseek(fd_src, offset, SEEK_SET);
     if (pos == (off_t) -1) {
@@ -2740,6 +2746,11 @@ ssize_t do_transfer_data(int fd_src, int fd_dst, off_t offset, size_t count)
     }
 
 out:
+    if (buf) {
+        free(buf);
+        buf = NULL;
+    }
+
     return ret;
 }
 

--- a/t/9300-unifyfs-stage-isolated.t
+++ b/t/9300-unifyfs-stage-isolated.t
@@ -32,7 +32,7 @@ test_expect_success "source.file exists" '
     test_path_is_file ${UNIFYFS_TEST_TMPDIR}/stage_source/source_9300.file
 '
 
-rm - f $ {UNIFYFS_TEST_TMPDIR} / config_9300/*
+rm -f ${UNIFYFS_TEST_TMPDIR}/config_9300/*
 rm -f ${UNIFYFS_TEST_TMPDIR}/stage_destination_9300/*
 
 test_expect_success "config_9300 directory is empty" '

--- a/util/unifyfs-stage/src/unifyfs-stage.c
+++ b/util/unifyfs-stage/src/unifyfs-stage.c
@@ -294,7 +294,10 @@ int main(int argc, char** argv)
         fprintf(stderr, "data transfer failed (%s)\n", strerror(errno));
     }
 
-    if (share_dir) {
+    /* wait until all processes are done */
+    MPI_Barrier(MPI_COMM_WORLD);
+
+    if (share_dir && rank == 0) {
         ret = create_status_file(ret);
         if (ret) {
             fprintf(stderr, "failed to create the status file (%s)\n",

--- a/util/unifyfs/src/unifyfs.c
+++ b/util/unifyfs/src/unifyfs.c
@@ -77,6 +77,7 @@ static struct option const long_opts[] = {
     { "stage-in", required_argument, NULL, 'i' },
     { "stage-out", required_argument, NULL, 'o' },
     { "timeout", required_argument, NULL, 't' },
+    { "stage-timeout", required_argument, NULL, 'T' },
     { 0, 0, 0, 0 },
 };
 


### PR DESCRIPTION
- adding a missing barrier in the unifyfs-stage utility.
- adding a missing long option (--stage-timeout) in the unifyfs utility.
- chaning the transfer buffer size to 8MB (from 1MB).


### Description
#540 


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

