### PR TITLE
Include sys/sysmacros.h in testlib.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -65,6 +65,7 @@ AC_CHECK_HEADERS([fcntl.h inttypes.h libgen.h limits.h mntent.h strings.h syslog
 AC_CHECK_HEADERS([wchar.h wctype.h])
 AC_CHECK_HEADERS([sys/mount.h sys/socket.h sys/statfs.h sys/time.h])
 AC_CHECK_HEADERS([arpa/inet.h netdb.h netinet/in.h])
+AC_CHECK_HEADER([sys/sysmacros.h], [], AC_MSG_ERROR([cannot find required header sys/sysmacros.h]))
 
 # Checks for library functions.
 AC_FUNC_MALLOC

--- a/examples/src/testlib.h
+++ b/examples/src/testlib.h
@@ -24,6 +24,7 @@
 #include <sys/time.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <unistd.h>
 #include <time.h>
 #include <mpi.h>


### PR DESCRIPTION
In recent Linux systems, major() and minor() are defined in
sys/sysmacros.h and sys/types.h no longer includes sys/sysmacros.h.  So,
we need to include sys/sysmacros.h in testlib.h.

Also adds a check for the existence of sys/sysmacros.h in configure.ac.

### Description
This is a very simple change: two files with a single line each.
Include sys/sysmacros.h in testlib.h and add an AC_CHECK_HEADER line to configure.ac.

### Motivation and Context
See issue #620 

### How Has This Been Tested?
Without this change, builds fail on some newer Linux systems (such as Ubuntu 20.04).  With this change, the build succeeds on Ubuntu 20.04.
Also, with this change, all the unit tests (ie: make check in the 't' directory) still either pass or are skipped.  (No fails, no errors.)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
