### PR TITLE
Set margo version in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ before_install:
 install:
   - . $HOME/spack/share/spack/setup-env.sh
   - spack install gotcha@1.0.3 && spack load gotcha@1.0.3
-  - spack install margo^mercury@1.0.1+bmi~ofi~boostsys && spack load argobots && spack load mercury && spack load margo
+  - spack install margo@0.4.3^mercury@1.0.1+bmi~ofi~boostsys && spack load argobots && spack load mercury && spack load margo
   - spack install spath && spack load spath
   # prepare build environment
   - eval $(./scripts/git_log_test_env.sh)


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
This sets the margo version for Travis CI to 0.4.3.

The upstream Margo Spack packages was recently updated, changing the default versions. Our .travis.yml specifies the Mercury version, but we never specified the Margo version, which now creates a version incompatibility.

```
$ spack install margo^mercury@1.0.1+bmi~ofi~boostsys && spack load argobots && spack load mercury && spack load margo
==> Error: An unsatisfiable version constraint has been detected for spec:

    mercury@1.0.1+bmi~boostsys~ofi


while trying to concretize the partial spec:

    margo@0.9%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
        ^argobots@1.0%gcc@7.5.0~debug~valgrind arch=linux-ubuntu18.04-x86_64
        ^autoconf@2.69%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
        ^automake@1.15.1%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
        ^json-c
        ^libtool@2.4.6%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64
        ^m4@1.4.18%gcc@7.5.0+sigsegv arch=linux-ubuntu18.04-x86_64
        ^pkgconf@1.7.3%gcc@7.5.0 arch=linux-ubuntu18.04-x86_64


margo requires mercury version 2.0.0:, but spec asked for 1.0.1
The command "spack install margo^mercury@1.0.1+bmi~ofi~boostsys && spack load argobots && spack load mercury && spack load margo" failed and exited with 1 during .
```