### PR TITLE
fix stat_cmd() output when errno != 0 from prior call

### DIFF
--- a/examples/src/testutil.c
+++ b/examples/src/testutil.c
@@ -283,9 +283,10 @@ int stat_cmd(test_cfg* cfg, char* filename)
     char* newline;
     char datestr[32];
 
+    errno = 0;
     rc = stat(filename, &sb);
     if (rc) {
-        test_print(cfg, "ERROR: stat(%s) - %s", filename, strerror(rc));
+        test_print(cfg, "ERROR: stat(%s) failed", filename);
         return rc;
     }
 


### PR DESCRIPTION
### Description

When testing MPI-IO on Summit, the writeread example was printing `stat_cmd()` output with non-zero errno even though the call to `stat()` succeeded. Fixed by setting errno to zero prior to calling `stat()`.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
