### PR TITLE
add option to sync after every write

### DIFF
--- a/common/src/unifyfs_configurator.h
+++ b/common/src/unifyfs_configurator.h
@@ -74,6 +74,7 @@
     UNIFYFS_CFG(client, recv_data_size, INT, UNIFYFS_DATA_RECV_SIZE, "shared memory segment size in bytes for receiving data from server", NULL) \
     UNIFYFS_CFG(client, write_index_size, INT, UNIFYFS_INDEX_BUF_SIZE, "write metadata index buffer size", NULL) \
     UNIFYFS_CFG(client, cwd, STRING, NULLSTRING, "current working directory", NULL) \
+    UNIFYFS_CFG(client, write_sync, BOOL, off, "sync every write to server", NULL) \
     UNIFYFS_CFG_CLI(log, verbosity, INT, 0, "log verbosity level", NULL, 'v', "specify logging verbosity level") \
     UNIFYFS_CFG_CLI(log, file, STRING, unifyfsd.log, "log file name", NULL, 'l', "specify log file name") \
     UNIFYFS_CFG_CLI(log, dir, STRING, LOGDIR, "log file directory", configurator_directory_check, 'L', "specify full path to directory to contain log file") \

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -71,6 +71,7 @@ a given section and key.
    local_extents     BOOL    service reads from local data if possible (default: off)
    recv_data_size    INT     maximum size (B) of memory buffer for receiving data from server
    write_index_size  INT     maximum size (B) of memory buffer for storing write log metadata
+   write_sync        BOOL    sync data to server after every write (default: off)
    ================  ======  =================================================================
 
 The ``cwd`` setting is used to emulate the behavior one


### PR DESCRIPTION
This adds an option to sync after every (successful) write operation.  This will slow down performance, but it could be a work around for codes that are missing the necessary sync calls.

This includes a runtime option to enable the auto-sync-after-write ``UNIFYFS_CLIENT_WRITE_SYNC=1``.

It should help with https://github.com/LLNL/UnifyFS/issues/560