### PR TITLE
client: define unifyfs super magic

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -93,7 +93,7 @@ if [ "$automake_sub_version" -lt "15" ]; then
 
     autotools_repos=(http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz
         http://ftp.gnu.org/gnu/automake/automake-1.15.tar.gz
-        http://mirror.team-cymru.org/gnu/libtool/libtool-2.4.2.tar.gz
+        http://mirror.team-cymru.org/gnu/libtool/libtool-2.4.6.tar.gz
         https://pkg-config.freedesktop.org/releases/pkg-config-0.27.1.tar.gz
     )
 
@@ -129,7 +129,7 @@ if [ "$automake_sub_version" -lt "15" ]; then
 
     # build libtool
     echo "### building libtool ###"
-    pushd libtool-2.4.2
+    pushd libtool-2.4.6
         ./configure --build=$sys_name --prefix=$INSTALL_DIR
         make
         make install
@@ -138,7 +138,7 @@ if [ "$automake_sub_version" -lt "15" ]; then
     # build pkg-config
     echo "### building pkg-config ###"
     pushd pkg-config-0.27.1
-        ./configure --build=$sys_name --prefix=$INSTALL_DIR
+        ./configure --build=$sys_name --prefix=$INSTALL_DIR --with-internal-glib
         make
         make install
     popd
@@ -146,7 +146,6 @@ else
     echo "### detected automake version is greater than or equal to 1.15 ###"
     echo "### skipping autotools build ###"
 fi
-
 
 echo "### building GOTCHA ###"
 cd GOTCHA

--- a/client/src/unifyfs-internal.h
+++ b/client/src/unifyfs-internal.h
@@ -355,6 +355,9 @@ extern logio_context* logio_ctx;
 extern int unifyfs_app_id;
 extern int unifyfs_client_id;
 
+/* whether to return UNIFYFS (true) or TMPFS (false) magic value from statfs */
+extern bool unifyfs_super_magic;
+
 /* keep track of what we've initialized */
 extern int unifyfs_initialized;
 

--- a/client/src/unifyfs-sysio.c
+++ b/client/src/unifyfs-sysio.c
@@ -40,6 +40,7 @@
  * Please also read this file LICENSE.CRUISE
  */
 
+#include "unifyfs.h"
 #include "unifyfs-internal.h"
 #include "unifyfs-sysio.h"
 #include "margo_client.h"
@@ -843,7 +844,16 @@ static int unifyfs_statfs(struct statfs* fsbuf)
     if (NULL != fsbuf) {
         memset(fsbuf, 0, sizeof(*fsbuf));
 
-        fsbuf->f_type = TMPFS_MAGIC; /* File system type */
+        /* set file system type */
+        if (unifyfs_super_magic) {
+            /* return a magic value that is specific to UnifyFS */
+            fsbuf->f_type = UNIFYFS_SUPER_MAGIC;
+        } else {
+            /* option to fallback to a well-known magic value for clients
+             * that don't handle a UnifyFS magic value */
+            fsbuf->f_type = TMPFS_MAGIC;
+        }
+
         fsbuf->f_bsize = UNIFYFS_LOGIO_CHUNK_SIZE; /* Optimal block size */
         //fsbuf->f_blocks = ??;  /* Total data blocks in filesystem */
         //fsbuf->f_bfree = ??;   /* Free blocks in filesystem */

--- a/client/src/unifyfs.c
+++ b/client/src/unifyfs.c
@@ -88,6 +88,9 @@ static off_t unifyfs_min_long;
 int    unifyfs_max_files;  /* maximum number of files to store */
 bool   unifyfs_local_extents;  /* track data extents in client to read local */
 
+/* whether to return UNIFYFS (true) or TMPFS (false) magic value from statfs */
+bool unifyfs_super_magic;
+
 /* log-based I/O context */
 logio_context* logio_ctx;
 
@@ -1746,6 +1749,17 @@ static int unifyfs_init(void)
             rc = configurator_bool_val(cfgval, &b);
             if (rc == 0) {
                 unifyfs_write_sync = (bool)b;
+            }
+        }
+
+        /* Determine SUPER MAGIC value to return from statfs.
+         * Use UNIFYFS_SUPER_MAGIC if true, TMPFS_SUPER_MAGIC otherwise. */
+        unifyfs_super_magic = true;
+        cfgval = client_cfg.client_super_magic;
+        if (cfgval != NULL) {
+            rc = configurator_bool_val(cfgval, &b);
+            if (rc == 0) {
+                unifyfs_super_magic = (bool)b;
             }
         }
 

--- a/client/src/unifyfs.h
+++ b/client/src/unifyfs.h
@@ -21,6 +21,11 @@
 extern "C" {
 #endif
 
+/* "UNFY" in ASCII */
+//#define UNIFYFS_SUPER_MAGIC (0x554E4659)
+
+/* "UnifyFS!" in ASCII */
+#define UNIFYFS_SUPER_MAGIC (0x556E696679465321)
 
 int unifyfs_mount(const char prefix[], int rank, size_t size,
                   int l_app_id);

--- a/common/src/unifyfs_configurator.h
+++ b/common/src/unifyfs_configurator.h
@@ -74,6 +74,7 @@
     UNIFYFS_CFG(client, max_files, INT, UNIFYFS_CLIENT_MAX_FILES, "client max file count", NULL) \
     UNIFYFS_CFG(client, write_index_size, INT, UNIFYFS_CLIENT_WRITE_INDEX_SIZE, "write metadata index buffer size", NULL) \
     UNIFYFS_CFG(client, write_sync, BOOL, off, "sync every write to server", NULL) \
+    UNIFYFS_CFG(client, super_magic, BOOL, on, "return UnifyFS super magic from statfs, TMPFS otherwise", NULL) \
     UNIFYFS_CFG_CLI(log, verbosity, INT, 0, "log verbosity level", NULL, 'v', "specify logging verbosity level") \
     UNIFYFS_CFG_CLI(log, file, STRING, unifyfsd.log, "log file name", NULL, 'l', "specify log file name") \
     UNIFYFS_CFG_CLI(log, dir, STRING, LOGDIR, "log file directory", configurator_directory_check, 'L', "specify full path to directory to contain log file") \

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -69,6 +69,7 @@ a given section and key.
    cwd               STRING  effective starting current working directory
    max_files         INT     maximum number of open files per client process (default: 128)
    local_extents     BOOL    service reads from local data if possible (default: off)
+   super_magic       BOOL    whether to return UNIFYFS (on) or TMPFS (off) statfs magic (default: on)
    write_index_size  INT     maximum size (B) of memory buffer for storing write log metadata
    write_sync        BOOL    sync data to server after every write (default: off)
    ================  ======  =================================================================

--- a/t/0110-statfs-gotcha.t
+++ b/t/0110-statfs-gotcha.t
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+# Source sharness environment scripts to pick up test environment
+# and UnifyFS runtime settings.
+#
+. $(dirname $0)/sharness.d/00-test-env.sh
+. $(dirname $0)/sharness.d/01-unifyfs-settings.sh
+
+# disable statfs from returning UnifyFS! super magic value,
+# return tmpfs magic instead
+export UNIFYFS_CLIENT_SUPER_MAGIC=0
+
+$JOB_RUN_COMMAND $UNIFYFS_BUILD_DIR/t/sys/statfs-gotcha.t

--- a/t/0510-statfs-static.t
+++ b/t/0510-statfs-static.t
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+# Source sharness environment scripts to pick up test environment
+# and UnifyFS runtime settings.
+#
+. $(dirname $0)/sharness.d/00-test-env.sh
+. $(dirname $0)/sharness.d/01-unifyfs-settings.sh
+
+# disable statfs from returning UnifyFS! super magic value,
+# return tmpfs magic instead
+export UNIFYFS_CLIENT_SUPER_MAGIC=0
+
+$JOB_RUN_COMMAND $UNIFYFS_BUILD_DIR/t/sys/statfs-static.t

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -114,6 +114,7 @@ test_cppflags = \
 sys_sysio_gotcha_t_SOURCES = \
   sys/sysio_suite.h \
   sys/sysio_suite.c \
+  sys/statfs.c \
   sys/creat-close.c \
   sys/creat64.c \
   sys/mkdir-rmdir.c \
@@ -133,6 +134,7 @@ sys_sysio_gotcha_t_LDFLAGS = $(test_gotcha_ldflags)
 sys_sysio_static_t_SOURCES = \
   sys/sysio_suite.h \
   sys/sysio_suite.c \
+  sys/statfs.c \
   sys/creat-close.c \
   sys/creat64.c \
   sys/mkdir-rmdir.c \

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -10,11 +10,13 @@ TESTS = \
 if HAVE_GOTCHA
   TESTS += \
     0100-sysio-gotcha.t \
+    0110-statfs-gotcha.t \
     0200-stdio-gotcha.t
 endif
 
 TESTS += \
   0500-sysio-static.t \
+  0510-statfs-static.t \
   0600-stdio-static.t \
   0700-unifyfs-stage-full.t \
   9005-unifyfs-unmount.t \
@@ -28,6 +30,7 @@ TESTS += \
 check_SCRIPTS = \
   0001-setup.t \
   0500-sysio-static.t \
+  0510-statfs-static.t \
   0600-stdio-static.t \
   0700-unifyfs-stage-full.t \
   9005-unifyfs-unmount.t \
@@ -41,6 +44,7 @@ check_SCRIPTS = \
 if HAVE_GOTCHA
   check_SCRIPTS += \
     0100-sysio-gotcha.t \
+    0110-statfs-gotcha.t \
     0200-stdio-gotcha.t
 endif
 
@@ -59,12 +63,14 @@ libexec_PROGRAMS = \
   common/seg_tree_test.t \
   common/slotmap_test.t \
   std/stdio-static.t \
+  sys/statfs-static.t \
   sys/sysio-static.t \
   unifyfs_unmount.t
 
 if HAVE_GOTCHA
   libexec_PROGRAMS += \
     std/stdio-gotcha.t \
+    sys/statfs-gotcha.t \
     sys/sysio-gotcha.t
 endif
 
@@ -150,6 +156,24 @@ sys_sysio_static_t_SOURCES = \
 sys_sysio_static_t_CPPFLAGS = $(test_cppflags)
 sys_sysio_static_t_LDADD = $(test_wrap_ldadd)
 sys_sysio_static_t_LDFLAGS = $(test_wrap_ldflags)
+
+sys_statfs_gotcha_t_SOURCES = \
+  sys/statfs_suite.h \
+  sys/statfs_suite.c \
+  sys/statfs.c
+
+sys_statfs_gotcha_t_CPPFLAGS = $(test_cppflags)
+sys_statfs_gotcha_t_LDADD = $(test_gotcha_ldadd)
+sys_statfs_gotcha_t_LDFLAGS = $(test_gotcha_ldflags)
+
+sys_statfs_static_t_SOURCES = \
+  sys/statfs_suite.h \
+  sys/statfs_suite.c \
+  sys/statfs.c
+
+sys_statfs_static_t_CPPFLAGS = $(test_cppflags)
+sys_statfs_static_t_LDADD = $(test_wrap_ldadd)
+sys_statfs_static_t_LDFLAGS = $(test_wrap_ldflags)
 
 std_stdio_gotcha_t_SOURCES = \
   std/stdio_suite.h \

--- a/t/sys/statfs.c
+++ b/t/sys/statfs.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2018, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2018, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyFS.
+ * For details, see https://github.com/LLNL/UnifyFS.
+ * Please read https://github.com/LLNL/UnifyFS/LICENSE for full license text.
+ */
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <string.h>
+#include <errno.h>
+#include <linux/limits.h>
+#include "t/lib/tap.h"
+#include "t/lib/testutil.h"
+
+/* for statfs */
+#include <sys/vfs.h>
+
+#include "unifyfs.h"
+
+/* This function contains the tests for UNIFYFS_WRAP(statfs) found in
+ * client/src/unifyfs-sysio.c. */
+int statfs_test(char* unifyfs_root, int expect_unifyfs_magic)
+{
+    /* Diagnostic message for reading and debugging output */
+    diag("Starting UNIFYFS_WRAP(statfs) tests");
+
+    /* We call statfs on the mountpoint. */
+    const char* path = unifyfs_root;
+
+    /* Call statfs and check that we get a 0 return code indicating success. */
+    struct statfs fs;
+    errno = 0;
+    int rc = statfs(path, &fs);
+    int err = errno;
+    ok(rc == 0,
+       "statfs %s (rc=%d, errno=%d): %s",
+       path, rc, err, strerror(err));
+
+    /* If statfs succeeded, check that we get the proper magic value back. */
+    if (rc == 0) {
+        long int fs_magic = fs.f_type;
+        if (expect_unifyfs_magic) {
+            /* In this case, we expect to get UNIFYFS_SUPER_MAGIC. */
+            long int unifyfs_magic = UNIFYFS_SUPER_MAGIC;
+            ok(fs_magic == unifyfs_magic,
+               "checking statfs.f_type %lx against UNIFYFS expected value %lx",
+               fs_magic, unifyfs_magic);
+        } else {
+            /* In this case, we expect to get TMPFS_MAGIC, see "man statfs". */
+            long int tmpfs_magic = 0x01021994;
+            ok(fs_magic == tmpfs_magic,
+               "checking statfs.f_type %lx against TMPFS expected value %lx",
+               fs_magic, tmpfs_magic);
+        }
+    }
+
+    diag("Finished UNIFYFS_WRAP(statfs) tests");
+
+    return 0;
+}

--- a/t/sys/statfs_suite.c
+++ b/t/sys/statfs_suite.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2018, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2018, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyFS.
+ * For details, see https://github.com/LLNL/UnifyFS.
+ * Please read https://github.com/LLNL/UnifyFS/LICENSE for full license text.
+ */
+
+#include <string.h>
+#include <mpi.h>
+#include <unifyfs.h>
+#include "t/lib/tap.h"
+#include "t/lib/testutil.h"
+
+#include "statfs_suite.h"
+
+/* The test suite for statfs wrappers found in client/src/unifyfs-sysio.c.
+ *
+ * This is specifically designed to test stafs when client super magic has
+ * been disabled, so that statfs returns TMPFS_MAGIC. */
+int main(int argc, char* argv[])
+{
+    int rank_num;
+    int rank;
+    char* unifyfs_root;
+    int rc;
+
+    MPI_Init(&argc, &argv);
+    MPI_Comm_size(MPI_COMM_WORLD, &rank_num);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+    plan(NO_PLAN);
+
+    unifyfs_root = testutil_get_mount_point();
+
+    /* Verify unifyfs_mount succeeds. */
+    rc = unifyfs_mount(unifyfs_root, rank, rank_num, 0);
+    ok(rc == 0, "unifyfs_mount(%s) (rc=%d)", unifyfs_root, rc);
+
+    /* If the mount fails, bailout, as there is no point in running the tests */
+    if (rc != 0) {
+        BAIL_OUT("unifyfs_mount in statfs_suite failed");
+    }
+
+    /* check that statfs returns TMPFS_MAGIC
+     * when UNIFYFS_CLIENT_SUPER_MAGIC=0 */
+    statfs_test(unifyfs_root, 0);
+
+    rc = unifyfs_unmount();
+    ok(rc == 0, "unifyfs_unmount(%s) (rc=%d)", unifyfs_root, rc);
+
+    MPI_Finalize();
+
+    done_testing();
+
+    return 0;
+}

--- a/t/sys/statfs_suite.h
+++ b/t/sys/statfs_suite.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2018, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2018, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyFS.
+ * For details, see https://github.com/LLNL/UnifyFS.
+ * Please read https://github.com/LLNL/UnifyFS/LICENSE for full license text.
+ */
+
+
+/* This test checks that statfs returns the correct value when one
+ * has set UNIFYFS_CLIENT_SUPER_MAGIC=0.  It runs as a separate
+ * test suite because it requires a different environmental
+ * configuration than the other tests. */
+#ifndef STATFS_SUITE_H
+#define STATFS_SUITE_H
+
+/* Tests for UNIFYFS_WRAP(statfs) */
+int statfs_test(char* unifyfs_root, int expect_unifyfs_magic);
+
+#endif /* STATFS_SUITE_H */

--- a/t/sys/sysio_suite.c
+++ b/t/sys/sysio_suite.c
@@ -71,6 +71,8 @@ int main(int argc, char* argv[])
      * break as that is likely to cause subsequent failures to start passing.
      */
 
+    statfs_test(unifyfs_root, 1);
+
     creat_close_test(unifyfs_root);
 
     creat64_test(unifyfs_root);

--- a/t/sys/sysio_suite.h
+++ b/t/sys/sysio_suite.h
@@ -30,6 +30,9 @@
 #ifndef SYSIO_SUITE_H
 #define SYSIO_SUITE_H
 
+/* Tests for UNIFYFS_WRAP(statfs) */
+int statfs_test(char* unifyfs_root, int expect_unifyfs_magic);
+
 /* Tests for UNIFYFS_WRAP(creat) and UNIFYFS_WRAP(close) */
 int creat_close_test(char* unifyfs_root);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This defines a ``UNIFYFS_SUPER_MAGIC`` value in ``unifyfs.h``.  The ``statfs`` wrapper returns this value by default in the ``struct statfs f_type`` field.  For clients that query ``statfs`` but do not yet handle a response of ``UNIFYFS_SUPER_MAGIC``, one can configure UnifyFS to return ``TMPFS_MAGIC`` instead by setting ``UNIFYFS_CLIENT_SUPER_MAGIC=0``.

```
UNIFYFS_CLIENT_SUPER_MAGIC=1 -> UNIFYFS_SUPER_MAGIC (default)
UNIFYFS_CLIENT_SUPER_MAGIC=0 -> TMPFS_MAGIC
```

A couple of proposed options for ``UNIFYFS_SUPER_MAGIC``:
```
0x554E4659 spells "UNFY" in ASCII (32-bit)
0x556E696679465321 spells "UnifyFS!" in ASCII (64-bit)
```

Other file system magic values can be seen with ``man statfs``:

```
              ADFS_SUPER_MAGIC      0xadf5
              AFFS_SUPER_MAGIC      0xADFF
              BEFS_SUPER_MAGIC      0x42465331
              BFS_MAGIC             0x1BADFACE
              CIFS_MAGIC_NUMBER     0xFF534D42
              CODA_SUPER_MAGIC      0x73757245
              COH_SUPER_MAGIC       0x012FF7B7
              CRAMFS_MAGIC          0x28cd3d45
              DEVFS_SUPER_MAGIC     0x1373
              EFS_SUPER_MAGIC       0x00414A53
              EXT_SUPER_MAGIC       0x137D
              EXT2_OLD_SUPER_MAGIC  0xEF51
              EXT2_SUPER_MAGIC      0xEF53
              EXT3_SUPER_MAGIC      0xEF53
              EXT4_SUPER_MAGIC      0xEF53
              HFS_SUPER_MAGIC       0x4244
              HPFS_SUPER_MAGIC      0xF995E849
              HUGETLBFS_MAGIC       0x958458f6
              ISOFS_SUPER_MAGIC     0x9660
              JFFS2_SUPER_MAGIC     0x72b6
              JFS_SUPER_MAGIC       0x3153464a
              MINIX_SUPER_MAGIC     0x137F /* orig. minix */
              MINIX_SUPER_MAGIC2    0x138F /* 30 char minix */
              MINIX2_SUPER_MAGIC    0x2468 /* minix V2 */
              MINIX2_SUPER_MAGIC2   0x2478 /* minix V2, 30 char names */
              MSDOS_SUPER_MAGIC     0x4d44
              NCP_SUPER_MAGIC       0x564c
              NFS_SUPER_MAGIC       0x6969
              NTFS_SB_MAGIC         0x5346544e
              OPENPROM_SUPER_MAGIC  0x9fa1
              PROC_SUPER_MAGIC      0x9fa0
              QNX4_SUPER_MAGIC      0x002f
              REISERFS_SUPER_MAGIC  0x52654973
              ROMFS_MAGIC           0x7275
              SMB_SUPER_MAGIC       0x517B
              SYSV2_SUPER_MAGIC     0x012FF7B6
              SYSV4_SUPER_MAGIC     0x012FF7B5
              TMPFS_MAGIC           0x01021994
              UDF_SUPER_MAGIC       0x15013346
              UFS_MAGIC             0x00011954
              USBDEVICE_SUPER_MAGIC 0x9fa2
              VXFS_SUPER_MAGIC      0xa501FCF5
              XENIX_SUPER_MAGIC     0x012FF7B4
              XFS_SUPER_MAGIC       0x58465342
              _XIAFS_SUPER_MAGIC    0x012FD16D
```

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
