### PR TITLE
Update CI testing environment directories

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,16 +6,6 @@ stages:
   - test-unit
   - test-integ
 
-# Rules to determine when a pipeline will be generated. If none of these rules
-# match, no pipeline will be generated.
-workflow:
-  rules:
-    - if: '$CI_PIPELINE_SOURCE == "schedule"'
-    - if: '$CI_PIPELINE_SOURCE == "web"'
-    - if: '$CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME == "dev"'
-    - if: '$CI_PIPELINE_SOURCE == "external_pull_request_event" && $CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_NAME == "dev"'
-    - if: '$CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH == "dev"'
-
 ##### System Templates #####
 
 # Generic system templates used to contruct the final jobs on specific
@@ -88,10 +78,6 @@ workflow:
 # full details.
 .integ-test-template:
   stage: test-integ
-  variables:
-    UNIFYFS_INSTALL: "$CI_PROJECT_DIR/unifyfs-install"
-    CI_PROJDIR: "$CI_PROJECT_DIR"
-    CI_NPROCS: "$NPROCS"
   script:
     - cd t/ci && prove -v RUN_CI_TESTS.sh
 

--- a/t/ci/001-setup.sh
+++ b/t/ci/001-setup.sh
@@ -72,7 +72,6 @@ done
 [[ -z $infomsg ]] && infomsg="-- UNIFYFS JOB INFO:"
 [[ -z $errmsg ]] && errmsg="!!!! UNIFYFS JOB ERROR:"
 
-export CI_PROJDIR=${CI_PROJDIR:-$HOME}
 export TMPDIR=${TMPDIR:-/tmp}
 export SYSTEM_NAME=$(echo $(hostname) | sed -r 's/(^[[:alpha:]]*)(.*)/\1/')
 
@@ -83,8 +82,14 @@ export SYSTEM_NAME=$(echo $(hostname) | sed -r 's/(^[[:alpha:]]*)(.*)/\1/')
 echo "$infomsg Setting up sharness"
 CI_DIR=${CI_DIR:-$(dirname "$(readlink -fm $BASH_SOURCE)")}
 SHARNESS_DIR="$(dirname "$CI_DIR")"
+UNIFYFS_SOURCE_DIR="$(dirname "$SHARNESS_DIR")"
+export CI_PROJDIR=${CI_PROJDIR:-"$(dirname "$UNIFYFS_SOURCE_DIR")"}
 echo "$infomsg CI_DIR: $CI_DIR"
 echo "$infomsg SHARNESS_DIR: $SHARNESS_DIR"
+echo "$infomsg UNIFYFS_SOURCE_DIR: $UNIFYFS_SOURCE_DIR"
+echo "$infomsg CI_PROJDIR: $CI_PROJDIR"
+
+SHARNESS_TEST_DIRECTORY=${SHARNESS_TEST_DIRECTORY:-$CI_DIR}
 source ${SHARNESS_DIR}/sharness.sh
 source $SHARNESS_DIR/sharness.d/02-functions.sh
 source $CI_DIR/ci-functions.sh
@@ -196,6 +201,7 @@ export UNIFYFS_DAEMONIZE=${UNIFYFS_DAEMONIZE:-off}
 # temp
 nlt=${TMPDIR}/unifyfs.${USER}.${SYSTEM_NAME}.${JOB_ID}
 export CI_TEMP_DIR=${CI_TEMP_DIR:-$nlt}
+$JOB_RUN_ONCE_PER_NODE mkdir -p $CI_TEMP_DIR
 export UNIFYFS_RUNSTATE_DIR=${UNIFYFS_RUNSTATE_DIR:-$CI_TEMP_DIR}
 export UNIFYFS_META_DB_PATH=${UNIFYFS_META_DB_PATH:-$CI_TEMP_DIR}
 echo "$infomsg UNIFYFS_RUNSTATE_DIR set as $UNIFYFS_RUNSTATE_DIR"

--- a/t/ci/ci-functions.sh
+++ b/t/ci/ci-functions.sh
@@ -439,11 +439,14 @@ cleanup_hosts()
     pdsh -w $l_hl 'test -f /dev/shm/svr_id && /bin/cat /dev/shm/svr_id'
     pdsh -w $l_hl 'test -f /dev/shm/unifyfsd_id && /bin/cat \
                    /dev/shm/unifyfsd_id'
+    pdsh -w $l_hl 'test -f /tmp/unifyfsd.err.* && /bin/cat \
+                   /tmp/unifyfsd.err.*'
     pdsh -w $l_hl '/bin/rm -rfv /tmp/na_sm /tmp/*unifyfs* /var/tmp/*unifyfs* \
                    /dev/shm/unifyfsd_id /dev/shm/svr_id /dev/shm/*na_sm* \
-                   "'${UNIFYFS_SPILLOVER_DATA_DIR}'"/spill*.log \
-                   "'${UNIFYFS_SPILLOVER_META_DIR}'"/spill*.log \
-                   /dev/shm/*-recv-* /dev/shm/*-req-* /dev/shm/*-super-*'
+                   /dev/shm/logio_mem* \
+                   "'${UNIFYFS_LOGIO_SPILL_DIR}'"/spill*.log \
+                   /dev/shm/*-recv-* /dev/shm/*-req-* /dev/shm/*-super-* \
+                   "'$CI_TEMP_DIR'"'
 
     # Reset capturing all output
     exec 1>&3 2>&4


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
This updates several environment variables in the CI environment to fix bugs that showed up when testing on different systems.

.gitlab-ci.yml

- Remove workflow rules for now to get all pipelines to build
- Remove CI related environment variables that are already set up in the Gitlab CI UI

001-setup.sh

- Change the default CI_PROJDIR envar to the directory containing the current source to avoid issues with symlinks.
- Set the SHARNESS_TEST_DIRECTORY to the current CI_DIR to avoid issues with symlinks when sharness.sh is sourced.
- Make sure the temporary directory for UnifyFS files exists on each node

ci-functions.sh

- If unifyfsd.err exists, cat it before removing
- Update which files are cleaned up

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)