### PR TITLE
Fix build issues and create Travis job matrix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -69,9 +69,13 @@ stages:
 .build-template:
   stage: build
   script:
+    - CC_PATH=$($CC_COMMAND)
+    - FC_PATH=$($FC_COMMAND)
+    - GOTCHA_INSTALL=$(spack location -i gotcha %$SPACK_COMPILER arch=$SPACK_ARCH)
+    - SPATH_INSTALL=$(spack location -i spath %$SPACK_COMPILER arch=$SPACK_ARCH)
     - ./autogen.sh
     - mkdir -p unifyfs-build unifyfs-install && cd unifyfs-build
-    - ../configure CC=$CC_PATH FC=$FC_PATH --prefix=${WORKING_DIR}/unifyfs-install --enable-fortran --disable-silent-rules
+    - ../configure CC=$CC_PATH FC=$FC_PATH --prefix=${WORKING_DIR}/unifyfs-install --with-gotcha=$GOTCHA_INSTALL --with-spath=$SPATH_INSTALL --enable-fortran --disable-silent-rules
     - make V=1
     - make V=1 install
   needs: []
@@ -96,7 +100,7 @@ stages:
 .integ-test-template:
   stage: test-integ
   script:
-    - cd t/ci && prove -v RUN_CI_TESTS.sh
+    - cd t/ci && unbuffer prove -v RUN_CI_TESTS.sh
 
 ##### Jobs #####
 
@@ -119,14 +123,13 @@ before_script:
   - which spack || ((cd $HOME/spack && git describe) && . $HOME/spack/share/spack/setup-env.sh)
   - if [[ -d $WORKING_DIR ]]; then cd ${WORKING_DIR}; else export WORKING_DIR=${CI_PROJECT_DIR}; fi
   - module load $COMPILER
-  - CC_PATH=$($CC_COMMAND)
-  - FC_PATH=$($FC_COMMAND)
   - SPACK_COMPILER=${COMPILER//\//@}
   - SPACK_ARCH="$(spack arch -p)-$(spack arch -o)-$(uname -m)"
+  - spack load automake@1.15 %$SPACK_COMPILER arch=$SPACK_ARCH
   - spack load gotcha %$SPACK_COMPILER arch=$SPACK_ARCH
   - spack load argobots %$SPACK_COMPILER arch=$SPACK_ARCH
   - spack load mercury %$SPACK_COMPILER arch=$SPACK_ARCH
-  - spack load margo %$SPACK_COMPILER arch=$SPACK_ARCH
+  - spack load mochi-margo %$SPACK_COMPILER arch=$SPACK_ARCH
   - spack load spath %$SPACK_COMPILER arch=$SPACK_ARCH
 
 # System specific jobs

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,24 +4,81 @@ os: linux
 
 addons:
   apt:
-    update: true
-    packages:
-      - autoconf
-      - autoconf-archive
-      - automake
-      - build-essential
-      - cmake
-      - gfortran
-      - libhdf5-openmpi-dev
-      - libopenmpi-dev
-      - libtool-bin
-      - m4
-      - openmpi-bin
+    packages: &native_deps
+    - autoconf
+    - autoconf-archive
+    - automake
+    - build-essential
+    - cmake
+    - gfortran
+    - libhdf5-openmpi-dev
+    - libopenmpi-dev
+    - libtool-bin
+    - m4
+    - openmpi-bin
+    - pkg-config
+
+jobs:
+  include:
+  - name: "Checkpatch"
+    before_install: skip
+    install: skip
+    before_script:
+      - eval $(./scripts/git_log_test_env.sh)
+      - export TEST_CHECKPATCH_SKIP_FILES
+    script: ./scripts/checkpatch.sh || test "$TEST_CHECKPATCH_ALLOW_FAILURE" = yes
+
+  - name: "GCC 4.9"
+    dist: xenial
+    addons:
+      apt:
+        update: true
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - *native_deps
+        - g++-4.9
+    env:
+      - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+
+  - name: "GCC 7.5"
+    addons:
+      apt:
+        update: true
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - *native_deps
+        - g++-7
+    env:
+      - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+
+  - name: "GCC 9.3"
+    addons:
+      apt:
+        update: true
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - *native_deps
+        - g++-9
+    env:
+      - MATRIX_EVAL="CC=gcc-9 && CXX=g++-9"
+
+  - name: "GCC 10.1"
+    addons:
+      apt:
+        update: true
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - *native_deps
+        - g++-10
+    env:
+      - MATRIX_EVAL="CC=gcc-10 && CXX=g++-10"
 
 before_install:
-  # The default environment variable $CC is known to interfere with
-  # MPI projects.
-  - test -n $CC && unset CC
+  - eval "${MATRIX_EVAL}"
   - echo kernel.yama.ptrace_scope=0 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
   - (cd $HOME/spack; git describe) || git clone https://github.com/spack/spack $HOME/spack
   # Create packages.yaml to prevent building dependencies that time out
@@ -62,16 +119,27 @@ before_install:
         externals:
         - spec: "openmpi@2.1.1"
           prefix: /usr
+      pkg-config:
+        buildable: False
+        externals:
+        - spec: "pkg-config@0.29.1"
+          prefix: /usr
     EOF
 
 install:
   - . $HOME/spack/share/spack/setup-env.sh
   - spack install gotcha@1.0.3 && spack load gotcha@1.0.3
-  - spack install mochi-margo ^libfabric fabrics=rxm,sockets,tcp && spack load argobots && spack load mercury && spack load mochi-margo
-  - spack install spath && spack load spath
+  - spack install mochi-margo ^mercury~boostsys ^libfabric fabrics=rxm,sockets,tcp && spack load argobots && spack load mercury && spack load mochi-margo
+  - spack install spath~mpi && spack load spath
   # prepare build environment
-  - eval $(./scripts/git_log_test_env.sh)
-  - export TEST_CHECKPATCH_SKIP_FILES
+  - GOTCHA_INSTALL=$(spack location -i gotcha)
+  - SPATH_INSTALL=$(spack location -i spath)
+
+script:
+  - export DISTCHECK_CONFIGURE_FLAGS="CC=$CC --with-gotcha=$GOTCHA_INSTALL --with-spath=$SPATH_INSTALL --enable-fortran"
+  - ./autogen.sh
+  - ./configure $DISTCHECK_CONFIGURE_FLAGS
+  - make distcheck V=1
 
 cache:
   directories:
@@ -81,14 +149,6 @@ cache:
 before_cache:
   - rm -f $HOME/spack/opt/spack/.spack-db/prefix_lock
 
-script:
-  # Force git to update the shallow clone and include tags so git-describe works
-  - git fetch --unshallow --tags
-  - export DISTCHECK_CONFIGURE_FLAGS="--enable-fortran"
-  - ./autogen.sh
-  - ./configure $DISTCHECK_CONFIGURE_FLAGS || cat config.log
-  - make distcheck V=1
-  - ./scripts/checkpatch.sh || test "$TEST_CHECKPATCH_ALLOW_FAILURE" = yes
-
 after_failure:
+  - find . -type f -name "config.log" -execdir cat {} \;
   - find . -type f -name "test-suite.log" -execdir cat {} \;

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ see [Build UnifyFS](http://unifyfs.readthedocs.io/en/dev/build.html).
 ## Build Status
 Status of UnifyFS development branch (dev):
 
-[![Build Status](https://api.travis-ci.org/LLNL/UnifyFS.png?branch=dev)](https://travis-ci.org/LLNL/UnifyFS)
+[![Build Status](https://api.travis-ci.com/LLNL/UnifyFS.png?branch=dev)](https://travis-ci.com/LLNL/UnifyFS)
 [![Read the Docs](https://readthedocs.org/projects/unifyfs/badge/?version=dev)](https://unifyfs.readthedocs.io)
 
 ## Contribute and Develop

--- a/client/src/Makefile.am
+++ b/client/src/Makefile.am
@@ -6,19 +6,21 @@ libunifyfsdir = $(includedir)
 if HAVE_GOTCHA
 lib_LTLIBRARIES += libunifyfs_gotcha.la
 libunifyfs_gotchadir = $(includedir)
-endif
 
 if HAVE_FORTRAN
 lib_LTLIBRARIES += libunifyfsf.la
-endif
+endif #HAVE_FORTRAN
+endif #HAVE_GOTCHA
 
 AM_CFLAGS = -Wall -Wno-strict-aliasing -Werror
 
 include_HEADERS = unifyfs.h $(UNIFYFS_COMMON_INSTALL_HDRS)
 
+if HAVE_GOTCHA
 if HAVE_FORTRAN
 include_HEADERS += unifyfsf.h
-endif
+endif #HAVE_FORTRAN
+endif #HAVE_GOTCHA
 
 CLIENT_COMMON_CPPFLAGS = \
   -I$(top_builddir)/client \

--- a/client/src/unifyfs-sysio.c
+++ b/client/src/unifyfs-sysio.c
@@ -246,7 +246,7 @@ static char* _getcwd_impl(char* path, size_t size)
          * that is big enough */
         buf = (char*) malloc(len);
         if (buf != NULL) {
-            strncpy(buf, unifyfs_cwd, len);
+            strlcpy(buf, unifyfs_cwd, len);
         } else {
             errno = ENOMEM;
         }

--- a/client/src/unifyfs.c
+++ b/client/src/unifyfs.c
@@ -924,7 +924,7 @@ int unifyfs_fid_create_file(const char* path)
     unifyfs_filelist[fid].in_use = 1;
 
     /* copy file name into slot */
-    strncpy((void*)&unifyfs_filelist[fid].filename, path, UNIFYFS_MAX_FILENAME);
+    strlcpy((void*)&unifyfs_filelist[fid].filename, path, UNIFYFS_MAX_FILENAME);
     LOGDBG("Filename %s got unifyfs fid %d",
            unifyfs_filelist[fid].filename, fid);
 

--- a/configure.ac
+++ b/configure.ac
@@ -14,7 +14,7 @@ AC_CONFIG_SRCDIR([configure.ac])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIR([m4])
 
-AM_INIT_AUTOMAKE([foreign tar-pax])
+AM_INIT_AUTOMAKE([foreign tar-pax 1.15])
 AM_SILENT_RULES([yes])
 
 AM_MAINTAINER_MODE([disable])
@@ -165,6 +165,12 @@ AS_IF([test "$have_C_mpi" != "yes"],
 # look for gotcha library, sets GOTCHA_INCLUDE, GOTCHA_LIB
 UNIFYFS_AC_GOTCHA
 
+# error out if fortran was enabled but GOTCHA wasn't found
+AM_COND_IF([HAVE_FORTRAN],[
+    AM_COND_IF([HAVE_GOTCHA],[],[
+        AC_MSG_ERROR([gotcha required when fortran is enabled])
+])],[])
+
 # look for spath library, sets SPATH_CFLAGS, SPATH_LDFLAGS, SPATH_LIBS
 UNIFYFS_AC_SPATH
 
@@ -198,7 +204,7 @@ AC_TRY_COMPILE(
 AC_MSG_CHECKING(if linker supports -wrap)
 OLD_LDFLAGS=$LDFLAGS
 LDFLAGS=$LDFLAGS
-LDFLAGS+="-Wl,-wrap,malloc"
+LDFLAGS+=" -Wl,-wrap,malloc"
 AC_LINK_IFELSE([AC_LANG_PROGRAM([[#include <stdlib.h>]],[[void* __wrap_malloc(size_t size);]],[[int *test = malloc(sizeof(int));]])],
 [
     AC_MSG_RESULT([yes])

--- a/docs/build.rst
+++ b/docs/build.rst
@@ -15,7 +15,7 @@ There are three options:
 Build UnifyFS and its dependencies with Spack
 ---------------------------------------------
 
-One may install UnifyFS and its dependencies with `Spack <https://github.com/spack/spack>`_.
+One may install UnifyFS and its dependencies with Spack_.
 If you already have Spack, make sure you have the latest release.
 If you use a clone of the Spack develop branch, be sure to pull the latest changes.
 
@@ -30,8 +30,8 @@ Install Spack
     $ # create a packages.yaml specific to your machine
     $ . spack/share/spack/setup-env.sh
 
-Use Spack's `shell support <https://spack.readthedocs.io/en/latest/getting_started.html#add-spack-to-the-shell>`_
-to add Spack to your ``PATH`` and enable use of the ``spack`` command.
+Use `Spack's shell support`_ to add Spack to your ``PATH`` and enable use of the
+``spack`` command.
 
 Build UnifyFS and its dependencies
 **********************************
@@ -48,24 +48,24 @@ desired, then do ``spack install unifyfs@develop``.
    new variants are added.
 
 Include or remove variants with Spack when installing UnifyFS when a custom
-build is desired. Type ``spack info unifyfs`` for more info.
+build is desired. Run ``spack info unifyfs`` for more info.
 
 .. table:: UnifyFS Build Variants
    :widths: auto
 
-   ==========  ========================================  ===========================
-      Variant  Command                                   Description
-   ==========  ========================================  ===========================
-   Auto-mount  ``spack install unifyfs+auto-mount``      Enable transparent mounting
-   HDF5        ``spack install unifyfs+hdf5``            Build with parallel HDF5
+   ==========  =============================  =======  ===========================
+      Variant  Command                        Default  Description
+               (``spack install <package>``)
+   ==========  =============================  =======  ===========================
+   Auto-mount  ``unifyfs+auto-mount``         True     Enable transparent mounting
+   HDF5        ``unifyfs+hdf5``               False    Build with parallel HDF5
 
-               ``spack install unifyfs+hdf5 ^hdf5~mpi``  Build with serial HDF5
-   Fortran     ``spack install unifyfs+fortran``         Enable Fortran support
-   MDHIM       ``spack install unifyfs+mdhim``           Enable MDHIM build options
-   PMI         ``spack install unifyfs+pmi``             Enable PMI2 support
-   PMIx        ``spack install unifyfs+pmix``            Enable PMIx support
-   spath       ``spack install unifyfs+spath``           Normalize relative paths
-   ==========  ========================================  ===========================
+               ``unifyfs+hdf5 ^hdf5~mpi``     False    Build with serial HDF5
+   Fortran     ``unifyfs+fortran``            False    Enable Fortran support
+   PMI         ``unifyfs+pmi``                False    Enable PMI2 support
+   PMIx        ``unifyfs+pmix``               False    Enable PMIx support
+   spath       ``unifyfs+spath``              True     Normalize relative paths
+   ==========  =============================  =======  ===========================
 
 .. attention::
 
@@ -74,8 +74,8 @@ build is desired. Type ``spack info unifyfs`` for more info.
     any dependencies of dependencies (cmake, perl, etc.) if you don't already
     have these dependencies installed through Spack or haven't told Spack where
     they are locally installed on your system (i.e., through a custom
-    `packages.yaml <https://spack.readthedocs.io/en/latest/build_settings.html#external-packages>`_).
-    Type ``spack spec -I unifyfs`` before installing to see what Spack is going
+    packages.yaml_).
+    Run ``spack spec -I unifyfs`` before installing to see what Spack is going
     to do.
 
 ---------------------------
@@ -88,9 +88,7 @@ One can install the UnifyFS dependencies with Spack and build UnifyFS
 with autotools.
 This is useful if one needs to modify the UnifyFS source code
 between builds.
-Take advantage of
-`Spack Environments <https://spack.readthedocs.io/en/latest/environments.html>`_
-to streamline this process.
+Take advantage of `Spack Environments`_ to streamline this process.
 
 .. _spack-build-label:
 
@@ -103,24 +101,25 @@ the UnifyFS dependencies can then be installed.
 .. code-block:: Bash
 
     $ spack install gotcha
-    $ spack install margo ^mercury+bmi
+    $ spack install mochi-margo ^libfabric fabrics=rxm,sockets,tcp
+    $ spack install spath~mpi
 
 .. tip::
 
-    You can use ``spack install --only=dependencies unifyfs`` to install all
+    You can run ``spack install --only=dependencies unifyfs`` to install all
     UnifyFS dependencies without installing UnifyFS.
 
     Keep in mind this will also install all the build dependencies and
     dependencies of dependencies if you haven't already installed them through
     Spack or told Spack where they are locally installed on your system via a
-    `packages.yaml <https://spack.readthedocs.io/en/latest/build_settings.html#external-packages>`_.
+    packages.yaml_.
 
 Build UnifyFS
 *************
 
-Download the latest UnifyFS release from the `Releases
-<https://github.com/LLNL/UnifyFS/releases>`_ page or clone the develop branch
-from the UnifyFS repository `https://github.com/LLNL/UnifyFS <https://github.com/LLNL/UnifyFS>`_.
+Download the latest UnifyFS release from the Releases_ page or clone the develop
+branch from the UnifyFS repository
+`https://github.com/LLNL/UnifyFS <https://github.com/LLNL/UnifyFS>`_.
 
 Load the dependencies into your environment and then
 configure and build UnifyFS from its source code directory.
@@ -128,14 +127,28 @@ configure and build UnifyFS from its source code directory.
 .. code-block:: Bash
 
     $ spack load gotcha
-    $ spack load mercury
     $ spack load argobots
-    $ spack load margo
+    $ spack load mercury
+    $ spack load mochi-margo
+    $ spack load spath
     $
     $ ./autogen.sh
-    $ ./configure --prefix=/path/to/install
+    $ ./configure --prefix=/path/to/install --with-gotcha=${gotcha_install} --with-spath=${spath_install}
     $ make
     $ make install
+
+Alternatively, UnifyFS can be configured using ``CPPFLAGS`` and ``LDFLAGS``:
+
+.. code-block:: Bash
+
+    $ ./configure --prefix=/path/to/install CPPFLAGS="-I${gotcha_install}/include -I{spath_install}/include" LDFLAGS="-L${gotcha_install}/lib64 -L${spath_install}/lib64
+
+.. admonition:: Spack package install location
+
+    The location where Spack installs any given package can be retrieved by
+    running ``spack location -i <package_name>``.
+
+    E.g.: ``gotcha_install=$(spack location -i gotcha)``
 
 To see all available build configuration options, run ``./configure --help``
 after ``./autogen.sh`` has been run.
@@ -146,9 +159,9 @@ after ``./autogen.sh`` has been run.
 Build dependencies with bootstrap and build UnifyFS with autotools
 ------------------------------------------------------------------
 
-Download the latest UnifyFS release from the `Releases
-<https://github.com/LLNL/UnifyFS/releases>`_ page or clone the develop branch
-from the UnifyFS repository `https://github.com/LLNL/UnifyFS <https://github.com/LLNL/UnifyFS>`_.
+Download the latest UnifyFS release from the Releases_ page or clone the develop
+branch from the UnifyFS repository
+`https://github.com/LLNL/UnifyFS <https://github.com/LLNL/UnifyFS>`_.
 
 Build the Dependencies
 **********************
@@ -156,9 +169,9 @@ Build the Dependencies
 UnifyFS requires MPI, GOTCHA, Margo and OpenSSL.
 References to these dependencies can be found on our :doc:`dependencies` page.
 
-A `bootstrap.sh <https://github.com/LLNL/UnifyFS/blob/dev/bootstrap.sh>`_ script
-in the UnifyFS source distribution downloads and installs all dependencies.
-Simply run the script in the top level directory of the source code.
+A bootstrap.sh_ script in the UnifyFS source distribution downloads and installs
+all dependencies.  Simply run the script in the top level directory of the
+source code.
 
 .. code-block:: Bash
 
@@ -181,11 +194,18 @@ As an example, the commands may look like:
 
 .. code-block:: Bash
 
-    $ export PKG_CONFIG_PATH=path/to/mercury/lib/pkgconfig:path/to/argobots/lib/pkgconfig:path/to/margo/lib/pkgconfig
+    $ export PKG_CONFIG_PATH=$INSTALL_DIR/lib/pkgconfig:$INSTALL_DIR/lib64/pkgconfig:$PKG_CONFIG_PATH
+    $ export LD_LIBRARY_PATH=$INSTALL_DIR/lib:$INSTALL_DIR/lib64:$LD_LIBRARY_PATH
     $ ./autogen.sh
-    $ ./configure --prefix=/path/to/install --with-gotcha=/path/to/gotcha
+    $ ./configure --prefix=/path/to/install CPPFLAGS=-I/path/to/install/include LDFLAGS="-L/path/to/install/lib -L/path/to/install/lib64"
     $ make
     $ make install
+
+Alternatively, UnifyFS can be configured using ``--with`` options:
+
+.. code-block:: Bash
+
+    $ ./configure --prefix=/path/to/install --with-gotcha=$INSTALL_DIR --with-spath=$INSTALL_DIR
 
 To see all available build configuration options, run ``./configure --help``
 after ``./autogen.sh`` has been run.
@@ -204,11 +224,12 @@ Fortran
 
 To use UnifyFS in Fortran applications, pass the ``--enable-fortran``
 option to configure. Note that only GCC Fortran (i.e., gfortran) is known to
-work with UnifyFS. There is an open
-`ifort_issue <https://github.com/LLNL/UnifyFS/issues/300>`_ with the Intel
-Fortran compiler as well as an
-`xlf_issue <https://github.com/LLNL/UnifyFS/issues/304>`_ with the IBM Fortran
-compiler.
+work with UnifyFS. There is an open ifort_issue_ with the Intel Fortran compiler
+as well as an xlf_issue_ with the IBM Fortran compiler.
+
+.. note::
+
+    UnifyFS requires GOTCHA when Fortran support is enabled
 
 GOTCHA
 ******
@@ -219,21 +240,18 @@ you can omit it during UnifyFS configuration by using the ``--without-gotcha``
 configure option. Without GOTCHA, static linker wrapping is required for I/O
 interception, see :doc:`link`.
 
+.. warning::
+
+    UnifyFS requires GOTCHA for dynamic I/O interception of MPI-IO functions. If
+    UnifyFS is configured using ``--without-gotcha``, support will be lost for
+    MPI-IO (and as a result, HDF5) applications.
+
 HDF5
 ****
 
 UnifyFS includes example programs that use HDF5. If HDF5 is not available on
 your target system, it can be omitted during UnifyFS configuration by using
 the ``--without-hdf5`` configure option.
-
-MDHIM
-*****
-
-Previous MDHIM-based support for file operations can be selected at configure
-time using the ``--enable-mdhim`` option. Using this option requires LevelDB as
-a dependency. Provide the path to your LevelDB install at configure time with
-the ``--with-leveldb=/path/to/leveldb`` option. Note that this may not
-currently be in a usable state.
 
 PMI2/PMIx Key-Value Store
 *************************
@@ -242,6 +260,15 @@ When available, UnifyFS uses the distributed key-value store capabilities
 provided by either PMI2 or PMIx. To enable this support, pass either
 the ``--enable-pmi`` or ``--enable-pmix`` option to configure. Without
 PMI support, a distributed file system accessible to all servers is required.
+
+SPATH
+******
+
+The spath library can be optionally used to normalize relative paths (e.g., ones
+containing ".", "..", and extra or trailing "/") and enable the support of using
+relative paths within an application. To enable, use the ``--with-spath``
+configure option or provide the appropriate ``CPPFLAGS`` and ``LDFLAGS`` at
+configure time.
 
 Transparent Mounting for MPI Applications
 *****************************************
@@ -254,3 +281,14 @@ the namespace mountpoint. To enable transparent mounting, use the
 ``--enable-mpi-mount`` configure option.
 
 ---------------------------
+
+.. explicit external hyperlink targets
+
+.. _bootstrap.sh: https://github.com/LLNL/UnifyFS/blob/dev/bootstrap.sh
+.. _ifort_issue: https://github.com/LLNL/UnifyFS/issues/300
+.. _Releases: https://github.com/LLNL/UnifyFS/releases
+.. _Spack: https://github.com/spack/spack
+.. _Spack Environments: https://spack.readthedocs.io/en/latest/environments.html
+.. _Spack's shell support: https://spack.readthedocs.io/en/latest/getting_started.html#add-spack-to-the-shell
+.. _packages.yaml: https://spack.readthedocs.io/en/latest/build_settings.html#external-packages
+.. _xlf_issue: https://github.com/LLNL/UnifyFS/issues/304

--- a/docs/dependencies.rst
+++ b/docs/dependencies.rst
@@ -10,12 +10,14 @@ Required
 
 - `GOTCHA <https://github.com/LLNL/GOTCHA/releases>`_ version 1.0.3
 
-- `Margo <https://xgitlab.cels.anl.gov/sds/margo>`_ version 0.4.3 and its dependencies:
+- `Margo <https://github.com/mochi-hpc/mochi-margo/releases>`_ version 0.9.1 and its dependencies:
 
-  - `Argobots <https://github.com/pmodels/argobots/releases/tag/v1.0>`_ version 1.0
-  - `Mercury <https://github.com/mercury-hpc/mercury/releases/tag/v1.0.1>`_ version 1.0.1
+  - `Argobots <https://github.com/pmodels/argobots/releases/tag/v1.0.1>`_ version 1.0.1
+  - `Mercury <https://github.com/mercury-hpc/mercury/releases/tag/v2.0.0>`_ version 2.0.0
 
-    - `bmi <https://xgitlab.cels.anl.gov/sds/bmi.git>`_
+    - `libfabric <https://github.com/ofiwg/libfabric>`_ and/or `bmi <https://github.com/radix-io/bmi/>`_
+
+  - `JSON-C <https://github.com/json-c/json-c>`_
 
 - `OpenSSL <https://www.openssl.org/source/>`_
 
@@ -30,8 +32,5 @@ Required
 --------
 Optional
 --------
-
-- `leveldb <https://github.com/google/leveldb/releases/tag/1.22>`_ version 1.22
-  needed when building with ``--enable-mdhim`` configure option
 
 - `spath <https://github.com/ecp-veloc/spath>`_ for normalizing relative paths

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -410,7 +410,7 @@ To run any of these examples manually, refer to the :doc:`examples`
 documentation.
 
 The UnifyFS examples_ are also being used as integration tests with
-continuous integration tools such as Bamboo_ or GitLab_.
+continuous integration tools such as Bamboo_ or `GitLab CI`_.
 
 ------------
 
@@ -419,7 +419,7 @@ Integration Tests
 -----------------
 
 The UnifyFS examples_ are being used as integration tests with continuation
-integration tools such as Bamboo_ or GitLab_.
+integration tools such as Bamboo_ or `GitLab CI`_.
 
 To run any of these examples manually, refer to the :doc:`examples`
 documentation.
@@ -1002,7 +1002,7 @@ comments in `t/ci/ci-functions.sh`_.
 .. explicit external hyperlink targets
 
 .. _Bamboo: https://www.atlassian.com/software/bamboo
-.. _GitLab: https://about.gitlab.com
+.. _GitLab CI: https://about.gitlab.com
 .. _examples: https://github.com/LLNL/UnifyFS/tree/dev/examples/src
 .. _libtap library: https://github.com/zorgnax/libtap
 .. _libtap README: https://github.com/zorgnax/libtap/blob/master/README.md

--- a/examples/src/Makefile.am
+++ b/examples/src/Makefile.am
@@ -57,18 +57,18 @@ if HAVE_GOTCHA
     chmod-gotcha \
     multi-write-gotcha \
     read-data-gotcha
-endif
+
+if HAVE_HDF5
+  libexec_PROGRAMS += \
+    app-hdf5-create-gotcha \
+    app-hdf5-writeread-gotcha
+endif #HAVE_HDF5
 
 if HAVE_FORTRAN
 libexec_PROGRAMS += \
   writeread-ftn
-endif
-
-if HAVE_HDF5
-libexec_PROGRAMS += \
-  app-hdf5-create-gotcha \
-  app-hdf5-writeread-gotcha
-endif
+endif #HAVE_FORTRAN
+endif #HAVE_GOTCHA
 
 CLEANFILES = $(libexec_PROGRAMS)
 

--- a/m4/spath.m4
+++ b/m4/spath.m4
@@ -1,4 +1,18 @@
 AC_DEFUN([UNIFYFS_AC_SPATH], [
+
+  AC_ARG_WITH([spath], [AS_HELP_STRING([--with-spath=PATH],
+    [path to installed libspath [default=/usr/local]])],
+    [],
+    [with_spath=no]
+  )
+
+  AS_IF([test x$with_spath != xno],
+    [
+      CPPFLAGS="-I${withval}/include ${CPPFLAGS}"
+      LDFLAGS="-L${withval}/lib -L${withval}/lib64 ${LDFLAGS}"
+    ]
+  )
+
   AC_CHECK_LIB([spath], [spath_strdup_reduce_str],
     [
       LIBS="$LIBS -lspath"

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -3,41 +3,52 @@ SUBDIRS = lib
 TEST_EXTENSIONS = .t
 T_LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) $(top_srcdir)/t/tap-driver.sh
 
+# Order matters
 TESTS = \
-	0001-setup.t \
-	0100-sysio-gotcha.t \
-	0200-stdio-gotcha.t \
-	0500-sysio-static.t \
-	0600-stdio-static.t \
-	0700-unifyfs-stage-full.t \
-	9005-unifyfs-unmount.t \
-	9010-stop-unifyfsd.t \
-	9020-mountpoint-empty.t \
-	9200-seg-tree-test.t \
-	9201-slotmap-test.t \
-	9300-unifyfs-stage-isolated.t \
-	9999-cleanup.t
+  0001-setup.t
+
+if HAVE_GOTCHA
+  TESTS += \
+    0100-sysio-gotcha.t \
+    0200-stdio-gotcha.t
+endif
+
+TESTS += \
+  0500-sysio-static.t \
+  0600-stdio-static.t \
+  0700-unifyfs-stage-full.t \
+  9005-unifyfs-unmount.t \
+  9010-stop-unifyfsd.t \
+  9020-mountpoint-empty.t \
+  9200-seg-tree-test.t \
+  9201-slotmap-test.t \
+  9300-unifyfs-stage-isolated.t \
+  9999-cleanup.t
 
 check_SCRIPTS = \
-	0001-setup.t \
-	0100-sysio-gotcha.t \
-	0200-stdio-gotcha.t \
-	0500-sysio-static.t \
-	0600-stdio-static.t \
-	0700-unifyfs-stage-full.t \
-	9005-unifyfs-unmount.t \
-	9010-stop-unifyfsd.t \
-	9020-mountpoint-empty.t \
-	9200-seg-tree-test.t \
-	9201-slotmap-test.t \
-	9300-unifyfs-stage-isolated.t \
-	9999-cleanup.t
+  0001-setup.t \
+  0500-sysio-static.t \
+  0600-stdio-static.t \
+  0700-unifyfs-stage-full.t \
+  9005-unifyfs-unmount.t \
+  9010-stop-unifyfsd.t \
+  9020-mountpoint-empty.t \
+  9200-seg-tree-test.t \
+  9201-slotmap-test.t \
+  9300-unifyfs-stage-isolated.t \
+  9999-cleanup.t
+
+if HAVE_GOTCHA
+  check_SCRIPTS += \
+    0100-sysio-gotcha.t \
+    0200-stdio-gotcha.t
+endif
 
 EXTRA_DIST = \
-	$(check_SCRIPTS) \
-	sharness.d \
-	sharness.sh \
-	tap-driver.sh
+  $(check_SCRIPTS) \
+  sharness.d \
+  sharness.sh \
+  tap-driver.sh
 
 AM_CFLAGS = -Wall -Werror
 
@@ -45,113 +56,120 @@ clean-local:
 	rm -fr trash-directory.* test-results *.log test_run_env.sh
 
 libexec_PROGRAMS = \
-	common/seg_tree_test.t \
-	common/slotmap_test.t \
-	std/stdio-gotcha.t \
-	std/stdio-static.t \
-	sys/sysio-gotcha.t \
-	sys/sysio-static.t \
-	unifyfs_unmount.t
+  common/seg_tree_test.t \
+  common/slotmap_test.t \
+  std/stdio-static.t \
+  sys/sysio-static.t \
+  unifyfs_unmount.t
 
+if HAVE_GOTCHA
+  libexec_PROGRAMS += \
+    std/stdio-gotcha.t \
+    sys/sysio-gotcha.t
+endif
 
 test_common_ldadd = \
-	$(top_builddir)/t/lib/libtap.la \
-	$(top_builddir)/t/lib/libtestutil.la
+  $(top_builddir)/t/lib/libtap.la \
+  $(top_builddir)/t/lib/libtestutil.la
 
 test_common_ldflags = \
-	$(AM_LDFLAGS) \
-	-static -lpthread
+  $(AM_LDFLAGS) \
+  -static -lpthread
 
 test_gotcha_ldadd = \
-	$(top_builddir)/t/lib/libtap.la \
-	$(top_builddir)/t/lib/libtestutil.la \
-	$(top_builddir)/client/src/libunifyfs_gotcha.la
+  $(top_builddir)/t/lib/libtap.la \
+  $(top_builddir)/t/lib/libtestutil.la \
+  $(top_builddir)/client/src/libunifyfs_gotcha.la
 
 test_gotcha_ldflags = \
-	$(AM_LDFLAGS)\
-	$(MPI_CLDFLAGS)
+  $(AM_LDFLAGS)\
+  $(MPI_CLDFLAGS)
 
 test_wrap_ldadd = \
-	$(top_builddir)/t/lib/libtap.la \
-	$(top_builddir)/t/lib/libtestutil.la \
-	$(top_builddir)/client/src/libunifyfs.la
+  $(top_builddir)/t/lib/libtap.la \
+  $(top_builddir)/t/lib/libtestutil.la \
+  $(top_builddir)/client/src/libunifyfs.la
 
 test_wrap_ldflags = \
-	$(AM_LDFLAGS) \
-	$(MPI_CLDFLAGS) \
-	$(CP_WRAPPERS) \
-	-static
+  $(AM_LDFLAGS) \
+  $(MPI_CLDFLAGS) \
+  $(CP_WRAPPERS) \
+  -static
 
 test_common_cppflags = \
-	-I$(top_srcdir) \
-	-I$(top_srcdir)/common/src \
-	-D_GNU_SOURCE \
-	$(AM_CPPFLAGS)
+  -I$(top_srcdir) \
+  -I$(top_srcdir)/common/src \
+  -D_GNU_SOURCE \
+  $(AM_CPPFLAGS)
 
 test_cppflags = \
-	-I$(top_srcdir) \
-	-I$(top_srcdir)/client/src \
-	-I$(top_srcdir)/common/src \
-	-D_GNU_SOURCE \
-	$(AM_CPPFLAGS) \
-	$(MPI_CFLAGS)
+  -I$(top_srcdir) \
+  -I$(top_srcdir)/client/src \
+  -I$(top_srcdir)/common/src \
+  -D_GNU_SOURCE \
+  $(AM_CPPFLAGS) \
+  $(MPI_CFLAGS)
 
 
-sys_sysio_gotcha_t_SOURCES = sys/sysio_suite.h \
-                             sys/sysio_suite.c \
-                             sys/creat-close.c \
-                             sys/creat64.c \
-                             sys/mkdir-rmdir.c \
-                             sys/open.c \
-                             sys/open64.c \
-                             sys/lseek.c \
-                             sys/write-read.c \
-                             sys/write-read-hole.c \
-                             sys/truncate.c \
-                             sys/unlink.c \
-                             sys/chdir.c
+sys_sysio_gotcha_t_SOURCES = \
+  sys/sysio_suite.h \
+  sys/sysio_suite.c \
+  sys/creat-close.c \
+  sys/creat64.c \
+  sys/mkdir-rmdir.c \
+  sys/open.c \
+  sys/open64.c \
+  sys/lseek.c \
+  sys/write-read.c \
+  sys/write-read-hole.c \
+  sys/truncate.c \
+  sys/unlink.c \
+  sys/chdir.c
 
 sys_sysio_gotcha_t_CPPFLAGS = $(test_cppflags)
 sys_sysio_gotcha_t_LDADD = $(test_gotcha_ldadd)
 sys_sysio_gotcha_t_LDFLAGS = $(test_gotcha_ldflags)
 
-sys_sysio_static_t_SOURCES = sys/sysio_suite.h \
-                             sys/sysio_suite.c \
-                             sys/creat-close.c \
-                             sys/creat64.c \
-                             sys/mkdir-rmdir.c \
-                             sys/open.c \
-                             sys/open64.c \
-                             sys/lseek.c \
-                             sys/write-read.c \
-                             sys/write-read-hole.c \
-                             sys/truncate.c \
-                             sys/unlink.c \
-                             sys/chdir.c
+sys_sysio_static_t_SOURCES = \
+  sys/sysio_suite.h \
+  sys/sysio_suite.c \
+  sys/creat-close.c \
+  sys/creat64.c \
+  sys/mkdir-rmdir.c \
+  sys/open.c \
+  sys/open64.c \
+  sys/lseek.c \
+  sys/write-read.c \
+  sys/write-read-hole.c \
+  sys/truncate.c \
+  sys/unlink.c \
+  sys/chdir.c
 
 sys_sysio_static_t_CPPFLAGS = $(test_cppflags)
 sys_sysio_static_t_LDADD = $(test_wrap_ldadd)
 sys_sysio_static_t_LDFLAGS = $(test_wrap_ldflags)
 
-std_stdio_gotcha_t_SOURCES = std/stdio_suite.h \
-                             std/stdio_suite.c \
-                             std/fopen-fclose.c \
-                             std/fseek-ftell.c \
-                             std/fwrite-fread.c \
-                             std/fflush.c \
-                             std/size.c
+std_stdio_gotcha_t_SOURCES = \
+  std/stdio_suite.h \
+  std/stdio_suite.c \
+  std/fopen-fclose.c \
+  std/fseek-ftell.c \
+  std/fwrite-fread.c \
+  std/fflush.c \
+  std/size.c
 
 std_stdio_gotcha_t_CPPFLAGS = $(test_cppflags)
 std_stdio_gotcha_t_LDADD = $(test_gotcha_ldadd)
 std_stdio_gotcha_t_LDFLAGS = $(test_gotcha_ldflags)
 
-std_stdio_static_t_SOURCES = std/stdio_suite.h \
-                             std/stdio_suite.c \
-                             std/fopen-fclose.c \
-                             std/fseek-ftell.c \
-                             std/fwrite-fread.c \
-                             std/fflush.c \
-                             std/size.c
+std_stdio_static_t_SOURCES = \
+  std/stdio_suite.h \
+  std/stdio_suite.c \
+  std/fopen-fclose.c \
+  std/fseek-ftell.c \
+  std/fwrite-fread.c \
+  std/fflush.c \
+  std/size.c
 
 std_stdio_static_t_CPPFLAGS = $(test_cppflags)
 std_stdio_static_t_LDADD = $(test_wrap_ldadd)

--- a/t/sys/chdir.c
+++ b/t/sys/chdir.c
@@ -25,6 +25,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <dirent.h>
+#include "config.h"
 #include "t/lib/tap.h"
 #include "t/lib/testutil.h"
 
@@ -163,6 +164,7 @@ int chdir_test(char* unifyfs_root)
        "%s:%d getcwd returned %s expected %s",
        __FILE__, __LINE__, str, buf);
 
+#ifdef HAVE_SPATH
     /* change back to root unifyfs directory */
     errno = 0;
     rc = chdir("..");
@@ -213,7 +215,10 @@ int chdir_test(char* unifyfs_root)
     is(str, buf2,
        "%s:%d getcwd returned %s expected %s",
        __FILE__, __LINE__, str, buf2);
-
+#else
+    skip(1, 9, "test requires missing spath dependency");
+    end_skip;
+#endif /* HAVE_SPATH */
 
 /* TODO: Some compilers throw a warning/error if one uses getwd().
  * For those compilers that allow it, it would be nice to execute
@@ -348,6 +353,7 @@ int chdir_test(char* unifyfs_root)
         free(str);
     }
 
+#ifdef HAVE_SPATH
     /* change back to root unifyfs directory */
     errno = 0;
     rc = chdir("..");
@@ -387,6 +393,10 @@ int chdir_test(char* unifyfs_root)
     if (str != NULL) {
         free(str);
     }
+#else
+    skip(1, 6, "test requires missing spath dependency");
+    end_skip;
+#endif /* HAVE_SPATH */
 
 
 /* TODO: Our directory wrappers are not fully functioning yet,


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->

Adjust UnifyFS to build and test properly with or without GOTCHA
- Adjust examples/src/Makefile.am to not build HDF5 examples when
  GOTCHA is unavailable
- Fix configure.ac -wrap test that fails when providing additional
  LDFLAGS during build
- Adjust t/Makefile.am to omit GOTCHA unit tests when building without
  GOTCHA
- Fix indentation issues in t/Makefile.am causing conditionals to be
  missed and always treated as "false" when building with GOTCHA

Fix build with Fortran and without GOTCHA
- Adjust client/src/Makefile.am and examples/src/Makefile.am to embed
  the `HAVE_FORTRAN` section within the `HAVE_GOTCHA` section
- Set configure to fail when attempting to build with Fortran enabled
  but GOTCHA wasn't found
- The latter two enforces the requirement of GOTCHA when enabling
  Fortran support

Add spath config option
- Create a simple --with-spath config option so users can configure using
  only "--with" options (need for distcheck), only CPPFLAGS/LDFLAGS, or both
- Skip unit tests that require spath when missing spath dependency

Note: Having "--with" options allows continued use of `distcheck` in
Travis, as `DISTCHECK_CONFIGURE_FLAGS` doesn't work with quotes
inside of options (e.g., multiple CPPFLAGS/LDFLAGS)

Set up jobs matrix in .travis.yml to test on different compilers (can see it [here](https://travis-ci.com/github/LLNL/UnifyFS/builds/219825383))
- Create CI jobs to build and test on GCC 4.9, 7.5, 9.3 and 10.1
- Pull syntax checker out into separate CI job so it only runs once
  and passes/fails independently of the different compiler builds
- Fix errors on new compilers
  - Fixes Spack issue that was patched for latest release (https://github.com/spack/spack/issues/21983)
  - Fixes issue #609
- Adjust configure to take GOTCHA and SPATH paths (or CPPFLAGS/LDFLAGS)
  to account for recent Spack change
  - Couldn't set Travis to always use latest Spack release as it
    still has much older version of the packages (e.g.,`margo@0.4.3`)

Update docs
- Update build docs
- Note GOTCHA requirement when enabling Fortran
- Add spath option to config sections
- Warn users of MPI-IO and HDF5 support loss when not using GOTCHA
- Update Margo dependency to v0.9.1
- Update Travis CI urls in README

Additional
- Set min `automake` version to 1.15

### Updated
Update bootstrap.sh
- Update urls for migrated repos (mochi-margo and bmi)
- Set Margo version to v0.9.1
- Remove old Mercury cmake options
- Add `-std=gnu99` cflags to margo configure if gcc is older than v5.x
- Update exports printed at end

Update .gitlab-ci.yml
- change loaded dependencies in `before_script`
- move envars only needed for `build` stage out of global `before_script`
- update `configure` line to account for build fixes
- unbuffer integration testing output in Gitlab CI web interface to avoid timeouts

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
### Updated
- Fixes: #608
- Fixes: #609 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
- Locally using all combinations of `--enable/disable-fortran`,
`--with/without-gotcha`, and `--with/without-spath`.
- On multiple GCC compiler versions in our new Travis jobs matrix

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Testing (addition of new tests or update to current tests)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
