### PR TITLE
Add CI job template to clone to alternate location

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,6 +2,7 @@
 # keyword, we prevent the testing stages from blocking, in favor of a
 # DAG.
 stages:
+  - init
   - build
   - test-unit
   - test-integ
@@ -45,6 +46,20 @@ stages:
 
 ##### Job Templates #####
 
+# Only use this template in a pre-build job if needing to clone and
+# run subsequent jobs from a non-default location.
+# The WORKING_DIR envar needs to be defined in the job variables.
+#
+# The before_script section here overrides the default before_script
+# for jobs using this template.
+.init-template:
+  stage: init
+  before_script:
+    - mkdir -pv $WORKING_DIR
+    - cd $WORKING_DIR
+  script:
+    - git clone -b ${CI_COMMIT_BRANCH} --depth=1 ${CI_REPOSITORY_URL} source
+
 # Build script used by each system. The CC and FC variables are set in
 # the specific job scripts and evaluated in the before_script in order
 # to customize which compiler will be used for each job.
@@ -56,7 +71,7 @@ stages:
   script:
     - ./autogen.sh
     - mkdir -p unifyfs-build unifyfs-install && cd unifyfs-build
-    - ../configure CC=$CC_PATH FC=$FC_PATH --prefix=$CI_PROJECT_DIR/unifyfs-install --enable-fortran --disable-silent-rules
+    - ../configure CC=$CC_PATH FC=$FC_PATH --prefix=${WORKING_DIR}/source/unifyfs-install --enable-fortran --disable-silent-rules
     - make V=1
     - make V=1 install
   needs: []
@@ -92,12 +107,17 @@ stages:
 # prior to running when new compilers or architectures need to be
 # tested.
 #
+# For jobs running in the not-default location, change directories
+# to the WORKING_DIR directory. Otherwise, set WORKING_DIR to be the
+# CI_PROJECT_DIR for the build step.
+#
 # The COMPILER, CC_PATH, and FC_PATH variables are evaluated here. Set
 # them in their specific job scripts.
 # SPACK_COMPILER and SPACK_ARCH are then set to load the matching
 # dependencies for the desired compiler.
 before_script:
   - which spack || ((cd $HOME/spack && git describe) && . $HOME/spack/share/spack/setup-env.sh)
+  - [[ -d $WORKING_DIR ]] && cd ${WORKING_DIR}/source || export WORKING_DIR=${CI_PROJECT_DIR}
   - module load $COMPILER
   - CC_PATH=$($CC_COMMAND)
   - FC_PATH=$($FC_COMMAND)

--- a/.gitlab/ascent.yml
+++ b/.gitlab/ascent.yml
@@ -1,8 +1,15 @@
 ##### Ascent Templates #####
 
+# The WORKING_DIR envar is defined to allow the init job to clone the
+# git repo to a different location than the default. Subsequent jobs
+# will then `cd` to this directory during their before_script stage.
+# The WORKING_DIR_BASE envar is definied in the Gitlab UI.
+#
 # The RUN_ASCENT variable can be toggled in the Gitlab interface to
 # toggle whether jobs should be run on this system.
 .ascent-template:
+  variables:
+    WORKING_DIR: ${WORKING_DIR_BASE}/${CI_PIPELINE_ID}
   extends: .base-template
   rules:
     - if: '$RUN_ASCENT != "ON"'
@@ -19,12 +26,16 @@
 
 ##### All Ascent Jobs #####
 
+ascent-gcc-4_8_5-init:
+  extends: [.ascent-shell-template, .init-template]
+
 ascent-gcc-4_8_5-build:
   variables:
     COMPILER: gcc/4.8.5
     CC_COMMAND: "which gcc"
     FC_COMMAND: "which gfortran"
   extends: [.ascent-shell-template, .build-template]
+  needs: ["ascent-gcc-4_8_5-init"]
 
 ascent-gcc-4_8_5-unit-test:
   variables:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

By default, when a Gitlab runner starts, it clones the repo to a default location before any of the job scripts are started. This default location is pre-defined in the `CI_PROJECT_DIR` envar.

This PR sets up an init stage template which can optionally be run before the build stage. This init stage will change to a desired directory and clone the repo again before executing any subsequent stages. The subsequent stages will simply change directories to the new clone during their `before_script` step.

The `WORKING_DIR` envar needs to be defined in the desired jobs in order to create, clone, build, and run any tests from the new location.
This PR sets up the Ascent jobs to use this new template and defines the `WORKING_DIR` envar using the `WORKING_DIR_BASE` envar. This envar is set, and can be changed, from the Gitlab web UI.

For jobs not needing to change locations, if the `WORKING_DIR` envar is not defined, it gets defined as `CI_PROJECT_DIR` during the default `before_script` step of the running job.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
