### PR TITLE
avoid truncate on creating a new file

### DIFF
--- a/client/src/unifyfs-sysio.c
+++ b/client/src/unifyfs-sysio.c
@@ -548,6 +548,9 @@ int UNIFYFS_WRAP(truncate)(const char* path, off_t length)
             }
         } else {
             /* invoke truncate rpc */
+            /* TODO: here, we don't correctly set EISDIR for directories.
+             * we could fetch file attribute w/ metaget and check for such
+             * invalid requests to avoid extra rpcs. */
             int gfid = unifyfs_generate_gfid(upath);
             int rc = invoke_client_truncate_rpc(gfid, length);
             if (rc != UNIFYFS_SUCCESS) {

--- a/examples/src/sysio-stat.c
+++ b/examples/src/sysio-stat.c
@@ -44,72 +44,6 @@ static char* filename = "/unifyfs";
 static int unmount;        /* unmount unifyfs after running the test */
 static int testrank = -1;  /* if negative, execute from all ranks */
 
-#define FP_SPECIAL 1
-
-static void dump_stat(int rank, const struct stat* sb)
-{
-    printf("## [RANK %d] %s\n", rank, filename);
-    printf("File type:                ");
-
-    switch (sb->st_mode & S_IFMT) {
-    case S_IFREG:
-        printf("regular file\n");
-        break;
-    case S_IFDIR:
-        printf("directory\n");
-        break;
-    case S_IFCHR:
-        printf("character device\n");
-        break;
-    case S_IFBLK:
-        printf("block device\n");
-        break;
-    case S_IFLNK:
-        printf("symbolic (soft) link\n");
-        break;
-    case S_IFIFO:
-        printf("FIFO or pipe\n");
-        break;
-    case S_IFSOCK:
-        printf("socket\n");
-        break;
-    default:
-        printf("unknown file type?\n");
-        break;
-    }
-
-    printf("Device containing i-node: major=%ld   minor=%ld\n",
-           (long) major(sb->st_dev), (long) minor(sb->st_dev));
-
-    printf("I-node number:            %ld\n", (long) sb->st_ino);
-
-    printf("Mode:                     %lo\n",
-           (unsigned long) sb->st_mode);
-
-    if (sb->st_mode & (S_ISUID | S_ISGID | S_ISVTX))
-        printf("    special bits set:     %s%s%s\n",
-               (sb->st_mode & S_ISUID) ? "set-UID " : "",
-               (sb->st_mode & S_ISGID) ? "set-GID " : "",
-               (sb->st_mode & S_ISVTX) ? "sticky " : "");
-
-    printf("Number of (hard) links:   %ld\n", (long) sb->st_nlink);
-
-    printf("Ownership:                UID=%ld   GID=%ld\n",
-           (long) sb->st_uid, (long) sb->st_gid);
-
-    if (S_ISCHR(sb->st_mode) || S_ISBLK(sb->st_mode))
-        printf("Device number (st_rdev):  major=%ld; minor=%ld\n",
-               (long) major(sb->st_rdev), (long) minor(sb->st_rdev));
-
-    printf("File size:                %lld bytes\n", (long long) sb->st_size);
-    printf("Optimal I/O block size:   %ld bytes\n", (long) sb->st_blksize);
-    printf("512B blocks allocated:    %lld\n", (long long) sb->st_blocks);
-
-    printf("Last file access:         %s", ctime(&sb->st_atime));
-    printf("Last file modification:   %s", ctime(&sb->st_mtime));
-    printf("Last status change:       %s\n\n", ctime(&sb->st_ctime));
-}
-
 static void do_stat(int rank)
 {
     int ret = 0;
@@ -120,7 +54,7 @@ static void do_stat(int rank)
         test_print(rank, "stat failed on \"%s\" (%d:%s)",
                    filename, errno, strerror(errno));
     } else {
-        dump_stat(rank, &sb);
+        dump_stat(rank, &sb, filename);
     }
 }
 

--- a/examples/src/sysio-truncate.c
+++ b/examples/src/sysio-truncate.c
@@ -45,74 +45,6 @@ static int unmount;                /* unmount unifyfs after running the test */
 static int testrank;
 static off_t targetlen;
 
-#define FP_SPECIAL 1
-
-static void dump_stat(int rank, const struct stat* sb)
-{
-    printf("## [RANK %d] %s\n", rank, filename);
-    printf("File type:                ");
-
-    switch (sb->st_mode & S_IFMT) {
-    case S_IFREG:
-        printf("regular file\n");
-        break;
-    case S_IFDIR:
-        printf("directory\n");
-        break;
-    case S_IFCHR:
-        printf("character device\n");
-        break;
-    case S_IFBLK:
-        printf("block device\n");
-        break;
-    case S_IFLNK:
-        printf("symbolic (soft) link\n");
-        break;
-    case S_IFIFO:
-        printf("FIFO or pipe\n");
-        break;
-    case S_IFSOCK:
-        printf("socket\n");
-        break;
-    default:
-        printf("unknown file type?\n");
-        break;
-    }
-
-    printf("Device containing i-node: major=%ld   minor=%ld\n",
-           (long) major(sb->st_dev), (long) minor(sb->st_dev));
-
-    printf("I-node number:            %ld\n", (long) sb->st_ino);
-
-    printf("Mode:                     %lo\n",
-           (unsigned long) sb->st_mode);
-
-    if (sb->st_mode & (S_ISUID | S_ISGID | S_ISVTX)) {
-        printf("    special bits set:     %s%s%s\n",
-               (sb->st_mode & S_ISUID) ? "set-UID " : "",
-               (sb->st_mode & S_ISGID) ? "set-GID " : "",
-               (sb->st_mode & S_ISVTX) ? "sticky " : "");
-    }
-
-    printf("Number of (hard) links:   %ld\n", (long) sb->st_nlink);
-
-    printf("Ownership:                UID=%ld   GID=%ld\n",
-           (long) sb->st_uid, (long) sb->st_gid);
-
-    if (S_ISCHR(sb->st_mode) || S_ISBLK(sb->st_mode)) {
-        printf("Device number (st_rdev):  major=%ld; minor=%ld\n",
-               (long) major(sb->st_rdev), (long) minor(sb->st_rdev));
-    }
-
-    printf("File size:                %lld bytes\n", (long long) sb->st_size);
-    printf("Optimal I/O block size:   %ld bytes\n", (long) sb->st_blksize);
-    printf("512B blocks allocated:    %lld\n", (long long) sb->st_blocks);
-
-    printf("Last file access:         %s", ctime(&sb->st_atime));
-    printf("Last file modification:   %s", ctime(&sb->st_mtime));
-    printf("Last status change:       %s\n\n", ctime(&sb->st_ctime));
-}
-
 static struct option long_opts[] = {
     { "debug", 0, 0, 'd' },
     { "help", 0, 0, 'h' },
@@ -222,7 +154,7 @@ int main(int argc, char** argv)
         } else {
             test_print(rank, "## stat before truncate to %llu\n",
                        (unsigned long long) targetlen);
-            dump_stat(rank, &sb);
+            dump_stat(rank, &sb, filename);
         }
 
         ret = truncate(filename, targetlen);
@@ -238,7 +170,7 @@ int main(int argc, char** argv)
         } else {
             test_print(rank, "## stat after truncate to %llu\n",
                        (unsigned long long) targetlen);
-            dump_stat(rank, &sb);
+            dump_stat(rank, &sb, filename);
         }
     }
 

--- a/examples/src/sysio-write.c
+++ b/examples/src/sysio-write.c
@@ -58,7 +58,6 @@ static int rank;
 static int total_ranks;
 
 static int debug;           /* pause for attaching debugger */
-static int unmount;         /* unmount unifyfs after running the test */
 static char* buf;           /* I/O buffer */
 static char* mountpoint = "/unifyfs";   /* unifyfs mountpoint */
 static char* filename = "testfile"; /* testfile name under mountpoint */
@@ -172,11 +171,10 @@ static struct option const long_opts[] = {
     { "pwrite", 0, 0, 'P' },
     { "synchronous", 0, 0, 'S' },
     { "standard", 0, 0, 's' },
-    { "unmount", 0, 0, 'u' },
     { 0, 0, 0, 0},
 };
 
-static char* short_opts = "b:n:c:df:hlm:p:PSsu";
+static char* short_opts = "b:n:c:df:hlm:p:PSs";
 
 static const char* usage_str =
     "\n"
@@ -202,7 +200,6 @@ static const char* usage_str =
     "                                  (default: n1)\n"
     " -S, --synchronous                sync metadata on each write\n"
     " -s, --standard                   do not use unifyfs but run standard I/O\n"
-    " -u, --unmount                    unmount the filesystem after test\n"
     "\n";
 
 static char* program;
@@ -270,10 +267,6 @@ int main(int argc, char** argv)
 
         case 's':
             standard = 1;
-            break;
-
-        case 'u':
-            unmount = 1;
             break;
 
         case 'h':
@@ -387,7 +380,7 @@ int main(int argc, char** argv)
         }
     }
 
-    if (!standard && unmount) {
+    if (!standard) {
         unifyfs_unmount();
     }
 

--- a/examples/src/testlib.h
+++ b/examples/src/testlib.h
@@ -25,6 +25,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <time.h>
 #include <mpi.h>
 
 extern int errno;
@@ -182,5 +183,73 @@ int lipsum_check(const char* buf, uint64_t len, uint64_t offset,
 
     return 0;
 }
+
+static inline
+void dump_stat(int rank, const struct stat* sb, const char* filename)
+{
+    printf("## [RANK %d] %s\n", rank, filename);
+    printf("File type:                ");
+
+    switch (sb->st_mode & S_IFMT) {
+    case S_IFREG:
+        printf("regular file\n");
+        break;
+    case S_IFDIR:
+        printf("directory\n");
+        break;
+    case S_IFCHR:
+        printf("character device\n");
+        break;
+    case S_IFBLK:
+        printf("block device\n");
+        break;
+    case S_IFLNK:
+        printf("symbolic (soft) link\n");
+        break;
+    case S_IFIFO:
+        printf("FIFO or pipe\n");
+        break;
+    case S_IFSOCK:
+        printf("socket\n");
+        break;
+    default:
+        printf("unknown file type?\n");
+        break;
+    }
+
+    printf("Device containing i-node: major=%ld   minor=%ld\n",
+           (long) major(sb->st_dev), (long) minor(sb->st_dev));
+
+    printf("I-node number:            %ld\n", (long) sb->st_ino);
+
+    printf("Mode:                     %lo\n",
+           (unsigned long) sb->st_mode);
+
+    if (sb->st_mode & (S_ISUID | S_ISGID | S_ISVTX)) {
+        printf("    special bits set:     %s%s%s\n",
+               (sb->st_mode & S_ISUID) ? "set-UID " : "",
+               (sb->st_mode & S_ISGID) ? "set-GID " : "",
+               (sb->st_mode & S_ISVTX) ? "sticky " : "");
+    }
+
+    printf("Number of (hard) links:   %ld\n", (long) sb->st_nlink);
+
+    printf("Ownership:                UID=%ld   GID=%ld\n",
+           (long) sb->st_uid, (long) sb->st_gid);
+
+    if (S_ISCHR(sb->st_mode) || S_ISBLK(sb->st_mode)) {
+        printf("Device number (st_rdev):  major=%ld; minor=%ld\n",
+               (long) major(sb->st_rdev), (long) minor(sb->st_rdev));
+    }
+
+    printf("File size:                %lld bytes\n", (long long) sb->st_size);
+    printf("Optimal I/O block size:   %ld bytes\n", (long) sb->st_blksize);
+    printf("512B blocks allocated:    %lld\n", (long long) sb->st_blocks);
+
+    printf("Last file access:         %s", ctime(&sb->st_atime));
+    printf("Last file modification:   %s", ctime(&sb->st_mtime));
+    printf("Last status change:       %s\n\n", ctime(&sb->st_ctime));
+}
+
 
 #endif /* __TESTLIB_H */


### PR DESCRIPTION
- avoid triggering truncate on creation of a new file in `open(2)`
- setting `EISDIR` for `truncate(2)` on a directory (when locally detected)

### Description
<!--- Describe your changes in detail -->
This patch fixes `unifyfs_fid_open` not to trigger the truncate operation after successfully creating a new file.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

