### PR TITLE
Modifying the read-data example to verify the data content.

### DIFF
--- a/examples/src/read-data.c
+++ b/examples/src/read-data.c
@@ -31,6 +31,7 @@
 #include <libgen.h>
 #include <getopt.h>
 #include <unifyfs.h>
+#include <time.h>
 
 #include "testutil.h"
 
@@ -40,9 +41,10 @@ static char filename[PATH_MAX];
 static char mountpoint[PATH_MAX];
 
 static char* buf;
-static unsigned int bufsize;
+static uint64_t bufsize;
+static int check;
 
-static int parse_line(char* line, unsigned long* offset, unsigned long* length)
+static int parse_line(char* line, uint64_t* offset, uint64_t* length)
 {
     char* pos = NULL;
 
@@ -60,13 +62,13 @@ static int parse_line(char* line, unsigned long* offset, unsigned long* length)
     *pos = '\0';
     pos++;
 
-    *offset = strtoul(line, NULL, 0);
-    *length = strtoul(pos, NULL, 0);
+    *offset = strtoull(line, NULL, 0);
+    *length = strtoull(pos, NULL, 0);
 
     return 0;
 }
 
-static void alloc_buf(unsigned long length)
+static void alloc_buf(uint64_t length)
 {
     if (!buf) {
         bufsize = length;
@@ -83,29 +85,80 @@ static void alloc_buf(unsigned long length)
     }
 }
 
+static void aligned_offlen(uint64_t filesize, uint64_t blocksize,
+                          uint64_t* off, uint64_t* len)
+{
+    uint64_t block_count = filesize / blocksize;
+
+    *off = (random() % (block_count - 1)) * blocksize;
+    *len = blocksize;
+}
+
+
+static void random_offlen(uint64_t filesize, uint64_t maxoff, uint64_t maxlen,
+                          uint64_t* off, uint64_t* len)
+{
+    uint64_t _off;
+    uint64_t _len;
+
+    _off = random() % maxoff;
+    _len = random() % maxlen;
+
+    while (_off + _len > filesize) {
+        _len = _len / 2 + 1;
+    }
+
+    *len = _len;
+    *off = _off;
+}
+
 static void do_pread(int fd, size_t length, off_t offset)
 {
     ssize_t ret = 0;
+    struct timespec ts1, ts2;
+    double ts1nsec, ts2nsec;
+    double elapsed_sec, mbps;
 
     alloc_buf(length);
 
     errno = 0;
 
+    clock_gettime(CLOCK_REALTIME, &ts1);
+
     ret = pread(fd, buf, length, offset);
+
+    clock_gettime(CLOCK_REALTIME, &ts2);
+
+    ts1nsec = 1e9 * 1.0 * ts1.tv_sec + 1.0 * ts1.tv_nsec;
+    ts2nsec = 1e9 * 1.0 * ts2.tv_sec + 1.0 * ts2.tv_nsec;
+    elapsed_sec = (ts2nsec - ts1nsec) / (1e9);
+
+    mbps = (1.0 * length / (1<<20)) / elapsed_sec;
 
     printf(" -> pread(off=%lu, len=%lu) = %zd", offset, length, ret);
     if (errno) {
         printf("  (err=%d, %s)\n", errno, strerror(errno));
     } else {
-        printf("\n");
+        printf(" (%.3f sec, %.3lf MB/s)\n", elapsed_sec, mbps);
+
+        if (check) {
+            uint64_t error_offset;
+            ret = lipsum_check(buf, length, offset, &error_offset);
+            if (ret < 0) {
+                printf("    * data verification failed at offset %" PRIu64 "\n",
+                       error_offset);
+            } else {
+                printf("    * data verification success\n");
+            }
+        }
     }
 }
 
 static void run_interactive(int fd)
 {
     int ret = 0;
-    unsigned long offset = 0;
-    unsigned long length = 0;
+    uint64_t offset = 0;
+    uint64_t length = 0;
     char* line = NULL;
     char linebuf[LINE_MAX];
 
@@ -131,13 +184,18 @@ static void run_interactive(int fd)
 
 static struct option long_opts[] = {
     { "help", 0, 0, 'h' },
+    { "check", 0, 0, 'c' },
     { "mount", 1, 0, 'm' },
     { "offset", 1, 0, 'o' },
     { "length", 1, 0, 'l' },
+    { "random", 1, 0, 'r' },
+    { "max-offset", 1, 0, 'O' },
+    { "max-length", 1, 0, 'L' },
+    { "aligned", 1, 0, 'a' },
     { 0, 0, 0, 0},
 };
 
-static char* short_opts = "hm:o:l:";
+static char* short_opts = "hcm:o:l:r:O:L:f:";
 
 static const char* usage_str =
 "\n"
@@ -150,10 +208,17 @@ static const char* usage_str =
 "'quit' will terminate the program.\n"
 "\n"
 "Available options:\n"
-" -h, --help                help message\n"
-" -m, --mount=<mountpoint>  use <mountpoint> for unifyfs (default: /unifyfs)\n"
-" -o, --offset=<offset>     read from <offset>\n"
-" -l, --length=<length>     read <length> bytes\n"
+" -h, --help               help message\n"
+" -c, --check              verify data content. data should be written using\n"
+"                          the write example with --check option\n"
+" -m, --mount=<mountpoint> use <mountpoint> for unifyfs (default: /unifyfs)\n"
+" -o, --offset=<offset>    read from <offset>\n"
+" -l, --length=<length>    read <length> bytes\n"
+" -r, --random=<repeat>    generate random offset and length <repeat> times,\n"
+"                          only workin in the non-interactive mode\n"
+" -O, --max-offset=<off>   generate a random offset not exceeding <off>\n"
+" -L, --max-length=<len>   generate a random length not exceeding <len>\n"
+" -f, --aligned=<size>     generate requests aligned with a blocksize <size>\n"
 "\n";
 
 static char* program;
@@ -171,8 +236,13 @@ int main(int argc, char** argv)
     int optidx = 0;
     int unifyfs = 0;
     int fd = -1;
-    unsigned long offset = 0;
-    unsigned long length = 0;
+    int random = 0;
+    uint64_t offset = 0;
+    uint64_t length = 0;
+    uint64_t maxoff = 0;
+    uint64_t maxlen = 0;
+    uint64_t aligned = 0;
+    uint64_t filesize = 0;
     struct stat sb;
     char* tmp_program = NULL;
 
@@ -187,16 +257,36 @@ int main(int argc, char** argv)
     while ((ch = getopt_long(argc, argv,
                              short_opts, long_opts, &optidx)) >= 0) {
         switch (ch) {
+        case 'c':
+            check = 1;
+            break;
+
         case 'm':
             sprintf(mountpoint, "%s", optarg);
             break;
 
         case 'o':
-            offset = strtoul(optarg, NULL, 0);
+            offset = strtoull(optarg, NULL, 0);
             break;
 
         case 'l':
-            length = strtoul(optarg, NULL, 0);
+            length = strtoull(optarg, NULL, 0);
+            break;
+
+        case 'r':
+            random = atoi(optarg);
+            break;
+
+        case 'O':
+            maxoff = strtoull(optarg, NULL, 0);
+            break;
+
+        case 'L':
+            maxlen = strtoull(optarg, NULL, 0);
+            break;
+
+        case 'a':
+            aligned = strtoull(optarg, NULL, 0);
             break;
 
         case 'h':
@@ -241,12 +331,37 @@ int main(int argc, char** argv)
         goto out;
     }
 
-    printf("%s (size = %lu)\n", filename, sb.st_size);
+    filesize = sb.st_size;
+    printf("%s (size = %lu)\n", filename, filesize);
 
-    if (offset == 0 && length == 0) {
+    if (offset == 0 && length == 0 && random == 0) {
         run_interactive(fd);
     } else {
-        do_pread(fd, length, offset);
+        if (random) {
+            struct timespec ts;
+
+            clock_gettime(CLOCK_REALTIME, &ts);
+            srandom(ts.tv_nsec % ts.tv_sec);
+
+            if (0 == maxoff) {
+                maxoff = filesize / 2;
+            }
+
+            if (0 == maxlen) {
+                maxlen = filesize / 2;
+            }
+
+            for (int i = 0; i < random; i++) {
+                if (aligned) {
+                    aligned_offlen(filesize, aligned, &offset, &length);
+                } else {
+                    random_offlen(filesize, maxoff, maxlen, &offset, &length);
+                }
+                do_pread(fd, length, offset);
+            }
+        } else {
+            do_pread(fd, length, offset);
+        }
     }
 
     ret = 0;

--- a/examples/src/testutil.h
+++ b/examples/src/testutil.h
@@ -759,7 +759,22 @@ int lipsum_check(const char* buf, uint64_t len, uint64_t offset,
     uint64_t i, val;
     uint64_t start = offset / sizeof(uint64_t);
     uint64_t count = len / sizeof(uint64_t);
+    uint64_t skip = 0;
+    uint64_t remain = 0;
     const uint64_t* ibuf = (uint64_t*) buf;
+
+    /* check if we have any extra bytes at the front and end */
+    if (offset % sizeof(uint64_t)) {
+        skip = sizeof(uint64_t) - (offset % sizeof(uint64_t));
+        remain = (len - skip) % sizeof(uint64_t);
+
+        ibuf = (uint64_t*) &buf[skip];
+        start++;
+
+        if (skip + remain >= sizeof(uint64_t)) {
+            count--;
+        }
+    }
 
     for (i = 0; i < count; i++) {
         val = start + i;


### PR DESCRIPTION
- modifying lipsum_check function (testutil.h) to check arbitrary byte
offset
- modifying read-data example to verify data content
- modifying read-data example to generate ramdom offset/length

### Description
This enhances the `read-data` example to verify the data correctness (when written with test examples). Also, `read-data` generates random offset and lengths.

### Motivation and Context
This is handy to check if UnifyFS delivers requested data contents correctly. Also, it can generate random read I/O requests, which might be useful for read performance/stress tests:

```
$ read-data-static --random=10 --check --maxlength=$((32*(1<<20))) /unifyfs/testfile
mounting unifyfs at /unifyfs ..
/unifyfs/testfile (size = 34359738368)
 -> pread(off=913763188, len=10672122) = 10672122 (1.679 sec, 6.061 MB/s)
    * data verification success
 -> pread(off=1154978998, len=8628740) = 8628740 (0.142 sec, 58.149 MB/s)
    * data verification success
 -> pread(off=2059285420, len=5659992) = 5659992 (0.508 sec, 10.619 MB/s)
    * data verification success
 -> pread(off=1012117804, len=29697544) = 29697544 (2.781 sec, 10.185 MB/s)
    * data verification success
 -> pread(off=1905967320, len=1167245) = 1167245 (0.028 sec, 39.165 MB/s)
    * data verification success
 -> pread(off=38323939, len=145059) = 145059 (0.949 sec, 0.146 MB/s)
    * data verification success
 -> pread(off=621623258, len=2768282) = 2768282 (0.057 sec, 46.497 MB/s)
    * data verification success
 -> pread(off=1854179011, len=24545426) = 24545426 (0.701 sec, 33.383 MB/s)
    * data verification success
 -> pread(off=916283002, len=10380415) = 10380415 (0.393 sec, 25.183 MB/s)
    * data verification success
 -> pread(off=321412244, len=32701354) = 32701354 (6.372 sec, 4.894 MB/s)
    * data verification success
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)
