### PR TITLE
filesize rpc only for regular files

### DIFF
--- a/client/src/unifyfs-sysio.c
+++ b/client/src/unifyfs-sysio.c
@@ -655,8 +655,8 @@ static int unifyfs_get_meta_with_size(int gfid, unifyfs_file_attr_t* pfattr)
 
     /* if file is laminated, we assume the file size in the meta
      * data is already accurate, if not, look up the current file
-     * size with an rpc */
-    if (!pfattr->is_laminated) {
+     * size with an rpc. we only track size for regular files. */
+    if (S_ISREG(pfattr->mode) && !pfattr->is_laminated) {
         /* lookup current global file size */
         size_t filesize;
         ret = invoke_client_filesize_rpc(gfid, &filesize);


### PR DESCRIPTION
Currently, invoking `stat(2)` leads unifyfs to trigger the filesize rpc even for non regular files, e.g., directories. This PR makes unifyfs to execute the filesize rpc only for (unlaminated) regular files.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)
