### PR TITLE
Allow runtime configuration of max clients per application

### DIFF
--- a/common/src/unifyfs_configurator.h
+++ b/common/src/unifyfs_configurator.h
@@ -86,7 +86,7 @@
     UNIFYFS_CFG(meta, db_path, STRING, RUNDIR, "metadata database path", configurator_directory_check) \
     UNIFYFS_CFG(meta, server_ratio, INT, META_DEFAULT_SERVER_RATIO, "metadata server ratio", NULL) \
     UNIFYFS_CFG(meta, range_size, INT, META_DEFAULT_RANGE_SZ, "metadata range size", NULL) \
-    UNIFYFS_CFG_CLI(runstate, dir, STRING, RUNDIR, "runstate file directory", configurator_directory_check, 'R', "specify full path to directory to contain server runstate file") \
+    UNIFYFS_CFG_CLI(runstate, dir, STRING, RUNDIR, "runstate file directory", configurator_directory_check, 'R', "specify full path to directory to contain server-local state") \
     UNIFYFS_CFG_CLI(server, hostfile, STRING, NULLSTRING, "server hostfile name", NULL, 'H', "specify full path to server hostfile") \
     UNIFYFS_CFG_CLI(server, init_timeout, INT, UNIFYFS_DEFAULT_INIT_TIMEOUT, "timeout of waiting for server initialization", NULL, 't', "timeout in seconds to wait for servers to be ready for clients") \
     UNIFYFS_CFG(server, max_app_clients, INT, MAX_APP_CLIENTS, "maximum number of clients per application", NULL) \

--- a/common/src/unifyfs_configurator.h
+++ b/common/src/unifyfs_configurator.h
@@ -86,10 +86,11 @@
     UNIFYFS_CFG(meta, db_path, STRING, RUNDIR, "metadata database path", configurator_directory_check) \
     UNIFYFS_CFG(meta, server_ratio, INT, META_DEFAULT_SERVER_RATIO, "metadata server ratio", NULL) \
     UNIFYFS_CFG(meta, range_size, INT, META_DEFAULT_RANGE_SZ, "metadata range size", NULL) \
-    UNIFYFS_CFG_CLI(runstate, dir, STRING, RUNDIR, "runstate file directory", configurator_directory_check, 'R', "specify full path to directory to contain server-local state") \
+    UNIFYFS_CFG_CLI(runstate, dir, STRING, RUNDIR, "runstate file directory", configurator_directory_check, 'R', "specify full path to directory to contain server runstate file") \
     UNIFYFS_CFG_CLI(server, hostfile, STRING, NULLSTRING, "server hostfile name", NULL, 'H', "specify full path to server hostfile") \
     UNIFYFS_CFG_CLI(server, init_timeout, INT, UNIFYFS_DEFAULT_INIT_TIMEOUT, "timeout of waiting for server initialization", NULL, 't', "timeout in seconds to wait for servers to be ready for clients") \
-    UNIFYFS_CFG_CLI(sharedfs, dir, STRING, NULLSTRING, "shared file system directory", configurator_directory_check, 'S', "specify full path to directory to contain files shared across servers") \
+    UNIFYFS_CFG(server, max_app_clients, INT, MAX_APP_CLIENTS, "maximum number of clients per application", NULL) \
+    UNIFYFS_CFG_CLI(sharedfs, dir, STRING, NULLSTRING, "shared file system directory", configurator_directory_check, 'S', "specify full path to directory to contain server shared files") \
 
 
 #ifdef __cplusplus

--- a/common/src/unifyfs_const.h
+++ b/common/src/unifyfs_const.h
@@ -64,10 +64,9 @@
 #define SLEEP_SLICE_PER_UNIT 50   /* unit: us */
 
 // Server - General
-#define MAX_NUM_APPS 64    /* max # apps supported by a single server */
-#define MAX_APP_CLIENTS 64 /* app processes per server */
-/* timeout (in seconds) of waiting for initialization of all servers */
-#define UNIFYFS_DEFAULT_INIT_TIMEOUT 120
+#define MAX_NUM_APPS 64     /* max # apps/mountpoints supported */
+#define MAX_APP_CLIENTS 256 /* max # clients per application */
+#define UNIFYFS_DEFAULT_INIT_TIMEOUT 120 /* server init timeout (seconds) */
 #define UNIFYFSD_PID_FILENAME "unifyfsd.pids"
 #define UNIFYFS_STAGE_STATUS_FILENAME "unifyfs-stage.status"
 

--- a/server/src/unifyfs_global.h
+++ b/server/src/unifyfs_global.h
@@ -168,7 +168,8 @@ typedef struct app_config {
 
     /* array of clients associated with this app */
     size_t num_clients;
-    app_client* clients[MAX_APP_CLIENTS];
+    size_t clients_sz;
+    app_client** clients;
 } app_config;
 
 app_config* get_application(int app_id);


### PR DESCRIPTION
### Description

Previously, we had a compile-time limit of 64 clients per application (where application == mountpoint). This PR makes it a server configuration option that can be set at runtime via the environment variable UNIFYFS_SERVER_MAX_APP_CLIENTS. I also upped the default number of clients to 256.

### How Has This Been Tested?

Tested on Summitdev by running 3 back-to-back writeread examples using the new default and a low limit (25). In the latter case, the limit was properly enforced.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
