### PR TITLE
Bugfix and enable use of unifyfs-stage with MPI mount

### DIFF
--- a/util/unifyfs-stage/src/Makefile.am
+++ b/util/unifyfs-stage/src/Makefile.am
@@ -5,10 +5,16 @@ unifyfs_stage_SOURCES = unifyfs-stage.c \
 
 noinst_HEADERS = unifyfs-stage.h
 
-unifyfs_stage_CPPFLAGS = $(AM_CPPFLAGS) $(MPI_CFLAGS) \
-                         $(OPENSSL_CFLAGS) \
-                         -I$(top_srcdir)/client/src \
-                         -I$(top_srcdir)/common/src
+stage_cppflags = $(AM_CPPFLAGS) $(MPI_CFLAGS) \
+   $(OPENSSL_CFLAGS) \
+   -I$(top_srcdir)/client/src \
+   -I$(top_srcdir)/common/src
+
+if USE_PMPI_WRAPPERS
+stage_cppflags += -DENABLE_MPI_MOUNT
+endif
+
+unifyfs_stage_CPPFLAGS = $(stage_cppflags)
 
 unifyfs_stage_LDADD = $(top_builddir)/client/src/libunifyfs.la -lrt -lm
 

--- a/util/unifyfs-stage/src/unifyfs-stage.c
+++ b/util/unifyfs-stage/src/unifyfs-stage.c
@@ -270,6 +270,10 @@ int main(int argc, char** argv)
     ctx->mountpoint = mountpoint;
     ctx->manifest_file = manifest_file;
 
+#if defined(ENABLE_MPI_MOUNT)
+    ctx->enable_mpi_mount = 1;
+#endif
+
     if (verbose) {
         unifyfs_stage_print(ctx);
     }
@@ -278,7 +282,7 @@ int main(int argc, char** argv)
         debug_pause(rank, "About to mount unifyfs.. ");
     }
 
-    if (should_we_mount_unifyfs) {
+    if (should_we_mount_unifyfs && !ctx->enable_mpi_mount) {
         ret = unifyfs_mount(mountpoint, rank, total_ranks, 0);
         if (ret) {
             fprintf(stderr, "failed to mount unifyfs at %s (%s)",
@@ -305,7 +309,7 @@ int main(int argc, char** argv)
         }
     }
 
-    if (should_we_mount_unifyfs) {
+    if (should_we_mount_unifyfs && !ctx->enable_mpi_mount) {
         ret = unifyfs_unmount();
         if (ret) {
             fprintf(stderr, "unmounting unifyfs failed (ret=%d)\n", ret);

--- a/util/unifyfs-stage/src/unifyfs-stage.h
+++ b/util/unifyfs-stage/src/unifyfs-stage.h
@@ -23,6 +23,7 @@ struct _unifyfs_stage {
     int checksum;           /* perform checksum? 0:no, 1:yes */
     int mode;               /* transfer mode? 0:serial, 1:parallel */
     int should_we_mount_unifyfs;  /* mount? 0:no (for testing), 1: yes */
+    int enable_mpi_mount;   /* automount during MPI_Init() */
     char* mountpoint;       /* unifyfs mountpoint */
     char* manifest_file;    /* manifest file containing the transfer list */
 };
@@ -37,6 +38,7 @@ static inline void unifyfs_stage_print(unifyfs_stage_t* ctx)
            "checksum = %d\n"
            "mode = %d\n"
            "should_we_mount_unifyfs = %d\n"
+           "mpi_mount = %d\n"
            "mountpoint = %s\n"
            "manifest file = %s\n",
            ctx->rank,
@@ -44,6 +46,7 @@ static inline void unifyfs_stage_print(unifyfs_stage_t* ctx)
            ctx->checksum,
            ctx->mode,
            ctx->should_we_mount_unifyfs,
+           ctx->enable_mpi_mount,
            ctx->mountpoint,
            ctx->manifest_file);
 }

--- a/util/unifyfs/src/unifyfs-rm.c
+++ b/util/unifyfs/src/unifyfs-rm.c
@@ -899,7 +899,7 @@ static int jsrun_stage(unifyfs_resource_t* resource,
 
     // full command: jsrun <jsrun args> <server args>
     snprintf(cmd, sizeof(cmd),
-             "jsrun --immediate -e -individual --stdio_stderr unifyfs-stage.err.%%h.%%p --stdio_stdout unifyfs-stage.out.%%h.%%p --nrs %zu -r1 -c1 -a1",
+             "jsrun --immediate -e individual --stdio_stderr unifyfs-stage.err.%%h.%%p --stdio_stdout unifyfs-stage.out.%%h.%%p --nrs %zu -r1 -c1 -a1",
              resource->n_nodes);
 
     generic_stage(cmd, jsrun_argc, args);


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Fixes a typo causing an error when attempting to transfer files out during `unifyfs terminate`.

Adds a flag when building unifyfs-stage to allows its use when using UnifyFS configured with `--enable-mpi-mount`.

<!--- Provide a general summary of your changes in the Title above -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes: #630

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
On a system with `jsrun`, using both UnifyFS with and without `--enable-mpi-mount`, transferred a simple HDF5 file out of UnifyFS and compared with same file when not using UnifyFS.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
