### PR TITLE
Fix: bootstrap space issue 618

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -268,7 +268,7 @@ echo -n "  export LD_LIBRARY_PATH=$INSTALL_DIR/lib:$INSTALL_DIR/lib64:"
 echo "\$LD_LIBRARY_PATH"
 
 echo "  ./autogen.sh"
-echo -n "  ./configure --prefix=$INSTALL_DIR CPPFLAGS=-I$INSTALL_DIR/include"
+echo -n "  ./configure --prefix=$INSTALL_DIR CPPFLAGS=-I$INSTALL_DIR/include "
 echo "LDFLAGS=\"-L$INSTALL_DIR/lib -L$INSTALL_DIR/lib64\""
 echo "  make && make install"
 echo ""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
This fixes the spacing issue that shows up at the end of the bootstrap script when printing out the information to install UnifyFS.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes: #618

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Ran the commands at the end of `bootstrap.sh` and observed the output.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
