### PR TITLE
Extend CI testing suite to include producer-consumer, MPI-IO, and shuffle tests

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -3,8 +3,9 @@ Examples
 ********
 
 There are several examples_ available on ways to use UnifyFS. These examples
-build into static and GOTCHA versions (pure POSIX versions coming soon) and are
-also used as a form of :doc:`intregraton testing <testing>`.
+build into static, GOTCHA, and pure POSIX (not linked with UnifyFS) versions
+depending on how they are linked. Several of the example programs are also used
+in the UnifyFS :doc:`intregraton testing <testing>`.
 
 Examples Locations
 ==================
@@ -144,7 +145,50 @@ One form of running this example could be:
 
 .. code-block:: Bash
 
-    $ srun -N4 -n4 write-static -m /myMountPoint -f myTestFile
+    $ srun -N4 -n4 write-static -m /unifyfs -f myTestFile
+
+Producer-Consumer Workflow
+==========================
+
+UnifyFS can be used to support producer/consumer workflows where processes in a
+job perform loosely synchronized communication through files such as in coupled
+simulation/analytics workflows.
+
+The *write.c* and *read.c* example programs can be used as a basic test in
+running a producer-consumer workflow with UnifyFS.
+
+.. code-block:: Bash
+    :caption: All hosts in allocation
+
+    $ # start unifyfs
+    $
+    $ # write on all hosts
+    $ srun -N4 -n16 write-gotcha -f testfile
+    $
+    $ # read on all hosts
+    $ srun -N4 -n16 read-gotcha -f testfile
+    $
+    $ # stop unifyfs
+
+.. code-block:: Bash
+    :caption: Disjoint hosts in allocation
+
+    $ # start unifyfs
+    $
+    $ # write on half of hosts
+    $ srun -N2 -n8 --exclude=$hostlist_subset1 write-gotcha -f testfile
+    $
+    $ # read on other half of hosts
+    $ srun -N2 -n8 --exclude=$hostlist_subset2 read-gotcha -f testfile
+    $
+    $ # stop unifyfs
+
+.. note::
+    Producer/consumer support with UnifyFS has been tested using POSIX and
+    MPI-IO APIs on x86_64 (MVAPICH) and Power 9 systems (Spectrum MPI).
+
+    These scenarios have been tested using both the same and disjoint sets of
+    hosts as well as using a shared file and a file per process for I/O.
 
 .. explicit external hyperlink targets
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -519,13 +519,12 @@ USAGE: ``UNIFYFS_CI_TEST_POSIX=yes|YES|no|NO``
 Determines whether any ``<example-name>-posix`` tests should be run since they
 require a real mountpoint to exist.
 
-This envar defaults to ``yes``. However, when ``$UNIFYFS_MOUNTPOINT`` is set to a
-real directory, this envar is switched to ``no``. The idea behind this is that
-the tests can be run a first time with a fake mountpoint (which will also run
-the posix tests), and then the tests can be run again with a real mountpoint and
-the posix tests won't be run twice. This behavior can be overridden by setting
-``UNIFYFS_CI_TEST_POSIX=yes|YES`` before running the integration tests when
-``$UNIFYFS_MOUNTPOINT`` is set to an existing directory.
+This envar defaults to ``no``. Setting this to ``yes`` will run the posix
+version of tests along with the regular tests. When ``$UNIFYFS_MOUNTPOINT`` is
+set to a existing directory, this option is set to ``no``. This is to allow
+running the tests a first time with a fake mountpoint while the posix tests use
+an existing mountpoint. Then the regular tests can be run again using an
+existing mountpoint and the posix tests won't be run twice.
 
 An example of testing a posix example can be see :ref:`below <posix-ex-label>`.
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -688,15 +688,32 @@ last to stop the server and clean up.
     $ . $UNIFYFS_CI_DIR/100-writeread-tests.sh
     $ . $UNIFYFS_CI_DIR/990-stop-server.sh
 
+The various CI test suites can be run multiple times with different behaviors.
+These behaviors are continually being extended. The `-h|--help` option for each
+script can show what alternate behaviors are currently implemented along with
+additional information for that particular suite.
+
+.. code-block:: BASH
+
+    [prompt]$ ./100-writeread-tests.sh --help
+    Usage: 100-writeread-tests.sh [options...]
+
+      options:
+        -h, --help        print help message
+        -M, --mpiio       use MPI-IO instead of POSIX I/O
+        -x, --shuffle     read different data than written
+
 ------------
 
 Adding New Tests
 ****************
 
-In order to add additional tests, create a script after the fashion of
-`t/ci/100-writeread-tests.sh`_ where the prefixed number indicates the desired
-order for running the tests. Then source that script in `t/ci/RUN_CI_TESTS.sh`_
-in the desired order.
+In order to add additional tests for different workflows, create a script after
+the fashion of `t/ci/100-writeread-tests.sh`_ where the prefixed number
+indicates the desired order for running the tests. Then source that script in
+`t/ci/RUN_CI_TESTS.sh`_ in the desired order. The different test suite scripts
+themselves can also be edited to add/change the number, types, and various
+behaviors each suite will execute.
 
 Just like the helpers functions found in sharness.d_, there are continuous
 integration helper functions (see :ref:`below <helper-label>` for more details)

--- a/t/ci/001-setup.sh
+++ b/t/ci/001-setup.sh
@@ -234,7 +234,7 @@ if [[ -d $UNIFYFS_MP ]]; then
 fi
 echo "$infomsg UNIFYFS_MOUNTPOINT established: $UNIFYFS_MP"
 
-export UNIFYFS_CI_TEST_POSIX=${UNIFYFS_CI_TEST_POSIX:-yes}
+export UNIFYFS_CI_TEST_POSIX=${UNIFYFS_CI_TEST_POSIX:-no}
 # Set up a real mountpoint for posix tests to write files to and allow tests to
 # check that those files exist
 if [[ ! $UNIFYFS_CI_TEST_POSIX =~ ^(no|NO)$ ]]; then

--- a/t/ci/110-write-tests.sh
+++ b/t/ci/110-write-tests.sh
@@ -33,7 +33,6 @@
 #     '
 #
 # For these tests, always include -b -c -n and -p in the app_args
-# Then for the necessary tests, include -M -P -S -V or -x.
 
 
 test_description="Write Tests"
@@ -42,21 +41,22 @@ while [[ $# -gt 0 ]]
 do
     case $1 in
         -h|--help)
+            echo "usage ./110-write-tests.sh -h|--help"
             ci_dir=$(dirname "$(readlink -fm $BASH_SOURCE)")
             $ci_dir/001-setup.sh -h
             exit
             ;;
         *)
-            echo "usage ./200-write-tests.sh -h|--help"
+            echo "usage ./110-write-tests.sh -h|--help"
             exit 1
             ;;
     esac
 done
 
-# These two functions are simply to prevent code duplication since testing the
-# output of each example with sharness is the same process. These do not need to
-# be used, especially if wanting to test for something specific when running an
-# example.
+# Call unify_run_test with the app name, mode, and arguments in order to
+# automatically generate the MPI launch command to run the application and put
+# the result in $app_output.
+# Then evaluate the return code and output.
 unify_test_write() {
     app_name=write-${1}
 
@@ -65,182 +65,58 @@ unify_test_write() {
     rc=$?
     lcount=$(echo "$app_output" | wc -l)
 
-    # Evaluate output
-    test_expect_success "$app_name $app_args: (line_count=${lcount}, rc=$rc)" '
-        test $rc = 0 &&
-        test $lcount = 18
-    '
-}
+    # Test the return code and resulting line count to determine pass/fail.
+    # If mode is posix, also test that the file or files exist at the mountpoint
+    # depending on whether testing shared file or file-per-process.
+    if [ "$1" = "posix" ]; then
+        filename=$(get_filename $app_name "$2" ".app")
 
-unify_test_write_posix() {
-    app_name=write-posix
-
-    # Run the test and get output
-    if test_have_prereq POSIX; then
-        unify_run_test $app_name "$1" app_output
-        rc=$?
-        lcount=$(echo "$app_output" | wc -l)
-        filename=$(get_filename $app_name "$1" ".app")
+        test_expect_success "$app_name $2: (line_count=${lcount}, rc=$rc)" '
+            test $rc = 0 &&
+            test $lcount = 18 &&
+            if [[ $io_pattern =~ (n1)$ ]]; then
+                test_path_is_file ${UNIFYFS_CI_POSIX_MP}/$filename
+            else
+                test_path_has_file_per_process $UNIFYFS_CI_POSIX_MP $filename
+            fi
+        '
+    else
+        test_expect_success "$app_name $2: (line_count=${lcount}, rc=$rc)" '
+            test $rc = 0 &&
+            test $lcount = 18
+        '
     fi
-
-    # Evaluate output
-    test_expect_success POSIX "$app_name $1: (line_count=${lcount}, rc=$rc)" '
-        test $rc = 0 &&
-        test $lcount = 18 &&
-        if [[ $io_pattern =~ (n1)$ ]]; then
-            test_path_is_file ${UNIFYFS_CI_POSIX_MP}/$filename
-        else
-            test_path_has_file_per_process $UNIFYFS_CI_POSIX_MP $filename
-        fi
-    '
 }
 
-# write-static -p n1 -n 2 -c 4KB -b 16KB
-runmode=static
-io_pattern="-p n1"
-io_sizes="-n 2 -c $((4 * $KB)) -b $((16 * $KB))"
-app_args="$io_pattern $io_sizes"
-unify_test_write $runmode "$app_args"
+### Run the write tests ###
 
-# write-gotcha -p n1 -n 2 -c 4KB -b 16KB
-runmode=gotcha
-unify_test_write $runmode "$app_args"
+# Array to determine the different file sizes that are created and tested. Each
+# item contains the number of blocks, chunk size, and block size to use when
+# writing or reading the file.
+io_sizes=("-n 32 -c $((64 * $KB)) -b $MB"
+          "-n 64 -c $MB -b $((4 *  $MB))"
+          "-n 32 -c $((4 * $MB)) -b $((16 * $MB))"
+)
 
-# write-posix -p n1 -n 2 -c 4KB -b 16KB
-runmode=posix
-unify_test_write_posix "$app_args"
+# I/O patterns to test with.
+# Includes shared file (-p n1) and file-per-process (-p nn)
+io_patterns=("-p n1" "-p nn")
 
-# Switch to -p nn
-io_pattern="-p nn"
-app_args="$io_pattern $io_sizes"
+# Mode of each test, whether static, gotcha, or posix (if desired)
+modes=(static gotcha)
 
-# write-posix -p nn -n 2 -c 4KB -b 16KB
-unify_test_write_posix "$app_args"
+# To run posix tests, set UNIFYFS_CI_TEST_POSIX=yes
+if test_have_prereq POSIX; then
+    modes+=(posix)
+fi
 
-# write-gotcha -p nn -n 2 -c 4KB -b 16KB
-runmode=gotcha
-unify_test_write $runmode "$app_args"
-
-# write-static -p nn -n 2 -c 4KB -b 16KB
-runmode=static
-unify_test_write $runmode "$app_args"
-
-# Increase sizes: -n 16 -c 32KB -b 1MB
-
-# write-static -p nn -n 16 -c 32KB -b 1MB
-io_sizes="-n 16 -c $((32 * $KB)) -b $MB"
-app_args="$io_pattern $io_sizes"
-unify_test_write $runmode "$app_args"
-
-# write-gotcha -p nn -n 16 -c 32KB -b 1MB
-runmode=gotcha
-unify_test_write $runmode "$app_args"
-
-# write-posix -p nn -n 16 -c 32KB -b 1MB
-runmode=posix
-unify_test_write_posix "$app_args"
-
-# Switch back to -p n1
-io_pattern="-p n1"
-app_args="$io_pattern $io_sizes"
-
-# write-posix -p n1 -n 16 -c 32KB -b 1MB
-unify_test_write_posix "$app_args"
-
-# write-gotcha -p n1 -n 16 -c 32KB -b 1MB
-runmode=gotcha
-unify_test_write $runmode "$app_args"
-
-# write-static -p n1 -n 16 -c 32KB -b 1MB
-runmode=static
-unify_test_write $runmode "$app_args"
-
-# Increase sizes: -n 32 -c 64KB -b 1MB
-
-# write-static -p n1 -n 32 -c 64KB -b 1MB
-io_sizes="-n 32 -c $((64 * $KB)) -b $MB"
-app_args="$io_pattern $io_sizes"
-unify_test_write $runmode "$app_args"
-
-# write-gotcha -p n1 -n 32 -c 64KB -b 1MB
-runmode=gotcha
-unify_test_write $runmode "$app_args"
-
-# write-posix -p n1 -n 32 -c 64KB -b 1MB
-runmode=posix
-unify_test_write_posix "$app_args"
-
-# Switch to -p nn
-io_pattern="-p nn"
-app_args="$io_pattern $io_sizes"
-
-# write-posix -p nn -n 32 -c 64KB -b 1MB
-unify_test_write_posix "$app_args"
-
-# write-gotcha -p nn -n 32 -c 64KB -b 1MB
-runmode=gotcha
-unify_test_write $runmode "$app_args"
-
-# write-static -p nn -n 32 -c 64KB -b 1MB
-runmode=static
-unify_test_write $runmode "$app_args"
-
-# Increase sizes: -n 64 -c 1MB -b 4MB
-
-# write-static -p nn -n 64 -c 1MB -b 4MB
-io_sizes="-n 64 -c $MB -b $((4 *  $MB))"
-app_args="$io_pattern $io_sizes"
-unify_test_write $runmode "$app_args"
-
-# write-gotcha -p nn -n 64 -c 1MB -b 4MB
-runmode=gotcha
-unify_test_write $runmode "$app_args"
-
-# write-posix -p nn -n 64 -c 1MB -b 4MB
-runmode=posix
-unify_test_write_posix "$app_args"
-
-# Switch back to -p n1
-io_pattern="-p n1"
-app_args="$io_pattern $io_sizes"
-
-# write-posix -p n1 -n 64 -c 1MB -b 4MB
-unify_test_write_posix "$app_args"
-
-# write-gotcha -p n1 -n 64 -c 1MB -b 4MB
-runmode=gotcha
-unify_test_write $runmode "$app_args"
-
-# write-static -p n1 -n 64 -c 1MB -b 4MB
-runmode=static
-unify_test_write $runmode "$app_args"
-
-# Increase sizes: -n 32 -c 4MB -b 16MB
-
-# write-static -p n1 -n 32 -c 4MB -b 16MB
-io_sizes="-n 32 -c $((4 * $MB)) -b $((16 * $MB))"
-app_args="$io_pattern $io_sizes"
-unify_test_write $runmode "$app_args"
-
-# write-gotcha -p n1 -n 32 -c 4MB -b 16MB
-runmode=gotcha
-unify_test_write $runmode "$app_args"
-
-# write-posix -p n1 -n 32 -c 4MB -b 16MB
-runmode=posix
-unify_test_write_posix "$app_args"
-
-# Switch to -p nn
-io_pattern="-p nn"
-app_args="$io_pattern $io_sizes"
-
-# write-posix -p nn -n 32 -c 4MB -b 16MB
-unify_test_write_posix "$app_args"
-
-# write-gotcha -p nn -n 32 -c 4MB -b 16MB
-runmode=gotcha
-unify_test_write $runmode "$app_args"
-
-# write-static -p nn -n 32 -c 4MB -b 16MB
-runmode=static
-unify_test_write $runmode "$app_args"
+# For each io_size, test with each io_pattern and for each io_pattern, test each
+# mode
+for io_size in "${io_sizes[@]}"; do
+    for io_pattern in "${io_patterns[@]}"; do
+        app_args="$io_pattern $io_size"
+        for mode in "${modes[@]}"; do
+            unify_test_write $mode "$app_args"
+        done
+    done
+done

--- a/t/ci/110-write-tests.sh
+++ b/t/ci/110-write-tests.sh
@@ -97,7 +97,7 @@ unify_test_write() {
 
         test_expect_success "$app_name $2: (line_count=${lcount}, rc=$rc)" '
             test $rc = 0 &&
-            test $lcount = 18 &&
+            test $lcount = 17 &&
             if [[ $io_pattern =~ (n1)$ ]]; then
                 test_path_is_file ${UNIFYFS_CI_POSIX_MP}/$filename
             else
@@ -107,7 +107,7 @@ unify_test_write() {
     else
         test_expect_success "$app_name $2: (line_count=${lcount}, rc=$rc)" '
             test $rc = 0 &&
-            test $lcount = 18
+            test $lcount = 17
         '
     fi
 }

--- a/t/ci/110-write-tests.sh
+++ b/t/ci/110-write-tests.sh
@@ -6,7 +6,7 @@
 # in the ci-functions.sh script that can make adding new tests easier. See the
 # full UnifyFS documentatation for more info.
 #
-# There are multiple ways to to run an example using `unify_run_test()`
+# There are multiple ways to run an example using `unify_run_test()`
 #     1. unify_run_test $app_name "$app_args" app_output
 #     2. app_output=$(unify_run_test $app_name "app_args")
 #
@@ -32,22 +32,46 @@
 #         test $lcount = 8
 #     '
 #
-# For these tests, always include -b -c -n and -p in the app_args
+# For these tests, always include -b, -c, -n, and -p in the app_args
 
 
 test_description="Write Tests"
 
-while [[ $# -gt 0 ]]
+WRITE_USAGE="$(cat <<EOF
+usage ./110-write-tests.sh [options]
+
+  options:
+    -h, --help        print this (along with overall) help message
+    -M, --mpiio       use MPI-IO instead of POSIX I/O
+
+Run a series of tests on the UnifyFS write example application. By default, a
+series of different file sizes are tested using POSIX-I/O on both a shared
+file and a file per process. They are run multiple times for each mode the app
+was built with (static, gotcha, and optionally posix).
+
+Providing available options can change the default I/O behavior and/or I/O type
+used. The varying I/O types are mutually exclusive options and thus only one
+should be provided at a time.
+EOF
+)"
+
+for arg in "$@"
 do
-    case $1 in
+    case $arg in
         -h|--help)
-            echo "usage ./110-write-tests.sh -h|--help"
+            echo "$WRITE_USAGE"
             ci_dir=$(dirname "$(readlink -fm $BASH_SOURCE)")
             $ci_dir/001-setup.sh -h
             exit
             ;;
+        -M|--mpiio)
+            [ -n "$write_io_type" ] &&
+                { echo "ERROR: mutually exclusive options provided"; \
+                  echo "$WRITE_USAGE"; exit 2; } ||
+                write_io_type="-M"
+            ;;
         *)
-            echo "usage ./110-write-tests.sh -h|--help"
+            echo "$WRITE_USAGE"
             exit 1
             ;;
     esac
@@ -103,18 +127,32 @@ io_sizes=("-n 32 -c $((64 * $KB)) -b $MB"
 io_patterns=("-p n1" "-p nn")
 
 # Mode of each test, whether static, gotcha, or posix (if desired)
-modes=(static gotcha)
+modes=(gotcha)
+
+# static linker wrapping will not see the syscalls in the MPI-IO libraries
+if [ "$write_io_type" != "-M" ]; then
+    modes+=(static)
+fi
 
 # To run posix tests, set UNIFYFS_CI_TEST_POSIX=yes
 if test_have_prereq POSIX; then
     modes+=(posix)
 fi
 
+# Reset additional behavior to default
+behavior=""
+
+# Set I/O type
+if [ -n "$write_io_type" ]; then
+    behavior="$behavior $write_io_type"
+    unset write_io_type # prevent option being picked up by subsequent runs
+fi
+
 # For each io_size, test with each io_pattern and for each io_pattern, test each
 # mode
 for io_size in "${io_sizes[@]}"; do
     for io_pattern in "${io_patterns[@]}"; do
-        app_args="$io_pattern $io_size"
+        app_args="$io_pattern $io_size $behavior"
         for mode in "${modes[@]}"; do
             unify_test_write $mode "$app_args"
         done

--- a/t/ci/120-read-tests.sh
+++ b/t/ci/120-read-tests.sh
@@ -33,7 +33,6 @@
 #     '
 #
 # For these tests, always include -b -c -n and -p in the app_args
-# Then for the necessary tests, include -M -P -S -V or -x.
 
 
 test_description="Read Tests"
@@ -42,21 +41,22 @@ while [[ $# -gt 0 ]]
 do
     case $1 in
         -h|--help)
+            echo "usage ./120-read-tests.sh -h|--help"
             ci_dir=$(dirname "$(readlink -fm $BASH_SOURCE)")
             $ci_dir/001-setup.sh -h
             exit
             ;;
         *)
-            echo "usage ./300-read-tests.sh -h|--help"
+            echo "usage ./120-read-tests.sh -h|--help"
             exit 1
             ;;
     esac
 done
 
-# These two functions are simply to prevent code duplication since testing the
-# output of each example with sharness is the same process. These do not need to
-# be used, especially if wanting to test for something specific when running an
-# example.
+# Call unify_run_test with the app name, mode, and arguments in order to
+# automatically generate the MPI launch command to run the application and put
+# the result in $app_output.
+# Then evaluate the return code and output.
 unify_test_read() {
     app_name=read-${1}
 
@@ -65,176 +65,42 @@ unify_test_read() {
     rc=$?
     lcount=$(echo "$app_output" | wc -l)
 
-    # Evaluate output
-    test_expect_success "$app_name $app_args: (line_count=${lcount}, rc=$rc)" '
+    # Test the return code and resulting line count to determine pass/fail.
+    test_expect_success "$app_name $2: (line_count=${lcount}, rc=$rc)" '
         test $rc = 0 &&
         test $lcount = 14
     '
 }
 
-unify_test_read_posix() {
-    app_name=read-posix
+### Run the read tests ###
 
-    # Run the test and get output
-    if test_have_prereq POSIX; then
-        unify_run_test $app_name "$1" app_output
-        rc=$?
-        lcount=$(echo "$app_output" | wc -l)
-    fi
+# Array to determine the different file sizes that are created and tested. Each
+# item contains the number of blocks, chunk size, and block size to use when
+# writing or reading the file.
+io_sizes=("-n 32 -c $((64 * $KB)) -b $MB"
+          "-n 64 -c $MB -b $((4 *  $MB))"
+          "-n 32 -c $((4 * $MB)) -b $((16 * $MB))"
+)
 
-    # Evaluate output
-    test_expect_success POSIX "$app_name $1: (line_count=${lcount}, rc=$rc)" '
-        test $rc = 0 &&
-        test $lcount = 14
-    '
-}
+# I/O patterns to test with.
+# Includes shared file (-p n1) and file-per-process (-p nn)
+io_patterns=("-p n1" "-p nn")
 
-# read-static -p n1 -n 2 -c 4KB -b 16KB
-runmode=static
-io_pattern="-p n1"
-io_sizes="-n 2 -c $((4 * $KB)) -b $((16 * $KB))"
-app_args="$io_pattern $io_sizes"
-unify_test_read $runmode "$app_args"
+# Mode of each test, whether static, gotcha, or posix (if desired)
+modes=(static gotcha)
 
-# read-gotcha -p n1 -n 2 -c 4KB -b 16KB
-runmode=gotcha
-unify_test_read $runmode "$app_args"
+# To run posix tests, set UNIFYFS_CI_TEST_POSIX=yes
+if test_have_prereq POSIX; then
+    modes+=(posix)
+fi
 
-# read-posix -p n1 -n 2 -c 4KB -b 16KB
-runmode=posix
-unify_test_read_posix "$app_args"
-
-# Switch to -p nn
-io_pattern="-p nn"
-app_args="$io_pattern $io_sizes"
-
-# read-posix -p nn -n 2 -c 4KB -b 16KB
-unify_test_read_posix "$app_args"
-
-# read-gotcha -p nn -n 2 -c 4KB -b 16KB
-runmode=gotcha
-unify_test_read $runmode "$app_args"
-
-# read-static -p nn -n 2 -c 4KB -b 16KB
-runmode=static
-unify_test_read $runmode "$app_args"
-
-# Increase sizes: -n 16 -c 32KB -b 1MB
-
-# read-static -p nn -n 16 -c 32KB -b 1MB
-io_sizes="-n 16 -c $((32 * $KB)) -b $MB"
-app_args="$io_pattern $io_sizes"
-unify_test_read $runmode "$app_args"
-
-# read-gotcha -p nn -n 16 -c 32KB -b 1MB
-runmode=gotcha
-unify_test_read $runmode "$app_args"
-
-# read-posix -p nn -n 16 -c 32KB -b 1MB
-runmode=posix
-unify_test_read_posix "$app_args"
-
-# Switch back to -p n1
-io_pattern="-p n1"
-app_args="$io_pattern $io_sizes"
-
-# read-posix -p n1 -n 16 -c 32KB -b 1MB
-unify_test_read_posix "$app_args"
-
-# read-gotcha -p n1 -n 16 -c 32KB -b 1MB
-runmode=gotcha
-unify_test_read $runmode "$app_args"
-
-# read-static -p n1 -n 16 -c 32KB -b 1MB
-runmode=static
-unify_test_read $runmode "$app_args"
-
-# Increase sizes: -n 32 -c 64KB -b 1MB
-
-# read-static -p n1 -n 32 -c 64KB -b 1MB
-io_sizes="-n 32 -c $((64 * $KB)) -b $MB"
-app_args="$io_pattern $io_sizes"
-unify_test_read $runmode "$app_args"
-
-# read-gotcha -p n1 -n 32 -c 64KB -b 1MB
-runmode=gotcha
-unify_test_read $runmode "$app_args"
-
-# read-posix -p n1 -n 32 -c 64KB -b 1MB
-runmode=posix
-unify_test_read_posix "$app_args"
-
-# Switch to -p nn
-io_pattern="-p nn"
-app_args="$io_pattern $io_sizes"
-
-# read-posix -p nn -n 32 -c 64KB -b 1MB
-unify_test_read_posix "$app_args"
-
-# read-gotcha -p nn -n 32 -c 64KB -b 1MB
-runmode=gotcha
-unify_test_read $runmode "$app_args"
-
-# read-static -p nn -n 32 -c 64KB -b 1MB
-runmode=static
-unify_test_read $runmode "$app_args"
-
-# Increase sizes: -n 64 -c 1MB -b 4MB
-
-# read-static -p nn -n 64 -c 1MB -b 4MB
-io_sizes="-n 64 -c $MB -b $((4 *  $MB))"
-app_args="$io_pattern $io_sizes"
-unify_test_read $runmode "$app_args"
-
-# read-gotcha -p nn -n 64 -c 1MB -b 4MB
-runmode=gotcha
-unify_test_read $runmode "$app_args"
-
-# read-posix -p nn -n 64 -c 1MB -b 4MB
-runmode=posix
-unify_test_read_posix "$app_args"
-
-# Switch back to -p n1
-io_pattern="-p n1"
-app_args="$io_pattern $io_sizes"
-
-# read-posix -p n1 -n 64 -c 1MB -b 4MB
-unify_test_read_posix "$app_args"
-
-# read-gotcha -p n1 -n 64 -c 1MB -b 4MB
-runmode=gotcha
-unify_test_read $runmode "$app_args"
-
-# read-static -p n1 -n 64 -c 1MB -b 4MB
-runmode=static
-unify_test_read $runmode "$app_args"
-
-# Increase sizes: -n 32 -c 4MB -b 16MB
-
-# read-static -p n1 -n 32 -c 4MB -b 16MB
-io_sizes="-n 32 -c $((4 * $MB)) -b $((16 * $MB))"
-app_args="$io_pattern $io_sizes"
-unify_test_read $runmode "$app_args"
-
-# read-gotcha -p n1 -n 32 -c 4MB -b 16MB
-runmode=gotcha
-unify_test_read $runmode "$app_args"
-
-# read-posix -p n1 -n 32 -c 4MB -b 16MB
-runmode=posix
-unify_test_read_posix "$app_args"
-
-# Switch to -p nn
-io_pattern="-p nn"
-app_args="$io_pattern $io_sizes"
-
-# read-posix -p n1 -n 32 -c 4MB -b 16MB
-unify_test_read_posix "$app_args"
-
-# read-gotcha -p n1 -n 32 -c 4MB -b 16MB
-runmode=gotcha
-unify_test_read $runmode "$app_args"
-
-# read-static -p n1 -n 32 -c 4MB -b 16MB
-runmode=static
-unify_test_read $runmode "$app_args"
+# For each io_size, test with each io_pattern and for each io_pattern, test each
+# mode
+for io_size in "${io_sizes[@]}"; do
+    for io_pattern in "${io_patterns[@]}"; do
+        app_args="$io_pattern $io_size"
+        for mode in "${modes[@]}"; do
+            unify_test_read $mode "$app_args"
+        done
+    done
+done

--- a/t/ci/120-read-tests.sh
+++ b/t/ci/120-read-tests.sh
@@ -95,7 +95,7 @@ unify_test_read() {
     # Test the return code and resulting line count to determine pass/fail.
     test_expect_success "$app_name $2: (line_count=${lcount}, rc=$rc)" '
         test $rc = 0 &&
-        test $lcount = 14
+        test $lcount = 13
     '
 }
 

--- a/t/ci/300-producer-consumer-tests.sh
+++ b/t/ci/300-producer-consumer-tests.sh
@@ -1,0 +1,166 @@
+#!/bin/bash
+
+# This contains all the tests for testing the producer-consumer workflow using
+# the write and read examples.
+#
+# There are convenience functions such as `unify_run_test()` and get_filename()
+# in the ci-functions.sh script that can make adding new tests easier. See the
+# full UnifyFS documentatation for more info.
+#
+# There are multiple ways to run an example using `unify_run_test()`
+#     1. unify_run_test $app_name "$app_args" app_output
+#     2. app_output=$(unify_run_test $app_name "app_args")
+#
+#     ---- Method 1
+#     app_output=$(unify_run_test $app_name "$app_args")
+#     rc=$?
+
+#     echo "$app_output"
+#     lcount=$(printf "%s" "$app_output" | wc -l)
+#     ----
+
+#     ---- Method 2
+#     unify_run_test $app_name "$app_args" app_output
+#     rc=$?
+#
+#     lcount=$(echo "$app_output" | wc -l)
+#     ----
+#
+# The output of an example can then be tested with sharness, for example:
+#
+#     test_expect_success "$app_name $app_args: (line_count=$lcount, rc=$rc)" '
+#         test $rc = 0 &&
+#         test $lcount = 8
+#     '
+#
+# For these tests, always include -b, -c, -n, and -p in the app_args
+
+
+test_description="Producer-Consumer Tests"
+
+PRODUCER_CONSUMER_USAGE="$(cat <<EOF
+usage ./300-producer-consumer-tests.sh [options]
+
+  options:
+    -h, --help        print this (along with overall) help message
+    -M, --mpiio       use MPI-IO instead of POSIX I/O
+
+Run a series of producer-consumer workload tests using the UnifyFS write and
+read example applications. By default, a series of different file sizes are
+tested using POSIX-I/O on both a shared file and a file per process. They are
+run multiple times for each mode the app was linked with (i.e., static, gotcha).
+
+Providing available options can change the default I/O behavior and/or I/O type
+used. The varying I/O types are mutually exclusive options and thus only one
+should be provided at a time.
+
+Only run this suite when using two or more hosts. Use 110-write-tests.sh
+followed by 120-read-tests.sh when using a single host as it will be equivalent
+in this case.
+EOF
+)"
+
+for arg in "$@"
+do
+    case $arg in
+        -h|--help)
+            echo "$PRODUCER_CONSUMER_USAGE"
+            ci_dir=$(dirname "$(readlink -fm $BASH_SOURCE)")
+            $ci_dir/001-setup.sh -h
+            exit
+            ;;
+        -M|--mpiio)
+            [ -n "$write_io_type" ] &&
+                { echo "ERROR: mutually exclusive options provided"; \
+                  echo "$PRODUCER_CONSUMER_USAGE"; exit 2; } ||
+                write_io_type="-M"
+            ;;
+        *)
+            echo "$PRODUCER_CONSUMER_USAGE"
+            exit 1
+            ;;
+    esac
+done
+
+if ! test_have_prereq MULTIPLE_HOSTS; then
+    say "WARNING: Only run 300-producer-consumer-tests.sh suite with two or" \
+        "more hosts."
+    say "On a single host, 110-write-tests.sh followed by 120-read-tests.sh" \
+        "is an equivalent set of tests."
+    return
+fi
+
+# Call unify_run_test with the app name (use "producer" instead of "write" and
+# "consumer" instead of "read"), mode, and arguments in order to automatically
+# generate the MPI launch command to run the application and put the result in
+# $app_output.
+# Then evaluate the return code and output.
+unify_test_producer_consumer() {
+    app_name=producer-${1}
+
+    # Run the producer test and get output
+    unify_run_test $app_name "$2" app_output
+    rc=$?
+    lcount=$(echo "$app_output" | wc -l)
+
+    # Test the return code and resulting line count to determine pass/fail.
+    test_expect_success "$app_name $2: (line_count=${lcount}, rc=$rc)" '
+        test $rc = 0 &&
+        test $lcount = 18
+    '
+
+    app_name=consumer-${1}
+
+    # Run the consumer test and get output
+    unify_run_test $app_name "$2" app_output
+    rc=$?
+    lcount=$(echo "$app_output" | wc -l)
+
+    # Test the return code and resulting line count to determine pass/fail.
+    test_expect_success "$app_name $2: (line_count=${lcount}, rc=$rc)" '
+        test $rc = 0 &&
+        test $lcount = 14
+    '
+}
+
+### Run the producer-consumer tests ###
+
+# Array to determine the different file sizes that are created and tested. Each
+# item contains the number of blocks, chunk size, and block size to use when
+# writing or reading the file.
+io_sizes=("-n 32 -c $((64 * $KB)) -b $MB"
+          "-n 64 -c $MB -b $((4 *  $MB))"
+          "-n 32 -c $((4 * $MB)) -b $((16 * $MB))"
+)
+
+# I/O patterns to test with.
+# Includes shared file (-p n1) and file-per-process (-p nn)
+io_patterns=("-p n1" "-p nn")
+
+# Mode of each test, whether static, gotcha, or posix (if desired)
+modes=(gotcha)
+
+# static linker wrapping will not see the syscalls in the MPI-IO libraries
+if [ "$write_io_type" != "-M" ]; then
+    modes+=(static)
+fi
+
+# Reset additional behavior to default
+behavior=""
+
+# Set I/O type
+if [ -n "$write_io_type" ]; then
+    behavior="$behavior $write_io_type"
+    unset write_io_type # prevent option being picked up by subsequent runs
+fi
+
+# For each io_size, test with each io_pattern and for each io_pattern, test each
+# mode
+for io_size in "${io_sizes[@]}"; do
+    for io_pattern in "${io_patterns[@]}"; do
+        app_args="$io_pattern $io_size $behavior"
+        for mode in "${modes[@]}"; do
+            unify_test_producer_consumer $mode "$app_args"
+        done
+    done
+done

--- a/t/ci/300-producer-consumer-tests.sh
+++ b/t/ci/300-producer-consumer-tests.sh
@@ -106,7 +106,7 @@ unify_test_producer_consumer() {
     # Test the return code and resulting line count to determine pass/fail.
     test_expect_success "$app_name $2: (line_count=${lcount}, rc=$rc)" '
         test $rc = 0 &&
-        test $lcount = 18
+        test $lcount = 17
     '
 
     app_name=consumer-${1}
@@ -119,7 +119,7 @@ unify_test_producer_consumer() {
     # Test the return code and resulting line count to determine pass/fail.
     test_expect_success "$app_name $2: (line_count=${lcount}, rc=$rc)" '
         test $rc = 0 &&
-        test $lcount = 14
+        test $lcount = 13
     '
 }
 

--- a/t/ci/RUN_CI_TESTS.sh
+++ b/t/ci/RUN_CI_TESTS.sh
@@ -103,6 +103,9 @@ echo "Setup time -- $(elapsed_time start_time setup_time)"
 # writeread example tests
 source $UNIFYFS_CI_DIR/100-writeread-tests.sh
 
+# writeread example with I/O shuffle tests
+source $UNIFYFS_CI_DIR/100-writeread-tests.sh --shuffle
+
 # write example tests
 source $UNIFYFS_CI_DIR/110-write-tests.sh
 

--- a/t/ci/RUN_CI_TESTS.sh
+++ b/t/ci/RUN_CI_TESTS.sh
@@ -100,17 +100,26 @@ echo "Setup time -- $(elapsed_time start_time setup_time)"
 # 990-stop-server.sh) in the desired order to run them.
 ##############################################################################
 
-# writeread example tests
+# POSIX-IO writeread example tests
 source $UNIFYFS_CI_DIR/100-writeread-tests.sh
 
-# writeread example with I/O shuffle tests
+# POSIX-IO writeread example with I/O shuffle tests
 source $UNIFYFS_CI_DIR/100-writeread-tests.sh --shuffle
 
-# write example tests
+# POSIX-IO write example tests
 source $UNIFYFS_CI_DIR/110-write-tests.sh
 
-# read example tests
+# POSIX-IO read example tests
 source $UNIFYFS_CI_DIR/120-read-tests.sh
+
+# MPI-IO writeread example tests
+source $UNIFYFS_CI_DIR/100-writeread-tests.sh --mpiio
+
+# MPI-IO write example tests
+#source $UNIFYFS_CI_DIR/110-write-tests.sh --mpiio
+
+# MPI-IO read example tests
+#source $UNIFYFS_CI_DIR/120-read-tests.sh --mpiio
 
 ##############################################################################
 # DO NOT add additional tests after this point

--- a/t/ci/RUN_CI_TESTS.sh
+++ b/t/ci/RUN_CI_TESTS.sh
@@ -121,6 +121,14 @@ source $UNIFYFS_CI_DIR/100-writeread-tests.sh --mpiio
 # MPI-IO read example tests
 #source $UNIFYFS_CI_DIR/120-read-tests.sh --mpiio
 
+### Producer-Consumer workload tests
+
+# POSIX-IO producer-consumer tests
+source $UNIFYFS_CI_DIR/300-producer-consumer-tests.sh
+
+# MPI-IO producer-consumer tests
+#source $UNIFYFS_CI_DIR/300-producer-consumer-tests.sh --mpiio
+
 ##############################################################################
 # DO NOT add additional tests after this point
 ##############################################################################

--- a/t/ci/RUN_CI_TESTS.sh
+++ b/t/ci/RUN_CI_TESTS.sh
@@ -116,10 +116,10 @@ source $UNIFYFS_CI_DIR/120-read-tests.sh
 source $UNIFYFS_CI_DIR/100-writeread-tests.sh --mpiio
 
 # MPI-IO write example tests
-#source $UNIFYFS_CI_DIR/110-write-tests.sh --mpiio
+source $UNIFYFS_CI_DIR/110-write-tests.sh --mpiio
 
 # MPI-IO read example tests
-#source $UNIFYFS_CI_DIR/120-read-tests.sh --mpiio
+source $UNIFYFS_CI_DIR/120-read-tests.sh --mpiio
 
 ### Producer-Consumer workload tests
 
@@ -127,7 +127,7 @@ source $UNIFYFS_CI_DIR/100-writeread-tests.sh --mpiio
 source $UNIFYFS_CI_DIR/300-producer-consumer-tests.sh
 
 # MPI-IO producer-consumer tests
-#source $UNIFYFS_CI_DIR/300-producer-consumer-tests.sh --mpiio
+source $UNIFYFS_CI_DIR/300-producer-consumer-tests.sh --mpiio
 
 ##############################################################################
 # DO NOT add additional tests after this point

--- a/t/ci/ci-functions.sh
+++ b/t/ci/ci-functions.sh
@@ -3,7 +3,6 @@
 export KB=$((2**10))
 export MB=$((2**20))
 export GB=$((2**30))
-app_id=0
 
 ### Project-local sharness code for UnifyFS's integration tests ###
 
@@ -268,9 +267,17 @@ get_filename()
 # Builds the test command that will be executed. Automatically sets any options
 # that are always wanted (-vkfo and the appropriate -m if posix test or not).
 #
-# Automatically builds the filename for -f based on the input app_name and
-# app_args and has .app appended to the end. This filename then also has .err
-# appended and is used for the stderr output file with JOB_RUN_COMMAND.
+# Automatically builds the base filename for -f and -o based on the input
+# app_name and app_args. Then .app and .out are appended to the end of each
+# respectively.
+# This base filename also has .err appended and is used for the stderr output
+# file with JOB_RUN_COMMAND.
+#
+# Adjustments for unique behavior is accounted for here as well. This includes
+# using the write/producer .app filename when reading/consuming, using the write
+# or read executables when the producer or consumer app name is passed in, and
+# using a different JOB_RUN_COMMAND that excludes hosts when running the
+# producer-consumer workflow.
 #
 # Args that can be passed in are ([-pncbx][-A|-M|-N|-P|-S|-V]). All other args
 # are set automatically.
@@ -278,7 +285,7 @@ get_filename()
 # $1 - Name of the example application to be tested (basetest-runmode)
 # $2 - Args for $1 consisting of ([-pncbx][-A|-M|-N|-P|-S|-V]). Encase in
 # quotes.
-# $3 - The runmode of test, used to determine if posix and set correct args
+# $3 - The runmode of the test (static, gotcha, posix)
 #
 # Returns the full test command ready to be executed.
 build_test_command()
@@ -292,30 +299,56 @@ build_test_command()
         return 1
     fi
 
-    # Autogenerate and format the filename based on app_name and app_args
+    # Autogenerate and format the base filename based on app_name and app_args
     local l_filename="$(get_filename $1 "$2")"
 
-    # Add stderr output file to finish building JOB_RUN_COMMAND
+    # Set stderr output file name
+    # app_err is defined in resource manager setup script
     local l_err_filename="$app_err ${UNIFYFS_LOG_DIR}/${l_filename}.err"
-    local l_job_run_command="$JOB_RUN_COMMAND $l_err_filename"
 
-    # Build example_command with options that are always wanted. Might need to
-    # adjust for other tests (i.e., app-mpiio), or write new functions
-    local l_app_id="-a $app_id"
+    # Set defaults for example executable name, application filename internal to
+    # UnifyFS, and JOB_RUN_COMMAND (defined in resource manager setup script)
+    local l_example_name="$1"
+    local l_app_filename="-f ${l_filename}.app"
+    local l_launch_command="$JOB_RUN_COMMAND"
+
     #local l_verbose="-v" # Sends DEBUG and test configuration info to stdout
 
-    # Filename needs to be the write file if testing the read example
+    # TODO: Refactor app_name checks to unify_run_test and call different
+    # functions depending on workflow being tested.
+    # Get base example executable name for adjusting jobs with unique behavior
     local l_app_name=$(echo $1 | sed -r 's/(\w)-.*/\1/')
     if [[ $l_app_name = "read" ]]; then
-        local l_app_filename="-f $(get_filename write-$3 "$2").app"
-    else
-        local l_app_filename="-f ${l_filename}.app"
+        # Filename needs to be the write file when testing the read example
+        local l_app_filename="-f $(get_filename write-$3 "$2" ".app")"
+    fi
+
+    # Producer in producer-consumer workflow
+    if [[ $l_app_name = "producer" ]]; then
+        # Use write executable
+        local l_example_name="write-$3"
+        # Exclude hosts used for consumer
+        local l_exclude_hosts="$exclude_option $(get_latter_hosts)"
+        # Change run command to use initial half of allocated hosts
+        local l_launch_command="$JOB_RUN_HALF_NODES $l_exclude_hosts"
+    fi
+
+    # Consumer in producer-consumer workflow
+    if [[ $l_app_name = "consumer" ]]; then
+        # Use read executable
+        local l_example_name="read-$3"
+        # Filename needs to be the producer file when running consumer test
+        local l_app_filename="-f $(get_filename producer-$3 "$2" ".app")"
+        # Exclude hosts used for producer
+        local l_exclude_hosts="$exclude_option $(get_initial_hosts)"
+        # Change run command to use latter half of allocated hosts
+        local l_launch_command="$JOB_RUN_HALF_NODES $l_exclude_hosts"
     fi
 
     # Set mountpoint to an existing dir & disable UnifyFS if running posix test
     if [[ $3 = "posix" ]]; then
         local l_mount="-U -m $UNIFYFS_CI_POSIX_MP"
-    else
+    else # Use UNIFYFS_MOUNTPOINT and enable data check
         local l_mount="-m $UNIFYFS_MP"
         local l_check="-k" # read.c tests fail on posix files
     fi
@@ -323,12 +356,17 @@ build_test_command()
     # Add outfile option for checking line count after test completes
     local l_outfile="-o ${UNIFYFS_LOG_DIR}/${l_filename}.out"
 
-    # Assemble full example_command
-    local l_app_args="$2 $l_app_id $l_check $l_verbose $l_mount $l_outfile \
+    # Assemble full list of args for application command
+    local l_app_args="$2 $l_check $l_verbose $l_mount $l_outfile \
                       $l_app_filename"
-    local l_full_app_name="${UNIFYFS_EXAMPLES}/${1} $l_app_args"
 
-    # Assemble full test_command
+    # Assemble full application command
+    local l_full_app_name="${UNIFYFS_EXAMPLES}/$l_example_name $l_app_args"
+
+    # Assemble full JOB_RUN_COMMAND
+    local l_job_run_command="$l_launch_command $l_err_filename"
+
+    # Assemble full test command
     local l_test_command="$l_job_run_command $l_full_app_name"
     echo $l_test_command
 }
@@ -384,7 +422,7 @@ unify_run_test()
         return 42
     fi
 
-    # Fail if user passed in filename, check,  mountpoint, outfile, verbose or
+    # Fail if user passed in filename, check, mountpoint, outfile, verbose or
     # disable UnifyFS since these are added automatically
     local opt="(-f|--file|-k|--check|-m|--mount|-o|--outfile|-v|--verbose|-U|\
                 --disable-unifyfs)"
@@ -398,9 +436,6 @@ unify_run_test()
     # Finally build and run the test
     local l_test_command=$(build_test_command $1 "$2" $l_runmode)
     say "Results for unifyfs_run_test: $l_test_command:"
-
-    # Uncomment to change app_id (-a) for each test. Comment to leave as 0.
-    #app_id=$(echo $(($app_id + 1)))
 
     # Get resulting output and rc of running the test
     local l_app_output; l_app_output="$($l_test_command)"

--- a/t/ci/ci-functions.sh
+++ b/t/ci/ci-functions.sh
@@ -377,8 +377,10 @@ unify_run_test()
         return 1
     fi
 
-    # Skip this test if posix test and UNIFYFS_CI_TEST_POSIX=no|NO
+    # If we somehow made it here with a posix test but don't have the POSIX
+    # prereq set, then return a non-zero code
     if ! test_have_prereq POSIX && [[ $l_runmode = "posix" ]]; then
+        echo >&2 "$errmsg posix test run withough POSIX prereq set"
         return 42
     fi
 

--- a/t/ci/setup-lsf.sh
+++ b/t/ci/setup-lsf.sh
@@ -6,26 +6,24 @@
 # Functions specific to LSF
 
 # Get the compute hosts being used in the current allocation.
-#
 # Returns the unique hosts being used on LSF, exluding the launch host.
 get_lsf_hosts()
 {
     # NOTE: It's possible that some systems with LSF may place the user on the
     # first compute node rather than a launch node.
     local l_hosts=$(uniq $LSB_DJOB_HOSTFILE | tail -n +2)
-    echo $l_hosts
+    echo "$l_hosts"
 }
 
 # Gets the compute hosts being used in the current allocation and returns them
 # as a list so they are usable by commands like pdsh.
-#
 # Returns the unique hosts being used on LSF as a list.
 # (e.g., host1,host2,...,hostn)
 get_hostlist()
 {
     local l_hosts=$(get_lsf_hosts)
-    #replace spaces with commas
-    local l_hostlist=${l_hosts//[[:blank:]]/,}
+    # Replace spaces with commas
+    local l_hostlist=$(echo $l_hosts | tr ' ' ',')
     echo $l_hostlist
 }
 
@@ -34,7 +32,7 @@ nnodes=$(get_lsf_hosts | wc -w)
 
 # Define each resource set
 nprocs=${UNIFYFS_CI_NPROCS:-1}
-ncores=${UNIFYFS_CI_NCORES:-20}
+ncores=${UNIFYFS_CI_NCORES:-18}
 
 # Total resource sets and how many per host
 nrs_per_node=${UNIFYFS_CI_NRS_PER_NODE:-1}
@@ -68,13 +66,42 @@ if [ $(($nres_sets / $nrs_per_node)) -gt $nnodes ]; then
     exit 1
 fi
 
-jsargs="-a${nprocs} -c${ncores} -r${nrs_per_node} -n${nres_sets}"
+jsargs="-a ${nprocs} -c ${ncores} -r ${nrs_per_node}"
 
 app_out="-o"
 app_err="-k"
-JOB_RUN_COMMAND="jsrun $jsargs"
+JOB_RUN_COMMAND="jsrun $jsargs -n ${nres_sets}"
 JOB_RUN_ONCE_PER_NODE="jsrun -r1"
 JOB_ID=${JOB_ID:-$LSB_JOBID}
+
+# Set up producer-consumer variables and functions when using two or more hosts
+if [[ $nnodes -ge 2 ]]; then
+    # Prereq for running 300-producer-consumer-tests.sh
+    test_set_prereq MULTIPLE_HOSTS
+
+    # Get the initial half of the hosts in the current allocation
+    get_initial_hosts()
+    {
+        local l_hosts=$(get_lsf_hosts)
+        local l_initial_hosts=$(echo "$l_hosts" | head -n $(($nnodes / 2 )))
+        # Replace spaces with commas
+        local l_initial_hostlist=$(echo $l_initial_hosts | tr ' ' ',')
+        echo $l_initial_hostlist
+    }
+
+    # Get the latter half of the hosts in the current allocation
+    get_latter_hosts()
+    {
+        local l_hosts=$(get_lsf_hosts)
+        local l_latter_hosts=$(echo "$l_hosts" | tail -n $(($nnodes / 2 )))
+        # Replace spaces with commas
+        local l_latter_hostlist=$(echo $l_latter_hosts | tr ' ' ',')
+        echo $l_latter_hostlist
+    }
+
+    exclude_option="-x"
+    JOB_RUN_HALF_NODES="jsrun $jsargs -n $(($nres_sets/2))"
+fi
 
 echo "$infomsg ====================== LSF Job Info ======================"
 echo "$infomsg ----------------------- Job Status -----------------------"

--- a/t/ci/setup-slurm.sh
+++ b/t/ci/setup-slurm.sh
@@ -19,14 +19,47 @@ get_hostlist()
 
 # Variables specific to SLURM
 nnodes=$SLURM_NNODES
+
 nres_sets=$SLURM_NNODES
 nprocs=${UNIFYFS_CI_NPROCS:-1}
 
 app_out="-o"
 app_err="-e"
-JOB_RUN_COMMAND="srun -N${nnodes} --ntasks-per-node=${nprocs}"
-JOB_RUN_ONCE_PER_NODE="srun -n${nnodes}"
+JOB_RUN_COMMAND="srun -N ${nnodes} --ntasks-per-node=${nprocs}"
+JOB_RUN_ONCE_PER_NODE="srun -n ${nnodes}"
 JOB_ID=${JOB_ID:-$SLURM_JOBID}
+
+# Set up producer-consumer variables and functions when using two or more hosts
+if [[ $nnodes -ge 2 ]]; then
+    # Prereq for running 300-producer-consumer-tests.sh
+    test_set_prereq MULTIPLE_HOSTS
+
+    # Get list of unique host names
+    # Only want to run once as order can change each time
+    # One alternative is to parse SLURM_NODELIST, which can get ugly
+    SLURM_HOSTS=$($JOB_RUN_ONCE_PER_NODE hostname)
+
+    # Get the initial half of the hosts in the current allocation
+    get_initial_hosts()
+    {
+        local l_initial_hosts=$(echo "$SLURM_HOSTS" | head -n $(($nnodes / 2)))
+        # Replace spaces with commas
+        local l_initial_hostlist=$(echo $l_initial_hosts | tr ' ' ',')
+        echo $l_initial_hostlist
+    }
+
+    # Get the latter half of the hosts in the current allocation
+    get_latter_hosts()
+    {
+        local l_latter_hosts=$(echo "$SLURM_HOSTS" | tail -n $(($nnodes / 2)))
+        # Replace spaces with commas
+        local l_latter_hostlist=$(echo $l_latter_hosts | tr ' ' ',')
+        echo $l_latter_hostlist
+    }
+
+    exclude_option="-x"
+    JOB_RUN_HALF_NODES="srun -N $(($nnodes/2)) --ntasks-per-node=${nprocs}"
+fi
 
 echo "$infomsg ====================== SLURM Job Info ======================"
 echo "$infomsg ------------------------ Job Status ------------------------"


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->

My steps in putting this together were logically separate so I thought I'd leave this as a series of logically separate commits. Will also make it easier to look back and see how to add additional tests/behavior to the current CI suites. I can always squash them if preferred.

---

### Refactor CI suites

This refactors the current writeread, write, and read CI test suites in order to make them easier to edit/add to and run again with different behavior. Removes the repetitive setting of variables/options and execution of tests and now does this with arrays and loops.
The default versions iterate over a series of file sizes (32MiB, 256MiB, and 512MiB per process) where each size is tested using a shared file and a file per process. Then for each of those the gotcha and statically linked executables are ran. Now to add/remove/edit what is tested simply edit the arrays.

Adds ability, option processing, and usage messages to the writeread, write and read CI test suites to enable running the various suites multiple times with different behavior.
Behaviors added here include running the suites again with MPI-IO (statically linked tests are skipped) as well as running the writeread suite with the shuffle option. More to come (stdio, pwrite/pread, etc).

Makes a couple small fixes in the write.c and read.c examples which allowed the MPI-IO tests to start passing.
Resolves #599

### Producer-Consumer Tests

First, the write and read suites being run on all the hosts in an allocation serves as one set of scenarios in which the producer/consumer workflow is being tested. The POSIX version of this was already in the test suite and with the above changes, the MPI-IO version will be as well.

The _t/ci/300-producer-consumer-tests.sh_ suite added here allows for testing the scenario of producer/consumer on disjoint sets of hosts within a single allocation.
Currently this tests under the assumption that there is an even number of hosts within the allocation. The producer uses the initial half of the hosts and the consumer uses the latter half of the hosts within an allocation.
This suite runs the same iteration of tests as mentioned above (varying file sizes, file types, and linked executables).
This suite defaults to POSIX as well, but also has the option to be run using MPI-IO.

One main different in this suite is `unify_run_test()` is called with "producer/consumer" in the `app_name` rather than "write/read". This is mainly so that the application file names within the UnifyFS mount point as well as the error and output file names that are auto-generated  when running the tests all remain unique.

The `build_test_command()` function has been adjusted to check for producer/consumer in the `app_name` and, if found, adjusts to use the correct executable as well as an altered job run command that excludes half of the hosts in the allocation. Made a note that this function should probably be refactored into multiple functions as future workflows are added to the testing suite (i.e., checkpoint/restart, etc).

Functions have been added to the _setup-lsf.sh_ and _setup-slurm.sh_ scripts to allow for retrieving a host list of the initial and latter hosts within an allocation.  An altered job run command, `JOB_RUN_HALF_NODES`, and option needed to exclude hosts are added to these scripts as well. These are used to build the job run command for producer/consumer in `build_test_command()`. 

### Additional items

Running the producer-consumer tests with POSIX and MPI-IO, the write and read tests with MPI-IO, and the writeread tests with the shuffle option and with MPI-IO are all added to the RUN_CI_TESTS.sh script to enable running the current full set of tests. This is ran with GitLab CI.

For the purely posix writeread, write, and read tests (not linked to UnifyFS), they are now not run at all (rather than skipped) when the option to run them is not set. This then removes the separate function for running posix tests and simplifies it in a single function. Lastly, the default for running the purely posix version of CI tests is set to "no". Set `UNIFYFS_CI_TEST_POSIX=yes` to now run them.

Update testing and example documentation.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Evaluate the ability of UnifyFS to support producer/consumer workflows with a variety of scenarios.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

New tests have all been run and passed on up to 8 nodes with 4 ppn on both an x86-64 and Power 9 system.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Testing (addition of new tests or update to current tests)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
