### PR TITLE
Fix unifyfs_fskv_init() bug

### DIFF
--- a/common/src/unifyfs_keyval.c
+++ b/common/src/unifyfs_keyval.c
@@ -516,7 +516,7 @@ static int unifyfs_fskv_init(unifyfs_cfg_t* cfg)
             err = errno;
             if ((rc != 0) && (err != EEXIST)) {
                 LOGERR("failed to create local kvstore directory %s - %s",
-                    localfs_kvdir, strerror(err));
+                       localfs_kvdir, strerror(err));
                 return (int)UNIFYFS_ERROR_KEYVAL;
             }
         } else {
@@ -525,39 +525,45 @@ static int unifyfs_fskv_init(unifyfs_cfg_t* cfg)
         }
     }
 
-    if ((UNIFYFS_SERVER == cfg->ptype) && (NULL != cfg->sharedfs_dir)) {
-        // find or create shared kvstore directory
-        snprintf(sharedfs_kvdir, sizeof(sharedfs_kvdir), "%s/kvstore",
-                 cfg->sharedfs_dir);
-        memset(&s, 0, sizeof(struct stat));
-        rc = stat(sharedfs_kvdir, &s);
-        if (rc != 0) {
-            // try to create it
-            rc = mkdir(sharedfs_kvdir, 0770);
-            err = errno;
-            if ((rc != 0) && (err != EEXIST)) {
-                LOGERR("failed to create kvstore directory %s - %s",
-                       sharedfs_kvdir, strerror(err));
-                return (int)UNIFYFS_ERROR_KEYVAL;
+    if (UNIFYFS_SERVER == cfg->ptype) {
+        if (NULL != cfg->sharedfs_dir) {
+            // find or create shared kvstore directory
+            snprintf(sharedfs_kvdir, sizeof(sharedfs_kvdir), "%s/kvstore",
+                     cfg->sharedfs_dir);
+            memset(&s, 0, sizeof(struct stat));
+            rc = stat(sharedfs_kvdir, &s);
+            if (rc != 0) {
+                // try to create it
+                rc = mkdir(sharedfs_kvdir, 0770);
+                err = errno;
+                if ((rc != 0) && (err != EEXIST)) {
+                    LOGERR("failed to create kvstore directory %s - %s",
+                           sharedfs_kvdir, strerror(err));
+                    return (int)UNIFYFS_ERROR_KEYVAL;
+                }
             }
-        }
 
-        // find or create rank-specific subdir
-        scnprintf(sharedfs_rank_kvdir, sizeof(sharedfs_rank_kvdir), "%s/%d",
-                 sharedfs_kvdir, kv_myrank);
-        memset(&s, 0, sizeof(struct stat));
-        rc = stat(sharedfs_rank_kvdir, &s);
-        if (rc != 0) {
-            // try to create it
-            rc = mkdir(sharedfs_rank_kvdir, 0770);
-            err = errno;
-            if ((rc != 0) && (err != EEXIST)) {
-                LOGERR("failed to create rank kvstore directory %s - %s",
-                       sharedfs_rank_kvdir, strerror(err));
-                return (int)UNIFYFS_ERROR_KEYVAL;
+            // find or create rank-specific subdir
+            scnprintf(sharedfs_rank_kvdir, sizeof(sharedfs_rank_kvdir), "%s/%d",
+                      sharedfs_kvdir, kv_myrank);
+            memset(&s, 0, sizeof(struct stat));
+            rc = stat(sharedfs_rank_kvdir, &s);
+            if (rc != 0) {
+                // try to create it
+                rc = mkdir(sharedfs_rank_kvdir, 0770);
+                err = errno;
+                if ((rc != 0) && (err != EEXIST)) {
+                    LOGERR("failed to create rank kvstore directory %s - %s",
+                           sharedfs_rank_kvdir, strerror(err));
+                    return (int)UNIFYFS_ERROR_KEYVAL;
+                }
             }
+            have_sharedfs_kvstore = 1;
+        } else {
+            // Server process, but nobody specified the sharedfs dir
+            LOGERR("can't create kvstore - sharedfs not specified");
+            return (int)UNIFYFS_ERROR_KEYVAL;
         }
-        have_sharedfs_kvstore = 1;
     }
 
     kv_max_keylen = UNIFYFS_MAX_KV_KEYLEN;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
If unifyfsd was started without specifying the shared dir, unifyfs_fskv_init() would not actually initialize the K/V store, but it would return success.  This commit adds code to check for that condition and, if the condition is found, return an error and write an appropriate message to the error log.

Note: most of the changes shown in the diff are actually whitespace.  (A bunch of code got indented one level.)  There's only a handful of new lines of code.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes issue #652

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Tested on an Unbuntu workstation.  

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
