### PR TITLE
use ABT after calling margo_init

### DIFF
--- a/server/src/unifyfs_server.c
+++ b/server/src/unifyfs_server.c
@@ -396,8 +396,6 @@ int main(int argc, char* argv[])
     }
 
     LOGDBG("initializing rpc service");
-    ABT_init(argc, argv);
-    ABT_mutex_create(&app_configs_abt_sync);
     rc = configurator_bool_val(server_cfg.margo_lazy_connect,
                                &margo_lazy_connect);
     rc = configurator_bool_val(server_cfg.margo_tcp,
@@ -407,6 +405,11 @@ int main(int argc, char* argv[])
         LOGERR("%s", unifyfs_rc_enum_description(rc));
         exit(1);
     }
+
+    /* We wait to call any ABT functions until after margo_init.
+     * Margo configures ABT in a particular way, so we defer to
+     * Margo to call ABT_init. */
+    ABT_mutex_create(&app_configs_abt_sync);
 
     ABT_mutex_lock(app_configs_abt_sync);
     failed_clients = arraylist_create(0);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This removes the call to ``ABT_init`` and defers that task to Margo.  Margo configures ABT in a particular way.

In particular, it increases the default ABT thread stack size from 4KB to 2MB:
https://github.com/mochi-hpc/mochi-margo/blob/ff094a5a26af19041860f9bba1e0e938c0194ae5/src/margo-init.c#L1533-L1534

which resolves some problems as described in:
https://github.com/pmodels/argobots/issues/333

Alternatively, we could call ``ABT_init`` before ``margo_init``.  However, we likely would need to configure ABT to be compatible with what Margo expects.  We need to set some ABT environment variables before calling ``ABT_init`` with something like:
```
    char env_str[64];
    sprintf(env_str, "%d", 2*1024*1024);
    setenv("ABT_THREAD_STACKSIZE", env_str, 0);

    ABT_init(argc, argv);
```
similar to what is done in margo here:
https://github.com/mochi-hpc/mochi-margo/blob/ff094a5a26af19041860f9bba1e0e938c0194ae5/src/margo-util.c#L29-L36

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
