### PR TITLE
fix: race condition on file create

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -410,7 +410,7 @@ To run any of these examples manually, refer to the :doc:`examples`
 documentation.
 
 The UnifyFS examples_ are also being used as integration tests with
-continuation integration tools such as Bamboo_ or GitLab_.
+continuous integration tools such as Bamboo_ or GitLab_.
 
 ------------
 
@@ -601,11 +601,11 @@ Misc
 """"
 
 ``KB``
-    :math:`2^10`.
+    :math:`2^{10}`.
 ``MB``
-    :math:`2^20`.
+    :math:`2^{20}`.
 ``GB``
-    :math:`2^30`.
+    :math:`2^{30}`.
 
 ------------
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
When more than one process tries to create a given file at the same time with ``open(O_CREAT)``, we were returning ``EEXIST`` on procs that lost the race.  Those procs should still open the file unless ``O_EXCL`` is also specified.

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
