### PR TITLE
Update Travis CI to use Mercury v1.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ install:
   - . $HOME/spack/share/spack/setup-env.sh
   - spack install leveldb && spack load leveldb
   - spack install gotcha@1.0.3 && spack load gotcha@1.0.3
-  - spack install margo^mercury+bmi~ofi~boostsys && spack load argobots && spack load mercury && spack load margo
+  - spack install margo^mercury@1.0.1+bmi~ofi~boostsys && spack load argobots && spack load mercury && spack load margo
   - spack install spath && spack load spath
   # prepare build environment
   - eval $(./scripts/git_log_test_env.sh)


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Travis is currently set up to use the default version of several of our dependencies. The default version for Mercury has changed to v2.0.0.

We are able to build with this version, but there appears to be an issue when starting the UnifyFS server.

This changes our Travis CI to use the previous default version of Mercury, v1.0.1.

### Motivation and Context
Workaround for issue #573 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

Build and run tests through Travis CI