### PR TITLE
draft of doc of stand-alone transfer

### DIFF
--- a/docs/run.rst
+++ b/docs/run.rst
@@ -122,6 +122,13 @@ Support for the SLURM resource manager is under development.
   Stage-in and Stage-out Manifest File Format
 -----------------------------------------------
 
+The transfer subsystem within UnifyFS can be invoked as above
+within the start process (to transfer files into the UnifyFS
+volume) or during the stop process (to transfer files out of
+the UnifyFS volume).  To do so, the user supplies a manifest
+file specifying the requested transfers.  Here is the formatted
+for that manifest file.
+
 The manifest file contains one or more file copy requests.
 Each line in the manifest corresponds to one file copy request,
 and it contains both the source and destination file paths. Currently,
@@ -143,3 +150,21 @@ Here is an example of a valid stage-in manifest file:
 ``/scratch/users/me/input_data/input_1.dat /unifyfs/input/input_1.dat``
 ``/home/users/me/configuration/run_12345.conf /unifyfs/config/run_12345.conf``
 ``"/home/users/me/file with space.dat" "/unifyfs/file with space.dat"``
+
+-----------------------------------------------
+  Stand-alone file stage application
+-----------------------------------------------
+The manifest subsystem can also be used during the job by
+invoking stand-alone transfer executable.  The command to use is
+"unify-static".  It's used similarly to the unix
+"cp" command, with source and destination, except that unify-static
+is aware that it is copying files between the external parallel
+file system and the internal UnifyFS volume.
+
+The stand-alone can be invoked at any time the UnifyFS servers
+are up and responding to requests.  Thus the user can move files
+in or out during a job where UnifyFS is running at any time
+during the job, if UnifyFS has been "start"ed as above.  This
+could be done during the job to bring in new input, or perhaps
+transfer results files out so they can be verified before they
+job terminates.

--- a/docs/run.rst
+++ b/docs/run.rst
@@ -119,14 +119,17 @@ within the source repository at ``util/scripts/lsfcsm``.
 Support for the SLURM resource manager is under development.
 
 -----------------------------------------------
-  Stage-in and Stage-out Manifest File Format
+  Transferring Data In and Out of UnifyFS
 -----------------------------------------------
+
+Stage Application
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 The transfer subsystem within UnifyFS can be invoked as above
 within the start process (to transfer files into the UnifyFS
 volume) or during the stop process (to transfer files out of
 the UnifyFS volume).  To do so, the user supplies a manifest
-file specifying the requested transfers.  Here is the formatted
+file specifying the requested transfers.  Here is the format
 for that manifest file.
 
 The manifest file contains one or more file copy requests.
@@ -151,12 +154,17 @@ Here is an example of a valid stage-in manifest file:
 ``/home/users/me/configuration/run_12345.conf /unifyfs/config/run_12345.conf``
 ``"/home/users/me/file with space.dat" "/unifyfs/file with space.dat"``
 
------------------------------------------------
+The transfer API stage functionality can also be used with a stand-alone
+application called "unifyfs-stage".  This function takes the argument
+of the name of a manifest file.  It can be run at any time, so could
+be run during a job, to transfer new into into the UnifyFS volume,
+or trasnfer results out and checked before the job ends.
+
   Stand-alone file stage application
------------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 The manifest subsystem can also be used during the job by
 invoking stand-alone transfer executable.  The command to use is
-"unify-static".  It's used similarly to the unix
+"transfer-static".  It's used similarly to the unix
 "cp" command, with source and destination, except that unify-static
 is aware that it is copying files between the external parallel
 file system and the internal UnifyFS volume.
@@ -168,3 +176,8 @@ during the job, if UnifyFS has been "start"ed as above.  This
 could be done during the job to bring in new input, or perhaps
 transfer results files out so they can be verified before they
 job terminates.
+
+Examples of use of the transfer-static command:
+srun -N 2 /path/to/libexec/transfer-static /path/on/parallelfs/file.dat /unifyfs/file.dat
+
+srun -N 2 /path/to/libexec/transfer-static /unifyfs/output.dat /scratch/my_output/output.dat


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Creating stand-alone documentation for the transfer application.

### Description
<!--- Describe your changes in detail -->
Expanded the "run" documentation page, as requested in meetings, to
document the stand-alone use of the transfer application that invokes
the transfer api under the hood.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Requested in meetings to illustrate the use as part of
debugging jobs.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted.
