### PR TITLE
add output file CLI option to testutil

### DIFF
--- a/examples/src/testutil.c
+++ b/examples/src/testutil.c
@@ -280,6 +280,7 @@ int stat_cmd(test_cfg* cfg, char* filename)
     int rc;
     const char* typestr;
     char* tmp;
+    char* newline;
     char datestr[32];
 
     rc = stat(filename, &sb);
@@ -357,15 +358,27 @@ int stat_cmd(test_cfg* cfg, char* filename)
     memset(datestr, 0, sizeof(datestr));
     timestamp = sb.st_atime;
     ctime_r(&timestamp, datestr);
+    newline = strchr(datestr, '\n');
+    if (NULL != newline) {
+        *newline = '\0';
+    }
     test_print(cfg, "Last file access:         %s", datestr);
 
     memset(datestr, 0, sizeof(datestr));
     timestamp = sb.st_mtime;
     ctime_r(&timestamp, datestr);
+    newline = strchr(datestr, '\n');
+    if (NULL != newline) {
+        *newline = '\0';
+    }
     test_print(cfg, "Last file modification:   %s", datestr);
 
     memset(datestr, 0, sizeof(datestr));
     timestamp = sb.st_ctime;
     ctime_r(&timestamp, datestr);
+    newline = strchr(datestr, '\n');
+    if (NULL != newline) {
+        *newline = '\0';
+    }
     test_print(cfg, "Last status change:       %s", datestr);
 }

--- a/examples/src/writeread.c
+++ b/examples/src/writeread.c
@@ -387,41 +387,41 @@ int main(int argc, char* argv[])
     double global_read_bw = bandwidth_mib(total_bytes, max_global_read_time);
 
     if (test_config.rank == 0) {
-        printf("File Create Time is %.6lf s\n",
-               time_create.elapsed_sec_all);
-        printf("Minimum Local Write BW is %.3lf MiB/s\n",
-               min_local_write_bw);
-        printf("Maximum Local Write BW is %.3lf MiB/s\n",
-               max_local_write_bw);
-        printf("Aggregate Local Write BW is %.3lf MiB/s\n",
-               aggr_local_write_bw);
-        printf("Global Write BW is %.3lf MiB/s\n",
-               global_write_bw);
-        printf("Minimum Local Sync Time is %.6lf s\n",
-               min_local_sync_time);
-        printf("Maximum Local Sync Time is %.6lf s\n",
-               max_local_sync_time);
-        printf("Global Sync Time is %.6lf s\n",
-               max_global_sync_time);
-        printf("Global Write+Sync BW is %.3lf MiB/s\n",
-               global_write_sync_bw);
-        printf("Stat Time Pre-Laminate is %.6lf s\n",
-               time_stat_pre.elapsed_sec_all);
-        printf("Stat Time Pre-Laminate2 is %.6lf s\n",
-               time_stat_pre.elapsed_sec_all);
-        printf("File Laminate Time is %.6lf s\n",
-               time_laminate.elapsed_sec_all);
-        printf("Stat Time Post-Laminate is %.6lf s\n",
-               time_stat_post.elapsed_sec_all);
-        printf("Minimum Local Read BW is %.3lf MiB/s\n",
-               min_local_read_bw);
-        printf("Maximum Local Read BW is %.3lf MiB/s\n",
-               max_local_read_bw);
-        printf("Aggregate Local Read BW is %.3lf MiB/s\n",
-               aggr_local_read_bw);
-        printf("Global Read BW is %.3lf MiB/s\n",
-               global_read_bw);
-        fflush(stdout);
+        errno = 0; /* just in case there was an earlier error */
+        test_print_once(cfg, "File Create Time is %.6lf s",
+                        time_create.elapsed_sec_all);
+        test_print_once(cfg, "Minimum Local Write BW is %.3lf MiB/s",
+                        min_local_write_bw);
+        test_print_once(cfg, "Maximum Local Write BW is %.3lf MiB/s",
+                        max_local_write_bw);
+        test_print_once(cfg, "Aggregate Local Write BW is %.3lf MiB/s",
+                        aggr_local_write_bw);
+        test_print_once(cfg, "Global Write BW is %.3lf MiB/s",
+                        global_write_bw);
+        test_print_once(cfg, "Minimum Local Sync Time is %.6lf s",
+                        min_local_sync_time);
+        test_print_once(cfg, "Maximum Local Sync Time is %.6lf s",
+                        max_local_sync_time);
+        test_print_once(cfg, "Global Sync Time is %.6lf s",
+                        max_global_sync_time);
+        test_print_once(cfg, "Global Write+Sync BW is %.3lf MiB/s",
+                        global_write_sync_bw);
+        test_print_once(cfg, "Stat Time Pre-Laminate is %.6lf s",
+                        time_stat_pre.elapsed_sec_all);
+        test_print_once(cfg, "Stat Time Pre-Laminate2 is %.6lf s",
+                        time_stat_pre.elapsed_sec_all);
+        test_print_once(cfg, "File Laminate Time is %.6lf s",
+                        time_laminate.elapsed_sec_all);
+        test_print_once(cfg, "Stat Time Post-Laminate is %.6lf s",
+                        time_stat_post.elapsed_sec_all);
+        test_print_once(cfg, "Minimum Local Read BW is %.3lf MiB/s",
+                        min_local_read_bw);
+        test_print_once(cfg, "Maximum Local Read BW is %.3lf MiB/s",
+                        max_local_read_bw);
+        test_print_once(cfg, "Aggregate Local Read BW is %.3lf MiB/s",
+                        aggr_local_read_bw);
+        test_print_once(cfg, "Global Read BW is %.3lf MiB/s",
+                        global_read_bw);
     }
 
     // cleanup


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

### Description

When provided via `-o|--outfile <file>`, rank 0 will open the
named output file and that rank's calls to test_print() and
test_print_once() will write to the output file. All other
ranks will still write to stdout, which is the default when
the option is not provided.

Also updates the writeread example to use test_print_once()
to print results to the output file. Similar changes will
be necessary for the other examples.

### Motivation and Context

This support will be used to further improve the use of examples in CI testing.

### How Has This Been Tested?

Tested with writeread example on Summit, up to 32 nodes.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
