### PR TITLE
test remove expect test fail

### DIFF
--- a/t/0700-unifyfs-stage-full.t
+++ b/t/0700-unifyfs-stage-full.t
@@ -58,7 +58,7 @@ test_expect_success "input file has been staged to output" '
 '
 
 test_expect_success "final output is identical to initial input" '
-    test_might_fail test_cmp ${UNIFYFS_TEST_TMPDIR}/stage_source/source_0700.file ${UNIFYFS_TEST_TMPDIR}/stage_destination_0700/destination_0700.file
+    test_cmp ${UNIFYFS_TEST_TMPDIR}/stage_source/source_0700.file ${UNIFYFS_TEST_TMPDIR}/stage_destination_0700/destination_0700.file
 '
 
 test_done


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Removes from test_might_fail from t/0700 script.  

### Description
<!--- Describe your changes in detail -->
This branch removes the test_might_fail from the last test of
t/0700-unifyfs-stage-full.t.  We will initially see if in the current
version of the sharness setup this is still needed.

If that works, we'll just submit this as is.  If not, we'll use
this branch to work out the problems, and then commit it when
it works.

This has not been tested; the PR being tested by
Travis IS the test.  

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted.
