### PR TITLE
fixing open example (sysio-open) to separate the create and open rank.

### DIFF
--- a/examples/src/sysio-open.c
+++ b/examples/src/sysio-open.c
@@ -165,7 +165,8 @@ int main(int argc, char** argv)
 
     MPI_Barrier(MPI_COMM_WORLD);
 
-    if (rank == open_rank) {
+    /* create the file from the create_rank */
+    if (rank == create_rank) {
         fd = open(targetfile, O_CREAT|O_RDWR|O_TRUNC, 0600);
         if (fd < 0) {
             test_print(rank, "open failed (%d: %s)\n",
@@ -180,7 +181,8 @@ int main(int argc, char** argv)
 
     MPI_Barrier(MPI_COMM_WORLD);
 
-    if (rank == open_rank) {
+    /* open from all ranks (open_rank == 0) or a specific open_rank */
+    if (!open_rank || rank == open_rank) {
         fd = open(targetfile, O_RDWR);
         if (fd < 0) {
             test_print(rank, "open failed (%d: %s)\n",


### PR DESCRIPTION
This is a fix of the sysio-open example, specifically to test a case of creating a file from a rank and opening the file from other ranks.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)
