### PR TITLE
Correct paths for ci builds using default location

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -55,10 +55,10 @@ stages:
 .init-template:
   stage: init
   before_script:
-    - mkdir -pv $WORKING_DIR
+    - mkdir -v $WORKING_DIR
     - cd $WORKING_DIR
   script:
-    - git clone -b ${CI_COMMIT_BRANCH} --depth=1 ${CI_REPOSITORY_URL} source
+    - git clone -b ${CI_COMMIT_BRANCH} --depth=1 ${CI_REPOSITORY_URL} $WORKING_DIR
 
 # Build script used by each system. The CC and FC variables are set in
 # the specific job scripts and evaluated in the before_script in order
@@ -71,7 +71,7 @@ stages:
   script:
     - ./autogen.sh
     - mkdir -p unifyfs-build unifyfs-install && cd unifyfs-build
-    - ../configure CC=$CC_PATH FC=$FC_PATH --prefix=${WORKING_DIR}/source/unifyfs-install --enable-fortran --disable-silent-rules
+    - ../configure CC=$CC_PATH FC=$FC_PATH --prefix=${WORKING_DIR}/unifyfs-install --enable-fortran --disable-silent-rules
     - make V=1
     - make V=1 install
   needs: []
@@ -117,7 +117,7 @@ stages:
 # dependencies for the desired compiler.
 before_script:
   - which spack || ((cd $HOME/spack && git describe) && . $HOME/spack/share/spack/setup-env.sh)
-  - if [[ -d $WORKING_DIR ]]; then cd ${WORKING_DIR}/source; else export WORKING_DIR=${CI_PROJECT_DIR}; fi
+  - if [[ -d $WORKING_DIR ]]; then cd ${WORKING_DIR}; else export WORKING_DIR=${CI_PROJECT_DIR}; fi
   - module load $COMPILER
   - CC_PATH=$($CC_COMMAND)
   - FC_PATH=$($FC_COMMAND)

--- a/.gitlab/ascent.yml
+++ b/.gitlab/ascent.yml
@@ -9,7 +9,7 @@
 # toggle whether jobs should be run on this system.
 .ascent-template:
   variables:
-    WORKING_DIR: ${WORKING_DIR_BASE}/${CI_PIPELINE_ID}
+    WORKING_DIR: ${WORKING_DIR_BASE}/${CI_PIPELINE_ID}/source
   extends: .base-template
   rules:
     - if: '$RUN_ASCENT != "ON"'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Previous commit got tests working on Ascent, but broke the artifact upload paths for jobs using the default `CI_PROJECT_DIR` location. This commit should fix that and allow the CI jobs to work in both cases.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)