### PR TITLE
Add unifyfs_get_config() to library API

### DIFF
--- a/client/src/unifyfs_api.c
+++ b/client/src/unifyfs_api.c
@@ -297,3 +297,30 @@ unifyfs_rc unifyfs_finalize(unifyfs_handle fshdl)
 
     return ret;
 }
+
+/* Retrieve client's UnifyFS configuration for the given handle. */
+unifyfs_rc unifyfs_get_config(unifyfs_handle fshdl,
+                              int* n_opts,
+                              unifyfs_cfg_option** options)
+{
+    if ((UNIFYFS_INVALID_HANDLE == fshdl) ||
+        (NULL == n_opts) ||
+        (NULL == options)) {
+        return EINVAL;
+    }
+    unifyfs_client* client = fshdl;
+
+    int num_options;
+    unifyfs_cfg_option* options_array;
+    int ret = unifyfs_config_get_options(&(client->cfg),
+                                         &num_options,
+                                         &options_array);
+    if (UNIFYFS_SUCCESS == ret) {
+        *n_opts = num_options;
+        *options = options_array;
+    } else {
+        *n_opts = 0;
+        *options = NULL;
+    }
+    return ret;
+}

--- a/client/src/unifyfs_api.h
+++ b/client/src/unifyfs_api.h
@@ -166,6 +166,19 @@ unifyfs_rc unifyfs_initialize(const char* mountpoint,
 unifyfs_rc unifyfs_finalize(unifyfs_handle fshdl);
 
 /*
+ * Retrieve client's UnifyFS configuration for the given handle.
+ *
+ * @param[in]   fshdl       Client file system handle
+ * @param[out]  n_opts      pointer to size of options array
+ * @param[out]  options     pointer to array of configuration options
+ *
+ * @return      UnifyFS success or failure code
+ */
+unifyfs_rc unifyfs_get_config(unifyfs_handle fshdl,
+                              int* n_opts,
+                              unifyfs_cfg_option** options);
+
+/*
  * Create and open a new file in UnifyFS.
  *
  * @param[in]   fshdl       Client file system handle

--- a/common/src/unifyfs_configurator.c
+++ b/common/src/unifyfs_configurator.c
@@ -133,29 +133,9 @@ int unifyfs_config_fini(unifyfs_cfg_t* cfg)
         cfg->sec##_##key = NULL;                                \
     }
 
-#define UNIFYFS_CFG_MULTI(sec, key, typ, desc, vfn, me) \
-    for (u = 0; u < me; u++) {                          \
-        if (cfg->sec##_##key[u] != NULL) {              \
-            free(cfg->sec##_##key[u]);                  \
-            cfg->sec##_##key[u] = NULL;                 \
-        }                                               \
-    }                                                   \
-    cfg->n_##sec##_##key = 0;
-
-#define UNIFYFS_CFG_MULTI_CLI(sec, key, typ, desc, vfn, me, opt, use)   \
-    for (u = 0; u < me; u++) {                                          \
-        if (cfg->sec##_##key[u] != NULL) {                              \
-            free(cfg->sec##_##key[u]);                                  \
-            cfg->sec##_##key[u] = NULL;                                 \
-        }                                                               \
-    }                                                                   \
-    cfg->n_##sec##_##key = 0;
-
-    UNIFYFS_CONFIGS;
+    UNIFYFS_CONFIGS
 #undef UNIFYFS_CFG
 #undef UNIFYFS_CFG_CLI
-#undef UNIFYFS_CFG_MULTI
-#undef UNIFYFS_CFG_MULTI_CLI
 
     return (int)UNIFYFS_SUCCESS;
 }
@@ -184,29 +164,9 @@ void unifyfs_config_print(unifyfs_cfg_t* cfg,
         fprintf(fp, "%s\n", msg);                                       \
     }
 
-#define UNIFYFS_CFG_MULTI(sec, key, typ, desc, vfn, me)                 \
-    for (u = 0; u < me; u++) {                                          \
-        if (cfg->sec##_##key[u] != NULL) {                              \
-            snprintf(msg, sizeof(msg), "UNIFYFS CONFIG: %s.%s[%u] = %s", \
-                     #sec, #key, u+1, cfg->sec##_##key[u]);             \
-            fprintf(fp, "%s\n", msg);                                   \
-        }                                                               \
-    }
-
-#define UNIFYFS_CFG_MULTI_CLI(sec, key, typ, desc, vfn, me, opt, use)   \
-    for (u = 0; u < me; u++) {                                          \
-        if (cfg->sec##_##key[u] != NULL) {                              \
-            snprintf(msg, sizeof(msg), "UNIFYFS CONFIG: %s.%s[%u] = %s", \
-                     #sec, #key, u+1, cfg->sec##_##key[u]);             \
-            fprintf(fp, "%s\n", msg);                                   \
-        }                                                               \
-    }
-
-    UNIFYFS_CONFIGS;
+    UNIFYFS_CONFIGS
 #undef UNIFYFS_CFG
 #undef UNIFYFS_CFG_CLI
-#undef UNIFYFS_CFG_MULTI
-#undef UNIFYFS_CFG_MULTI_CLI
 
     fflush(fp);
 }
@@ -239,35 +199,9 @@ void unifyfs_config_print_ini(unifyfs_cfg_t* cfg,
         last_sec = curr_sec;                                            \
     }
 
-#define UNIFYFS_CFG_MULTI(sec, key, typ, desc, vfn, me)                 \
-    for (u = 0; u < me; u++) {                                          \
-        if (cfg->sec##_##key[u] != NULL) {                              \
-            curr_sec = #sec;                                            \
-            if ((last_sec == NULL) || (strcmp(curr_sec, last_sec) != 0)) \
-                fprintf(inifp, "\n[%s]\n", curr_sec);                   \
-            fprintf(inifp, "%s = %s ; (instance %u)\n",                 \
-                    #key, cfg->sec##_##key[u], u+1);                    \
-            last_sec = curr_sec;                                        \
-        }                                                               \
-    }
-
-#define UNIFYFS_CFG_MULTI_CLI(sec, key, typ, desc, vfn, me, opt, use)   \
-    for (u = 0; u < me; u++) {                                          \
-        if (cfg->sec##_##key[u] != NULL) {                              \
-            curr_sec = #sec;                                            \
-            if ((last_sec == NULL) || (strcmp(curr_sec, last_sec) != 0)) \
-                fprintf(inifp, "\n[%s]\n", curr_sec);                   \
-            fprintf(inifp, "%s = %s ; (instance %u)\n",                 \
-                    #key, cfg->sec##_##key[u], u+1);                    \
-            last_sec = curr_sec;                                        \
-        }                                                               \
-    }
-
-    UNIFYFS_CONFIGS;
+    UNIFYFS_CONFIGS
 #undef UNIFYFS_CFG
 #undef UNIFYFS_CFG_CLI
-#undef UNIFYFS_CFG_MULTI
-#undef UNIFYFS_CFG_MULTI_CLI
 
     fflush(inifp);
 }
@@ -291,19 +225,9 @@ int unifyfs_config_set_defaults(unifyfs_cfg_t* cfg)
     if (0 != strcmp(val, "NULLSTRING"))                         \
         cfg->sec##_##key = strdup(val);
 
-#define UNIFYFS_CFG_MULTI(sec, key, typ, desc, vfn, me)                 \
-    cfg->n_##sec##_##key = 0;                                           \
-    memset((void *)cfg->sec##_##key, 0, sizeof(cfg->sec##_##key));
-
-#define UNIFYFS_CFG_MULTI_CLI(sec, key, typ, desc, vfn, me, opt, use)   \
-    cfg->n_##sec##_##key = 0;                                           \
-    memset((void *)cfg->sec##_##key, 0, sizeof(cfg->sec##_##key));
-
-    UNIFYFS_CONFIGS;
+    UNIFYFS_CONFIGS
 #undef UNIFYFS_CFG
 #undef UNIFYFS_CFG_CLI
-#undef UNIFYFS_CFG_MULTI
-#undef UNIFYFS_CFG_MULTI_CLI
 
     return (int)UNIFYFS_SUCCESS;
 }
@@ -320,17 +244,9 @@ void unifyfs_config_cli_usage(char* arg0)
     fprintf(stderr, "    -%c,--%s-%s <%s>\t%s (default value: %s)\n",   \
             opt, #sec, #key, #typ, use, stringify(dv));
 
-#define UNIFYFS_CFG_MULTI(sec, key, typ, desc, vfn, me)
-
-#define UNIFYFS_CFG_MULTI_CLI(sec, key, typ, desc, vfn, me, opt, use)   \
-    fprintf(stderr, "    -%c,--%s-%s <%s>\t%s (multiple values supported - max %u entries)\n", \
-            opt, #sec, #key, #typ, use, me);
-
-    UNIFYFS_CONFIGS;
+    UNIFYFS_CONFIGS
 #undef UNIFYFS_CFG
 #undef UNIFYFS_CFG_CLI
-#undef UNIFYFS_CFG_MULTI
-#undef UNIFYFS_CFG_MULTI_CLI
 
     fflush(stderr);
 }
@@ -351,14 +267,11 @@ static struct option cli_options[] = {
 #define UNIFYFS_CFG(sec, key, typ, dv, desc, vfn)
 #define UNIFYFS_CFG_CLI(sec, key, typ, dv, desc, vfn, opt, use) \
     { #sec "-" #key, required_argument, NULL, opt },
-#define UNIFYFS_CFG_MULTI(sec, key, typ, desc, vfn, me)
-#define UNIFYFS_CFG_MULTI_CLI(sec, key, typ, desc, vfn, me, opt, use)   \
-    { #sec "-" #key, required_argument, NULL, opt },
+
     UNIFYFS_CONFIGS
 #undef UNIFYFS_CFG
 #undef UNIFYFS_CFG_CLI
-#undef UNIFYFS_CFG_MULTI
-#undef UNIFYFS_CFG_MULTI_CLI
+
     { NULL, 0, NULL, 0 }
 };
 
@@ -397,25 +310,10 @@ int unifyfs_config_process_cli_args(unifyfs_cfg_t* cfg,
         short_opts[sndx++] = ':';                               \
         cli_options[ondx++].has_arg = required_argument;        \
     }
-#define UNIFYFS_CFG_MULTI(sec, key, typ, desc, vfn, me)
 
-#define UNIFYFS_CFG_MULTI_CLI(sec, key, typ, desc, vfn, me, opt, use)   \
-    short_opts[sndx++] = opt;                                           \
-    if (strcmp(#typ, "BOOL") == 0) {                                    \
-        short_opts[sndx++] = ':';                                       \
-        short_opts[sndx++] = ':';                                       \
-        cli_options[ondx++].has_arg = optional_argument;                \
-    }                                                                   \
-    else {                                                              \
-        short_opts[sndx++] = ':';                                       \
-        cli_options[ondx++].has_arg = required_argument;                \
-    }
-
-    UNIFYFS_CONFIGS;
+    UNIFYFS_CONFIGS
 #undef UNIFYFS_CFG
 #undef UNIFYFS_CFG_CLI
-#undef UNIFYFS_CFG_MULTI
-#undef UNIFYFS_CFG_MULTI_CLI
 
     //fprintf(stderr, "UNIFYFS CONFIG DEBUG: short-opts '%s'\n", short_opts);
 
@@ -440,21 +338,10 @@ int unifyfs_config_process_cli_args(unifyfs_cfg_t* cfg,
             break;                                              \
         }
 
-#define UNIFYFS_CFG_MULTI(sec, key, typ, desc, vfn, me)
-
-#define UNIFYFS_CFG_MULTI_CLI(sec, key, typ, desc, vfn, me, opt, use)   \
-        case opt: {                                                     \
-            if (cfg->sec##_##key[cfg->n_##sec##_##key] != NULL)         \
-                free(cfg->sec##_##key[cfg->n_##sec##_##key];            \
-            cfg->sec##_##key[cfg->n_##sec##_##key++] = strdup(optarg);  \
-            break;                                                      \
-        }
-
         UNIFYFS_CONFIGS
 #undef UNIFYFS_CFG
 #undef UNIFYFS_CFG_CLI
-#undef UNIFYFS_CFG_MULTI
-#undef UNIFYFS_CFG_MULTI_CLI
+
 
         case ':':
             usage_err = 1;
@@ -547,33 +434,9 @@ int unifyfs_config_process_environ(unifyfs_cfg_t* cfg)
         cfg->sec##_##key = strdup(envval);                      \
     }
 
-#define UNIFYFS_CFG_MULTI(sec, key, typ, desc, vfn, me) \
-    for (u = 0; u < me; u++) {                          \
-        envval = getenv_helper(#sec, #key, u+1);        \
-        if (envval != NULL) {                           \
-            if (cfg->sec##_##key[u] != NULL)            \
-                free(cfg->sec##_##key[u]);              \
-            cfg->sec##_##key[u] = strdup(envval);       \
-            cfg->n_##sec##_##key++;                     \
-        }                                               \
-    }
-
-#define UNIFYFS_CFG_MULTI_CLI(sec, key, typ, desc, vfn, me, opt, use)   \
-    for (u = 0; u < me; u++) {                                          \
-        envval = getenv_helper(#sec, #key, u+1);                        \
-        if (envval != NULL) {                                           \
-            if (cfg->sec##_##key[u] != NULL)                            \
-                free(cfg->sec##_##key[u]);                              \
-            cfg->sec##_##key[u] = strdup(envval);                       \
-            cfg->n_##sec##_##key++;                                     \
-        }                                                               \
-    }
-
-    UNIFYFS_CONFIGS;
+    UNIFYFS_CONFIGS
 #undef UNIFYFS_CFG
 #undef UNIFYFS_CFG_CLI
-#undef UNIFYFS_CFG_MULTI
-#undef UNIFYFS_CFG_MULTI_CLI
 
     return (int)UNIFYFS_SUCCESS;
 }
@@ -618,21 +481,10 @@ int inih_config_handler(void* user,
         }                                                               \
     }
 
-#define UNIFYFS_CFG_MULTI(sec, key, typ, desc, vfn, me)                 \
-    else if ((strcmp(section, #sec) == 0) && (strcmp(kee, #key) == 0)) { \
-        cfg->sec##_##key[cfg->n_##sec##_##key++] = strdup(val);         \
-    }
-
-#define UNIFYFS_CFG_MULTI_CLI(sec, key, typ, desc, vfn, me, opt, use)   \
-    else if ((strcmp(section, #sec) == 0) && (strcmp(kee, #key) == 0)) { \
-        cfg->sec##_##key[cfg->n_##sec##_##key++] = strdup(val);         \
-    }
-
-UNIFYFS_CONFIGS
+    UNIFYFS_CONFIGS
 #undef UNIFYFS_CFG
 #undef UNIFYFS_CFG_CLI
-#undef UNIFYFS_CFG_MULTI
-#undef UNIFYFS_CFG_MULTI_CLI
+
 
     return 1;
 }
@@ -751,21 +603,9 @@ int unifyfs_config_process_option(unifyfs_cfg_t* cfg,
             }                                                                \
         }
 
-#define UNIFYFS_CFG_MULTI(sec, key, typ, desc, vfn, me)                      \
-        else if ((strcmp(section, #sec) == 0) && (strcmp(kee, #key) == 0)) { \
-            cfg->sec##_##key[cfg->n_##sec##_##key++] = strdup(opt_val);      \
-        }
-
-#define UNIFYFS_CFG_MULTI_CLI(sec, key, typ, desc, vfn, me, opt, use)        \
-        else if ((strcmp(section, #sec) == 0) && (strcmp(kee, #key) == 0)) { \
-            cfg->sec##_##key[cfg->n_##sec##_##key++] = strdup(opt_val);      \
-        }
-
-UNIFYFS_CONFIGS
+        UNIFYFS_CONFIGS
 #undef UNIFYFS_CFG
 #undef UNIFYFS_CFG_CLI
-#undef UNIFYFS_CFG_MULTI
-#undef UNIFYFS_CFG_MULTI_CLI
 
     }
 
@@ -778,7 +618,7 @@ int unifyfs_config_process_options(unifyfs_cfg_t* cfg,
                                    unifyfs_cfg_option* options)
 {
     if (nopt > 0) {
-        if (NULL == options) {
+        if ((NULL == cfg) || (NULL == options)) {
             return EINVAL;
         }
         for (int i = 0; i < nopt; i++) {
@@ -791,6 +631,71 @@ int unifyfs_config_process_options(unifyfs_cfg_t* cfg,
             }
         }
     }
+    return UNIFYFS_SUCCESS;
+}
+
+int unifyfs_config_get_options(unifyfs_cfg_t* cfg,
+                               int* nopt,
+                               unifyfs_cfg_option** options)
+{
+    if ((NULL == cfg) || (NULL == nopt) || (NULL == options)) {
+        return EINVAL;
+    }
+
+    *nopt = 0;
+    *options = NULL;
+
+    /* first, count the non-NULL settings */
+    int num_set = 0;
+
+#define UNIFYFS_CFG(sec, key, typ, dv, desc, vfn)                       \
+    if (cfg->sec##_##key != NULL) {                                     \
+        num_set++;                                                      \
+    }
+
+#define UNIFYFS_CFG_CLI(sec, key, typ, dv, desc, vfn, opt, use)         \
+    if (cfg->sec##_##key != NULL) {                                     \
+        num_set++;                                                      \
+    }
+
+    UNIFYFS_CONFIGS
+#undef UNIFYFS_CFG
+#undef UNIFYFS_CFG_CLI
+
+    /* now, allocate and fill the options array */
+    unifyfs_cfg_option* opts = calloc(num_set, sizeof(unifyfs_cfg_option));
+    if (NULL == opts) {
+        return ENOMEM;
+    }
+
+    int opt_ndx = 0;
+    unifyfs_cfg_option* curr_opt;
+    char kee[256];
+
+#define UNIFYFS_CFG(sec, key, typ, dv, desc, vfn)                       \
+    if (cfg->sec##_##key != NULL) {                                     \
+        curr_opt = opts + opt_ndx;                                      \
+        opt_ndx++;                                                      \
+        snprintf(kee, sizeof(kee), "%s.%s", #sec, #key);                \
+        curr_opt->opt_name = strdup(kee);                               \
+        curr_opt->opt_value = strdup(cfg->sec##_##key);                 \
+    }
+
+#define UNIFYFS_CFG_CLI(sec, key, typ, dv, desc, vfn, opt, use)         \
+    if (cfg->sec##_##key != NULL) {                                     \
+        curr_opt = opts + opt_ndx;                                      \
+        opt_ndx++;                                                      \
+        snprintf(kee, sizeof(kee), "%s.%s", #sec, #key);                \
+        curr_opt->opt_name = strdup(kee);                               \
+        curr_opt->opt_value = strdup(cfg->sec##_##key);                 \
+    }
+
+    UNIFYFS_CONFIGS
+#undef UNIFYFS_CFG
+#undef UNIFYFS_CFG_CLI
+
+    *nopt = num_set;
+    *options = opts;
     return UNIFYFS_SUCCESS;
 }
 
@@ -888,7 +793,7 @@ int unifyfs_config_validate(unifyfs_cfg_t* cfg)
         }                                                               \
     }
 
-    UNIFYFS_CONFIGS;
+    UNIFYFS_CONFIGS
 #undef UNIFYFS_CFG
 #undef UNIFYFS_CFG_CLI
 #undef UNIFYFS_CFG_MULTI

--- a/common/src/unifyfs_configurator.h
+++ b/common/src/unifyfs_configurator.h
@@ -67,7 +67,7 @@
     UNIFYFS_CFG_CLI(unifyfs, cleanup, BOOL, off, "cleanup storage on server exit", NULL, 'C', "on|off") \
     UNIFYFS_CFG_CLI(unifyfs, configfile, STRING, /etc/unifyfs.conf, "path to configuration file", configurator_file_check, 'f', "specify full path to config file") \
     UNIFYFS_CFG_CLI(unifyfs, consistency, STRING, LAMINATED, "consistency model", NULL, 'c', "specify consistency model (NONE | LAMINATED | POSIX)") \
-    UNIFYFS_CFG_CLI(unifyfs, daemonize, BOOL, on, "enable server daemonization", NULL, 'D', "on|off") \
+    UNIFYFS_CFG_CLI(unifyfs, daemonize, BOOL, off, "enable server daemonization", NULL, 'D', "on|off") \
     UNIFYFS_CFG_CLI(unifyfs, mountpoint, STRING, /unifyfs, "mountpoint directory", NULL, 'm', "specify full path to desired mountpoint") \
     UNIFYFS_CFG(client, cwd, STRING, NULLSTRING, "current working directory", NULL) \
     UNIFYFS_CFG(client, fsync_persist, BOOL, on, "persist written data to storage on fsync()", NULL) \
@@ -119,20 +119,10 @@ typedef struct {
 #define UNIFYFS_CFG_CLI(sec, key, typ, dv, desc, vfn, opt, use) \
     char *sec##_##key;
 
-#define UNIFYFS_CFG_MULTI(sec, key, typ, dv, desc, vfn, me) \
-    char *sec##_##key[me]; \
-    unsigned n_##sec##_##key;
-
-#define UNIFYFS_CFG_MULTI_CLI(sec, key, typ, dv, desc, vfn, me, opt, use) \
-    char *sec##_##key[me]; \
-    unsigned n_##sec##_##key;
-
     UNIFYFS_CONFIGS
-
 #undef UNIFYFS_CFG
 #undef UNIFYFS_CFG_CLI
-#undef UNIFYFS_CFG_MULTI
-#undef UNIFYFS_CFG_MULTI_CLI
+
 } unifyfs_cfg_t;
 
 /* initialization and cleanup */
@@ -177,6 +167,9 @@ int unifyfs_config_process_options(unifyfs_cfg_t* cfg,
                                    int nopt,
                                    unifyfs_cfg_option* options);
 
+int unifyfs_config_get_options(unifyfs_cfg_t* cfg,
+                               int* nopt,
+                               unifyfs_cfg_option** options);
 
 int unifyfs_config_validate(unifyfs_cfg_t* cfg);
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -56,7 +56,7 @@ a given section and key.
    cleanup        BOOL    cleanup storage on server exit (default: off)
    configfile     STRING  path to custom configuration file
    consistency    STRING  consistency model [ LAMINATED | POSIX | NONE ]
-   daemonize      BOOL    enable server daemonization (default: on)
+   daemonize      BOOL    enable server daemonization (default: off)
    mountpoint     STRING  mountpoint path prefix (default: /unifyfs)
    =============  ======  ===============================================
 

--- a/t/api/api_suite.c
+++ b/t/api/api_suite.c
@@ -57,6 +57,8 @@ int main(int argc, char* argv[])
 
     rc = api_initialize_test(unifyfs_root, &fshdl);
     if (rc == UNIFYFS_SUCCESS) {
+        api_config_test(unifyfs_root, &fshdl);
+
         api_create_open_remove_test(unifyfs_root, &fshdl);
 
         api_write_read_sync_stat_test(unifyfs_root, &fshdl,

--- a/t/api/api_suite.h
+++ b/t/api/api_suite.h
@@ -35,6 +35,10 @@
 int api_initialize_test(char* unifyfs_root,
                         unifyfs_handle* fshdl);
 
+/* Tests API get-configuration */
+int api_config_test(char* unifyfs_root,
+                    unifyfs_handle* fshdl);
+
 /* Tests API finalization */
 int api_finalize_test(char* unifyfs_root,
                       unifyfs_handle* fshdl);

--- a/t/api/init-fini.c
+++ b/t/api/init-fini.c
@@ -17,7 +17,7 @@
 int api_initialize_test(char* unifyfs_root,
                         unifyfs_handle* fshdl)
 {
-    diag("Starting API initialization tests");
+    diag("Starting API initialization test");
 
     int n_configs = 1;
     unifyfs_cfg_option chk_size = { .opt_name = "logio.chunk_size",
@@ -28,20 +28,46 @@ int api_initialize_test(char* unifyfs_root,
        "%s:%d unifyfs_initialize() is successful: rc=%d (%s)",
        __FILE__, __LINE__, rc, unifyfs_rc_enum_description(rc));
 
-    diag("Finished API initialization tests");
+    diag("Finished API initialization test");
+    return rc;
+}
+
+int api_config_test(char* unifyfs_root,
+                    unifyfs_handle* fshdl)
+{
+    diag("Starting API get-configuration test");
+
+    int n_opt;
+    unifyfs_cfg_option* options;
+    int rc = unifyfs_get_config(*fshdl, &n_opt, &options);
+    ok(rc == UNIFYFS_SUCCESS && NULL != options,
+       "%s:%d unifyfs_get_config() is successful: rc=%d (%s)",
+       __FILE__, __LINE__, rc, unifyfs_rc_enum_description(rc));
+
+    if (NULL != options) {
+        for (int i = 0; i < n_opt; i++) {
+            unifyfs_cfg_option* opt = options + i;
+            diag("UNIFYFS CONFIG: %s = %s", opt->opt_name, opt->opt_value);
+            free((void*)opt->opt_name);
+            free((void*)opt->opt_value);
+        }
+        free(options);
+    }
+
+    diag("Finished API get-configuration test");
     return rc;
 }
 
 int api_finalize_test(char* unifyfs_root,
                       unifyfs_handle* fshdl)
 {
-    diag("Starting API finalization tests");
+    diag("Starting API finalization test");
 
     int rc = unifyfs_finalize(*fshdl);
     ok(rc == UNIFYFS_SUCCESS,
        "%s:%d unifyfs_finalize() is successful: rc=%d (%s)",
        __FILE__, __LINE__, rc, unifyfs_rc_enum_description(rc));
 
-    diag("Finished API finalization tests");
+    diag("Finished API finalization test");
     return rc;
 }


### PR DESCRIPTION
### Description

Adds a programmatic way for library API clients to query the configuration settings for an initialized `unifyfs_handle`. The unit tests for the library API have been updated to exercise the new method.

Also includes:
* remove unused `UNIFYFS_CFG_MULTI` and `UNIFYFS_CFG_MULTI_CLI` macros from `unifyfs_configurator.[ch]`
* turn off `unifyfs.daemonize` config setting by default, since it causes issues on many types of systems but doesn't really offer any benefit

### How Has This Been Tested?

Tested in Ubuntu Docker

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Testing (addition of new tests or update to current tests)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
