### PR TITLE
add script to download and build autotools

### DIFF
--- a/autotools/buildme
+++ b/autotools/buildme
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+set -x
+
+#mkdir -p autotools
+#cd autotools
+
+installdir=`pwd`/install
+
+# add autotools install bin to our path
+export PATH=${installdir}/bin:$PATH
+
+# build autoconf
+if [ ! -f autoconf-2.69.tar.gz ] ; then
+  wget http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz
+fi
+rm -rf autoconf-2.69
+tar -zxf autoconf-2.69.tar.gz
+pushd autoconf-2.69
+  ./configure --prefix=$installdir
+  make
+  make install
+popd
+
+# build automake
+if [ ! -f automake-1.15.tar.gz ] ; then
+  wget http://ftp.gnu.org/gnu/automake/automake-1.15.tar.gz
+fi
+rm -rf automake-1.15
+tar -zxf automake-1.15.tar.gz
+pushd automake-1.15
+  ./configure --prefix=$installdir
+  make
+  make install
+popd
+
+# build libtool
+if [ ! -f libtool-2.4.6.tar.gz ] ; then
+  wget http://mirror.team-cymru.org/gnu/libtool/libtool-2.4.6.tar.gz
+fi
+rm -rf libtool-2.4.6
+tar -zxf libtool-2.4.6.tar.gz
+pushd libtool-2.4.6
+  ./configure --prefix=$installdir
+  make
+  make install
+popd
+
+# build libtool
+if [ ! -f pkg-config-0.29.2.tar.gz ] ; then
+  wget https://pkg-config.freedesktop.org/releases/pkg-config-0.29.2.tar.gz
+fi
+rm -rf pkg-config-0.29.2
+tar -zxf pkg-config-0.29.2.tar.gz
+pushd pkg-config-0.29.2
+  ./configure --prefix=$installdir
+  make
+  make install
+popd


### PR DESCRIPTION
@CamStan , this helps with builds of @MichaelBrim 's readrpc branch on LLNL systems.  I recycled this "buildme" script from another project.  It pulls versions of autotools that are dated, but newer than what we have on the system.

First, run the autotools buildme script:
```
cd autotools
./buildme
```

Then, modify your PATH (to point to your autotools install) and PKG_CONFIG_PATH (to point to system pkg-config directories) before building UnifyFS:
```
export PATH=`pwd`/autotools/install/bin:$PATH
export PKG_CONFIG_PATH=/usr/share/pkgconfig:/usr/lib64/pkgconfig:$PKG_CONFIG_PATH
./autogen.sh
...
```

It still prints warnings and feels hacky with PKG_CONFIG.  It needs work, but it lets me build.