### PR TITLE
Add client unlink callbacks

### DIFF
--- a/client/src/margo_client.h
+++ b/client/src/margo_client.h
@@ -43,6 +43,7 @@ typedef struct ClientRpcIds {
     hg_id_t mread_req_data_id;
     hg_id_t mread_req_complete_id;
     hg_id_t transfer_complete_id;
+    hg_id_t unlink_callback_id;
 } client_rpcs_t;
 
 typedef struct ClientRpcContext {

--- a/client/src/unifyfs_api_file.c
+++ b/client/src/unifyfs_api_file.c
@@ -239,13 +239,8 @@ unifyfs_rc unifyfs_remove(unifyfs_handle fshdl,
     }
 
     unifyfs_rc ret = UNIFYFS_SUCCESS;
-
-    /* invoke unlink rpc */
     int gfid = unifyfs_generate_gfid(filepath);
-    int rc = invoke_client_unlink_rpc(client, gfid);
-    if (rc != UNIFYFS_SUCCESS) {
-        ret = rc;
-    }
+    int rc;
 
     /* clean up the local state for this file (if any) */
     int fid = unifyfs_fid_from_gfid(client, gfid);
@@ -257,6 +252,12 @@ unifyfs_rc unifyfs_remove(unifyfs_handle fshdl,
              * its file id active */
             ret = rc;
         }
+    }
+
+    /* invoke unlink rpc */
+    rc = invoke_client_unlink_rpc(client, gfid);
+    if (rc != UNIFYFS_SUCCESS) {
+        ret = rc;
     }
 
     return ret;

--- a/client/src/unifyfs_api_internal.h
+++ b/client/src/unifyfs_api_internal.h
@@ -34,9 +34,12 @@ typedef struct {
     int fid;                      /* local file index in filemetas array */
     int storage;                  /* FILE_STORAGE type */
 
+    int pending_unlink;           /* received unlink callback */
+
     int needs_sync;               /* have unsynced writes */
     struct seg_tree extents_sync; /* Segment tree containing our coalesced
                                    * writes between sync operations */
+
     struct seg_tree extents;      /* Segment tree of all local data extents */
 
     unifyfs_file_attr_t attrs;    /* UnifyFS and POSIX file attributes */

--- a/common/src/arraylist.c
+++ b/common/src/arraylist.c
@@ -32,6 +32,9 @@
 #include <unistd.h>
 #include <stdlib.h>
 
+/* Create an arraylist with the given capacity.
+ * If capacity == 0, use the default ARRAYLIST_CAPACITY.
+ * Returns the new arraylist, or NULL on error. */
 arraylist_t* arraylist_create(int capacity)
 {
     arraylist_t* arr = (arraylist_t*) malloc(sizeof(arraylist_t));
@@ -54,6 +57,7 @@ arraylist_t* arraylist_create(int capacity)
     return arr;
 }
 
+/* Returns the arraylist capacity in elements, or -1 on error */
 int arraylist_capacity(arraylist_t* arr)
 {
     if (NULL == arr) {
@@ -62,6 +66,7 @@ int arraylist_capacity(arraylist_t* arr)
     return arr->cap;
 }
 
+/* Returns the current arraylist size in elements, or -1 on error */
 int arraylist_size(arraylist_t* arr)
 {
     if (NULL == arr) {
@@ -70,6 +75,40 @@ int arraylist_size(arraylist_t* arr)
     return arr->size;
 }
 
+/* Reset the arraylist size to zero */
+int arraylist_reset(arraylist_t* arr)
+{
+    if (NULL == arr) {
+        return -1;
+    }
+
+    arr->size = 0;
+
+    return 0;
+}
+
+/* Free all arraylist elements, the array storage, and the arraylist_t */
+int arraylist_free(arraylist_t* arr)
+{
+    if (NULL == arr) {
+        return -1;
+    }
+
+    if (NULL != arr->elems) {
+        for (int i = 0; i < arr->cap; i++) {
+            if (arr->elems[i] != NULL) {
+                free(arr->elems[i]);
+            }
+        }
+        free(arr->elems);
+    }
+
+    free(arr);
+
+    return 0;
+}
+
+/* Get the element at given position */
 void* arraylist_get(arraylist_t* arr, int pos)
 {
     if ((NULL == arr) || (pos >= arr->size)) {
@@ -78,6 +117,7 @@ void* arraylist_get(arraylist_t* arr, int pos)
     return arr->elems[pos];
 }
 
+/* Remove the element at given list index and return it */
 void* arraylist_remove(arraylist_t* arr, int pos)
 {
     void* item = arraylist_get(arr, pos);
@@ -99,7 +139,7 @@ void* arraylist_remove(arraylist_t* arr, int pos)
     return item;
 }
 
-/* Inserts element at given index (pos) in the arraylist.
+/* Insert the element at the given list index (pos) in the arraylist.
  * Overwrites (and frees) any existing element at that index.
  * Returns 0 on success, or -1 on error */
 int arraylist_insert(arraylist_t* arr, int pos, void* elem)
@@ -153,33 +193,28 @@ int arraylist_add(arraylist_t* arr, void* elem)
     }
 }
 
-int arraylist_reset(arraylist_t* arr)
+/* Sort the arraylist elements using the given comparison function (cmpfn).
+ * Note that the comparison function should properly handle NULL pointer
+ * elements of the array.
+ * Return 0 on success, -1 on error */
+int arraylist_sort(arraylist_t* arr,
+                   int (*cmpfn)(const void *, const void *))
 {
     if (NULL == arr) {
         return -1;
     }
 
-    arr->size = 0;
+    /* sort using provided comparison function */
+    qsort(arr->elems, arr->cap, sizeof(void*), cmpfn);
 
-    return 0;
-}
-
-int arraylist_free(arraylist_t* arr)
-{
-    if (NULL == arr) {
-        return -1;
-    }
-
-    if (NULL != arr->elems) {
-        for (int i = 0; i < arr->cap; i++) {
-            if (arr->elems[i] != NULL) {
-                free(arr->elems[i]);
-            }
+    /* adjust size to match last used index */
+    int last_used_pos = -1;
+    for (int i = 0; i < arr->cap; i++) {
+        if (arr->elems[i] != NULL) {
+            last_used_pos = i;
         }
-        free(arr->elems);
     }
-
-    free(arr);
+    arr->size = last_used_pos + 1;
 
     return 0;
 }

--- a/common/src/arraylist.h
+++ b/common/src/arraylist.h
@@ -39,14 +39,44 @@ typedef struct {
     void** elems;
 } arraylist_t;
 
+/* Create an arraylist with the given capacity.
+ * If capacity == 0, use the default ARRAYLIST_CAPACITY.
+ * Returns the new arraylist, or NULL on error. */
 arraylist_t* arraylist_create(int capacity);
-int arraylist_add(arraylist_t* arr, void* elem);
-int arraylist_reset(arraylist_t* arr);
-int arraylist_free(arraylist_t* arr);
-int arraylist_insert(arraylist_t* arr, int pos, void* elem);
-void* arraylist_get(arraylist_t* arr, int pos);
-void* arraylist_remove(arraylist_t* arr, int pos);
+
+/* Returns the arraylist capacity in elements, or -1 on error */
 int arraylist_capacity(arraylist_t* arr);
+
+/* Returns the current arraylist size in elements, or -1 on error */
 int arraylist_size(arraylist_t* arr);
+
+/* Reset the arraylist size to zero */
+int arraylist_reset(arraylist_t* arr);
+
+/* Get the element at the given list index (pos)) */
+void* arraylist_get(arraylist_t* arr, int pos);
+
+/* Remove the element at given list index (pos) and return it */
+void* arraylist_remove(arraylist_t* arr, int pos);
+
+/* Free all arraylist elements, the array storage, and the arraylist_t.
+ * Returns 0 on success, -1 on error */
+int arraylist_free(arraylist_t* arr);
+
+/* Adds element to the end of the current list.
+ * Returns list index of newly added element, or -1 on error */
+int arraylist_add(arraylist_t* arr, void* elem);
+
+/* Insert the element at the given list index (pos) in the arraylist.
+ * Overwrites (and frees) any existing element at that index.
+ * Returns 0 on success, or -1 on error */
+int arraylist_insert(arraylist_t* arr, int pos, void* elem);
+
+/* Sort the arraylist elements using the given comparison function (cmpfn).
+ * Note that the comparison function should properly handle NULL pointer
+ * elements of the array.
+ * Return 0 on success, -1 on error */
+int arraylist_sort(arraylist_t* arr,
+                   int (*cmpfn)(const void *, const void *));
 
 #endif

--- a/common/src/unifyfs_client_rpcs.h
+++ b/common/src/unifyfs_client_rpcs.h
@@ -47,6 +47,13 @@ typedef enum {
     UNIFYFS_CLIENT_RPC_UNMOUNT
 } client_rpc_e;
 
+typedef enum {
+    UNIFYFS_CLIENT_CALLBACK_INVALID = 0,
+    UNIFYFS_CLIENT_CALLBACK_LAMINATE,
+    UNIFYFS_CLIENT_CALLBACK_TRUNCATE,
+    UNIFYFS_CLIENT_CALLBACK_UNLINK
+} client_callback_e;
+
 /* unifyfs_attach_rpc (client => server)
  *
  * initialize server access to client's shared memory and file state */
@@ -188,6 +195,18 @@ MERCURY_GEN_PROC(unifyfs_unlink_in_t,
 MERCURY_GEN_PROC(unifyfs_unlink_out_t,
                  ((int32_t)(ret)))
 DECLARE_MARGO_RPC_HANDLER(unifyfs_unlink_rpc)
+
+/* unifyfs_unlink_callback_rpc (server => client)
+ *
+ * given an app_id, client_id, and global file id,
+ * free the client metadata and data associated with the file */
+MERCURY_GEN_PROC(unifyfs_unlink_callback_in_t,
+                 ((int32_t)(app_id))
+                 ((int32_t)(client_id))
+                 ((int32_t)(gfid)))
+MERCURY_GEN_PROC(unifyfs_unlink_callback_out_t,
+                 ((int32_t)(ret)))
+DECLARE_MARGO_RPC_HANDLER(unifyfs_unlink_callback_rpc)
 
 /* unifyfs_laminate_rpc (client => server)
  *

--- a/common/src/unifyfs_logio.c
+++ b/common/src/unifyfs_logio.c
@@ -40,9 +40,27 @@ typedef struct log_header {
     size_t reserved_sz;        /* reserved data bytes */
     size_t chunk_sz;           /* data chunk size */
     off_t  data_offset;        /* file/memory offset where data chunks start */
+
+    volatile int updating;     /* flag to prevent client/server update races */
 } log_header;
 /* chunk slot_map immediately follows header and occupies rest of the page */
 // slot_map chunk_map;         /* chunk slot_map that tracks reservations */
+
+inline void LOCK_LOG_HEADER(log_header* hdr)
+{
+    assert(NULL != hdr);
+    while (hdr->updating) {
+        usleep(10);
+    }
+    hdr->updating = 1;
+}
+
+inline void UNLOCK_LOG_HEADER(log_header* hdr)
+{
+    assert(NULL != hdr);
+    assert(hdr->updating);
+    hdr->updating = 0;
+}
 
 static inline
 slot_map* log_header_to_chunkmap(log_header* hdr)
@@ -548,6 +566,7 @@ int unifyfs_logio_alloc(logio_context* ctx,
     if (NULL != ctx->shmem) {
         /* get shmem log header and chunk slotmap */
         shmem_hdr = (log_header*) ctx->shmem->addr;
+        LOCK_LOG_HEADER(shmem_hdr);
         chunkmap = log_header_to_chunkmap(shmem_hdr);
 
         /* calculate number of chunks needed for requested bytes */
@@ -561,6 +580,7 @@ int unifyfs_logio_alloc(logio_context* ctx,
             /* success, all needed chunks allocated in shmem */
             allocated_bytes = res_chunks * chunk_sz;
             shmem_hdr->reserved_sz += allocated_bytes;
+            UNLOCK_LOG_HEADER(shmem_hdr);
             res_off = (off_t)(res_slot * chunk_sz);
             *log_offset = res_off;
             return UNIFYFS_SUCCESS;
@@ -583,12 +603,15 @@ int unifyfs_logio_alloc(logio_context* ctx,
                 mem_res_nchk = res_chunks;
                 mem_res_at_end = 1;
             }
+        } else {
+            UNLOCK_LOG_HEADER(shmem_hdr);
         }
     }
 
     if (NULL != ctx->spill_hdr) {
         /* get spill log header and chunk slotmap */
         spill_hdr = (log_header*) ctx->spill_hdr;
+        LOCK_LOG_HEADER(spill_hdr);
         chunkmap = log_header_to_chunkmap(spill_hdr);
 
         /* calculate number of chunks needed for remaining bytes */
@@ -603,6 +626,7 @@ int unifyfs_logio_alloc(logio_context* ctx,
             if (0 == mem_res_at_end) {
                 /* success, full reservation in spill */
                 spill_hdr->reserved_sz += allocated_bytes;
+                UNLOCK_LOG_HEADER(spill_hdr);
                 res_off = (off_t)(res_slot * chunk_sz);
                 if (NULL != shmem_hdr) {
                     /* update log offset to account for shmem log size */
@@ -629,6 +653,7 @@ int unifyfs_logio_alloc(logio_context* ctx,
                     if (rc != UNIFYFS_SUCCESS) {
                         LOGERR("slotmap_release() for logio shmem failed");
                     }
+                    UNLOCK_LOG_HEADER(shmem_hdr);
                     mem_res_slot = 0;
                     mem_res_nchk = 0;
                     mem_allocation = 0;
@@ -642,6 +667,7 @@ int unifyfs_logio_alloc(logio_context* ctx,
                         /* success, full reservation in spill */
                         allocated_bytes = res_chunks * chunk_sz;
                         spill_hdr->reserved_sz += allocated_bytes;
+                        UNLOCK_LOG_HEADER(spill_hdr);
                         res_off = (off_t)(res_slot * chunk_sz);
                         if (NULL != shmem_hdr) {
                             /* update log offset to include shmem log size */
@@ -653,11 +679,15 @@ int unifyfs_logio_alloc(logio_context* ctx,
                 } else {
                     /* successful reservation spanning shmem and spill */
                     shmem_hdr->reserved_sz += mem_allocation;
+                    UNLOCK_LOG_HEADER(shmem_hdr);
                     spill_hdr->reserved_sz += allocated_bytes;
+                    UNLOCK_LOG_HEADER(spill_hdr);
                     *log_offset = res_off;
                     return UNIFYFS_SUCCESS;
                 }
             }
+        } else {
+            UNLOCK_LOG_HEADER(spill_hdr);
         }
     }
 
@@ -669,6 +699,7 @@ int unifyfs_logio_alloc(logio_context* ctx,
         if (rc != UNIFYFS_SUCCESS) {
             LOGERR("slotmap_release() for logio shmem failed");
         }
+        UNLOCK_LOG_HEADER(shmem_hdr);
     }
     LOGDBG("returning ENOSPC");
     return ENOSPC;
@@ -699,6 +730,7 @@ int unifyfs_logio_free(logio_context* ctx,
     }
 
     /* determine chunk allocations based on log offset */
+    size_t released_bytes;
     size_t sz_in_mem = 0;
     size_t sz_in_spill = 0;
     off_t spill_offset = 0;
@@ -711,26 +743,34 @@ int unifyfs_logio_free(logio_context* ctx,
     size_t chunk_sz, chunk_slot, num_chunks;
     if (sz_in_mem > 0) {
         /* release shared memory chunks */
+        LOCK_LOG_HEADER(shmem_hdr);
         chunk_sz = shmem_hdr->chunk_sz;
         chunk_slot = log_offset / chunk_sz;
         num_chunks = bytes_to_chunks(sz_in_mem, chunk_sz);
+        released_bytes = chunk_sz * num_chunks;
         chunkmap = log_header_to_chunkmap(shmem_hdr);
         rc = slotmap_release(chunkmap, chunk_slot, num_chunks);
         if (rc != UNIFYFS_SUCCESS) {
             LOGERR("slotmap_release() for logio shmem failed");
         }
+        shmem_hdr->reserved_sz -= released_bytes;
+        UNLOCK_LOG_HEADER(shmem_hdr);
     }
     if (sz_in_spill > 0) {
         /* release spill chunks */
         spill_hdr = (log_header*) ctx->spill_hdr;
+        LOCK_LOG_HEADER(spill_hdr);
         chunk_sz = spill_hdr->chunk_sz;
         chunk_slot = spill_offset / chunk_sz;
         num_chunks = bytes_to_chunks(sz_in_spill, chunk_sz);
+        released_bytes = chunk_sz * num_chunks;
         chunkmap = log_header_to_chunkmap(spill_hdr);
         rc = slotmap_release(chunkmap, chunk_slot, num_chunks);
         if (rc != UNIFYFS_SUCCESS) {
             LOGERR("slotmap_release() for logio spill failed");
         }
+        spill_hdr->reserved_sz -= released_bytes;
+        UNLOCK_LOG_HEADER(spill_hdr);
     }
     return rc;
 }

--- a/examples/src/checkpoint-restart.c
+++ b/examples/src/checkpoint-restart.c
@@ -358,6 +358,15 @@ int main(int argc, char* argv[])
         test_print(cfg, "ERROR - Restart data verification failed!");
     }
 
+    if (cfg->remove_target) {
+        test_print_verbose_once(cfg,
+            "DEBUG: removing file %s", target_file);
+        rc = test_remove_file(cfg, target_file);
+        if (rc) {
+            test_print(cfg, "ERROR - test_remove_file(%s) failed", target_file);
+        }
+    }
+
     // post-restart cleanup
     free(restart_data);
     free(req);

--- a/examples/src/write-transfer.c
+++ b/examples/src/write-transfer.c
@@ -429,6 +429,15 @@ int main(int argc, char* argv[])
                         global_read_bw);
     }
 
+    if (cfg->remove_target) {
+        test_print_verbose_once(cfg,
+            "DEBUG: removing file %s", target_file);
+        rc = test_remove_file(cfg, target_file);
+        if (rc) {
+            test_print(cfg, "ERROR - test_remove_file(%s) failed", target_file);
+        }
+    }
+
     // cleanup
     free(target_file);
     free(destination_file);

--- a/examples/src/write.c
+++ b/examples/src/write.c
@@ -307,6 +307,15 @@ int main(int argc, char* argv[])
                         eff_write_bw);
     }
 
+    if (cfg->remove_target) {
+        test_print_verbose_once(cfg,
+            "DEBUG: removing file %s", target_file);
+        rc = test_remove_file(cfg, target_file);
+        if (rc) {
+            test_print(cfg, "ERROR - test_remove_file(%s) failed", target_file);
+        }
+    }
+
     // cleanup
     free(target_file);
 

--- a/examples/src/writeread.c
+++ b/examples/src/writeread.c
@@ -449,6 +449,15 @@ int main(int argc, char* argv[])
                         global_read_bw);
     }
 
+    if (cfg->remove_target) {
+        test_print_verbose_once(cfg,
+            "DEBUG: removing file %s", target_file);
+        rc = test_remove_file(cfg, target_file);
+        if (rc) {
+            test_print(cfg, "ERROR - test_remove_file(%s) failed", target_file);
+        }
+    }
+
     // cleanup
     free(target_file);
 

--- a/server/src/margo_server.c
+++ b/server/src/margo_server.c
@@ -339,6 +339,12 @@ static void register_client_server_rpcs(margo_instance_id mid)
                        unifyfs_transfer_complete_in_t,
                        unifyfs_transfer_complete_out_t,
                        NULL);
+
+    unifyfsd_rpc_context->rpcs.client_unlink_callback_id =
+        MARGO_REGISTER(mid, "unifyfs_unlink_callback_rpc",
+                       unifyfs_unlink_callback_in_t,
+                       unifyfs_unlink_callback_out_t,
+                       NULL);
 }
 
 /* margo_server_rpc_init
@@ -645,7 +651,8 @@ int invoke_client_heartbeat_rpc(int app_id,
     hg_handle_t handle = create_client_handle(rpc_id, app_id, client_id);
 
     /* call rpc function */
-    LOGDBG("invoking the heartbeat rpc function in client");
+    LOGDBG("invoking the heartbeat rpc function in client[%d:%d]",
+           app_id, client_id);
     double timeout_msec = 500; /* half a second */
     hret = margo_forward_timed(handle, &in, timeout_msec);
     if (hret != HG_SUCCESS) {
@@ -713,7 +720,8 @@ int invoke_client_mread_req_data_rpc(int app_id,
     hg_handle_t handle = create_client_handle(rpc_id, app_id, client_id);
 
     /* call rpc function */
-    LOGDBG("invoking the mread req data rpc function in client");
+    LOGDBG("invoking the mread[%d] req data (index=%d) rpc function in "
+           "client[%d:%d]", mread_id, read_index, app_id, client_id);
     hret = margo_forward(handle, &in);
     if (hret != HG_SUCCESS) {
         LOGERR("margo_forward() failed");
@@ -771,8 +779,8 @@ int invoke_client_mread_req_complete_rpc(int app_id,
     hg_handle_t handle = create_client_handle(rpc_id, app_id, client_id);
 
     /* call rpc function */
-    LOGDBG("invoking the mread[%d] complete rpc function in client",
-            mread_id);
+    LOGDBG("invoking the mread[%d] complete rpc function in client[%d:%d]",
+            mread_id, app_id, client_id);
     hret = margo_forward(handle, &in);
     if (hret != HG_SUCCESS) {
         LOGERR("margo_forward() failed");
@@ -824,8 +832,8 @@ int invoke_client_transfer_complete_rpc(int app_id,
     hg_handle_t handle = create_client_handle(rpc_id, app_id, client_id);
 
     /* call rpc function */
-    LOGDBG("invoking the transfer[%d] complete rpc function in client",
-           transfer_id);
+    LOGDBG("invoking the transfer[%d] complete rpc function in client[%d:%d]",
+           transfer_id, app_id, client_id);
     hret = margo_forward(handle, &in);
     if (hret != HG_SUCCESS) {
         LOGERR("margo_forward() failed");
@@ -836,6 +844,57 @@ int invoke_client_transfer_complete_rpc(int app_id,
     /* decode response */
     int ret;
     unifyfs_transfer_complete_out_t out;
+    hret = margo_get_output(handle, &out);
+    if (hret == HG_SUCCESS) {
+        LOGDBG("Got response ret=%" PRIi32, out.ret);
+        ret = (int) out.ret;
+        margo_free_output(handle, &out);
+    } else {
+        LOGERR("margo_get_output() failed");
+        ret = UNIFYFS_ERROR_MARGO;
+    }
+
+    /* free resources */
+    margo_destroy(handle);
+
+    return ret;
+}
+
+/* invokes the client mread request completion rpc function */
+int invoke_client_unlink_callback_rpc(int app_id,
+                                      int client_id,
+                                      int gfid)
+{
+    hg_return_t hret;
+
+    /* check that we have initialized margo */
+    if (NULL == unifyfsd_rpc_context) {
+        return UNIFYFS_FAILURE;
+    }
+
+    /* fill input struct */
+    unifyfs_unlink_callback_in_t in;
+    in.app_id    = (int32_t) app_id;
+    in.client_id = (int32_t) client_id;
+    in.gfid      = (int32_t) gfid;
+
+    /* get handle to rpc function */
+    hg_id_t rpc_id = unifyfsd_rpc_context->rpcs.client_unlink_callback_id;
+    hg_handle_t handle = create_client_handle(rpc_id, app_id, client_id);
+
+    /* call rpc function */
+    LOGDBG("invoking the unlink (gfid=%d) callback rpc function in "
+           "client[%d:%d]", gfid, app_id, client_id);
+    hret = margo_forward(handle, &in);
+    if (hret != HG_SUCCESS) {
+        LOGERR("margo_forward() failed");
+        margo_destroy(handle);
+        return UNIFYFS_ERROR_MARGO;
+    }
+
+    /* decode response */
+    int ret;
+    unifyfs_unlink_callback_out_t out;
     hret = margo_get_output(handle, &out);
     if (hret == HG_SUCCESS) {
         LOGDBG("Got response ret=%" PRIi32, out.ret);

--- a/server/src/margo_server.h
+++ b/server/src/margo_server.h
@@ -55,6 +55,7 @@ typedef struct ServerRpcIds {
     hg_id_t client_mread_data_id;
     hg_id_t client_mread_complete_id;
     hg_id_t client_transfer_complete_id;
+    hg_id_t client_unlink_callback_id;
 } server_rpcs_t;
 
 typedef struct ServerRpcContext {
@@ -107,5 +108,10 @@ int invoke_client_transfer_complete_rpc(int app_id,
                                         int client_id,
                                         int transfer_id,
                                         int error_code);
+
+/* invokes the client unlink callback rpc function */
+int invoke_client_unlink_callback_rpc(int app_id,
+                                      int client_id,
+                                      int gfid);
 
 #endif // MARGO_SERVER_H

--- a/server/src/unifyfs_global.h
+++ b/server/src/unifyfs_global.h
@@ -187,9 +187,6 @@ unifyfs_rc disconnect_app_client(app_client* clnt);
 
 unifyfs_rc cleanup_app_client(app_config* app, app_client* clnt);
 
-
-/* arraylist to track failed clients */
-arraylist_t* failed_clients; // = NULL
 unifyfs_rc add_failed_client(int app_id, int client_id);
 
 

--- a/server/src/unifyfs_request_manager.h
+++ b/server/src/unifyfs_request_manager.h
@@ -36,6 +36,13 @@
 #include "unifyfs_metadata_mdhim.h"
 
 typedef struct {
+    client_callback_e req_type;
+    int app_id;
+    int client_id;
+    int gfid;
+} client_callback_req;
+
+typedef struct {
     client_rpc_e req_type;
     hg_handle_t handle;
     void* input;
@@ -86,6 +93,9 @@ typedef struct reqmgr_thrd {
 
     /* list of client rpc requests */
     arraylist_t* client_reqs;
+
+    /* list of client callback requests */
+    arraylist_t* client_callbacks;
 
     /* flag set to indicate request manager thread should exit */
     int exit_flag;
@@ -148,6 +158,15 @@ int rm_handle_chunk_read_responses(reqmgr_thrd_t* thrd_ctrl,
  * @return 0 on success, errno otherwise
  */
 int rm_submit_read_request(server_read_req_t* req);
+
+/**
+ * @brief submit a client callback request to the request manager thread.
+ *
+ * @param req   pointer to client callback request struct
+ *
+ * @return UNIFYFS_SUCCESS, or error code
+ */
+int rm_submit_client_callback_request(client_callback_req* req);
 
 /**
  * @brief submit a client rpc request to the request manager thread.

--- a/server/src/unifyfs_server.c
+++ b/server/src/unifyfs_server.c
@@ -58,6 +58,9 @@ server_info_t* glb_servers; // array of server_info_t
 
 unifyfs_cfg_t server_cfg;
 
+/* arraylist to track failed clients */
+arraylist_t* failed_clients; // = NULL
+
 static ABT_mutex app_configs_abt_sync;
 static app_config* app_configs[UNIFYFS_SERVER_MAX_NUM_APPS]; /* list of apps */
 static size_t clients_per_app = UNIFYFS_SERVER_MAX_APP_CLIENTS;


### PR DESCRIPTION
### Description

This callback informs clients that they should cleanup any associated file state, including releasing storage for unsynced extents. The callback rpc is only sent to clients that have previously registered extents with their local server.

The client callback support in the request manager thread has been designed to make it easy to add other callbacks in the future.

Also:
* adds an integer flag to the logio header to avoid concurrent updates by the client and server.
* adds a program option (`-u|--unlink`) to examples to unlink target file
* adds a new `arraylist_sort()` method


### Motivation and Context

Fixes a few of the deficiencies identified in review of PR #656

### How Has This Been Tested?

Tested in Ubuntu Docker and on OLCF Summit

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
