### PR TITLE
Ensure logio data is persisted on user fsync()

### DIFF
--- a/client/src/unifyfs_api.c
+++ b/client/src/unifyfs_api.c
@@ -123,9 +123,21 @@ unifyfs_rc unifyfs_initialize(const char* mountpoint,
         }
     }
 
+    /* Determine whether we persist data to storage device on fsync().
+     * Turning this setting off speeds up fsync() by only syncing the
+     * extent metadata, but it violates POSIX semanatics. */
+    client->use_fsync_persist = true;
+    cfgval = client_cfg->client_fsync_persist;
+    if (cfgval != NULL) {
+        rc = configurator_bool_val(cfgval, &b);
+        if (rc == 0) {
+            client->use_fsync_persist = (bool)b;
+        }
+    }
+
     /* Determine whether we automatically sync every write to server.
-     * This slows write performance, but it can serve as a work
-     * around for apps that do not have all necessary syncs. */
+     * Turning this setting on slows write performance, but it can serve
+     * as a workaround for apps that do not have all the necessary syncs. */
     client->use_write_sync = false;
     cfgval = client_cfg->client_write_sync;
     if (cfgval != NULL) {

--- a/client/src/unifyfs_api_internal.h
+++ b/client/src/unifyfs_api_internal.h
@@ -60,6 +60,7 @@ typedef struct unifyfs_client {
     /* mountpoint configuration */
     unifyfs_cfg_t cfg;               /* user-provided configuration */
 
+    bool use_fsync_persist;          /* persist data to storage on fsync() */
     bool use_local_extents;          /* enable tracking of local extents */
     bool use_write_sync;             /* sync for every write operation */
     bool use_unifyfs_magic;          /* return UNIFYFS (true) or TMPFS (false)

--- a/client/src/unifyfs_fid.h
+++ b/client/src/unifyfs_fid.h
@@ -145,8 +145,14 @@ int unifyfs_fid_truncate(unifyfs_client* client,
                          int fid,
                          off_t length);
 
-/* Sync extent data for file to server if needed */
+/* Sync extent data for file to storage */
+int unifyfs_fid_sync_data(unifyfs_client* client,
+                          int fid);
+
+/* Sync extent metadata for file to server if needed */
 int unifyfs_fid_sync_extents(unifyfs_client* client,
                              int fid);
+
+
 
 #endif /* UNIFYFS_FID_H */

--- a/common/src/unifyfs_configurator.h
+++ b/common/src/unifyfs_configurator.h
@@ -70,6 +70,7 @@
     UNIFYFS_CFG_CLI(unifyfs, daemonize, BOOL, on, "enable server daemonization", NULL, 'D', "on|off") \
     UNIFYFS_CFG_CLI(unifyfs, mountpoint, STRING, /unifyfs, "mountpoint directory", NULL, 'm', "specify full path to desired mountpoint") \
     UNIFYFS_CFG(client, cwd, STRING, NULLSTRING, "current working directory", NULL) \
+    UNIFYFS_CFG(client, fsync_persist, BOOL, on, "persist written data to storage on fsync()", NULL) \
     UNIFYFS_CFG(client, local_extents, BOOL, off, "track extents to service reads of local data", NULL) \
     UNIFYFS_CFG(client, max_files, INT, UNIFYFS_CLIENT_MAX_FILES, "client max file count", NULL) \
     UNIFYFS_CFG(client, write_index_size, INT, UNIFYFS_CLIENT_WRITE_INDEX_SIZE, "write metadata index buffer size", NULL) \

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -67,8 +67,9 @@ a given section and key.
    Key               Type    Description
    ================  ======  =================================================================
    cwd               STRING  effective starting current working directory
-   max_files         INT     maximum number of open files per client process (default: 128)
+   fsync_persist     BOOL    persist data to storage on fsync() (default: on)
    local_extents     BOOL    service reads from local data if possible (default: off)
+   max_files         INT     maximum number of open files per client process (default: 128)
    super_magic       BOOL    whether to return UNIFYFS (on) or TMPFS (off) statfs magic (default: on)
    write_index_size  INT     maximum size (B) of memory buffer for storing write log metadata
    write_sync        BOOL    sync data to server after every write (default: off)


### PR DESCRIPTION
### Description

This PR makes it so we persist logio data to storage when a client uses `fsync()`, unless the `client.fsync_persist` configuration option is used to disable this behavior.

### Motivation and Context

See issue #645

### How Has This Been Tested?

Tested in Ubuntu Docker container

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
