### PR TITLE
Testing: print failed tests at end of run

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,6 @@ stages:
 
 .slurm-single-node-template:
   variables:
-    JOB_LAUNCH_COMMAND: "srun -N1 -n1"
     LLNL_SLURM_SCHEDULER_PARAMETERS: "-N 1 -p $QUEUE -t $UNIT_WALL_TIME -J unifyfs-unit-tests"
 
 .slurm-multi-node-template:
@@ -35,7 +34,6 @@ stages:
 
 .lsf-single-node-template:
   variables:
-    JOB_LAUNCH_COMMAND: "jsrun -r1 -n1"
     LLNL_LSF_SCHEDULER_PARAMETERS: "-nnodes 1 -q $QUEUE -W $UNIT_WALL_TIME -J unifyfs-unit-tests"
     SCHEDULER_PARAMETERS: "-nnodes 1 -P $PROJECT_ID -W $UNIT_WALL_TIME -J unifyfs-unit-tests"
 

--- a/.gitlab/ascent.yml
+++ b/.gitlab/ascent.yml
@@ -21,6 +21,8 @@
   tags: [nobatch]
 
 .ascent-batch-template:
+  variables:
+    JOB_LAUNCH_COMMAND: "jsrun -r1 -n1"
   extends: .ascent-template
   tags: [batch]
 

--- a/t/sharness.sh
+++ b/t/sharness.sh
@@ -158,6 +158,8 @@ test_fixed=0
 test_broken=0
 test_success=0
 
+declare -a failed_tests_list=()
+
 die() {
 	code=$?
 	if test -n "$EXIT_OK"; then
@@ -270,6 +272,7 @@ test_ok_() {
 test_failure_() {
 	test_failure=$(($test_failure + 1))
 	say_color error "not ok $test_count - $1"
+	failed_tests_list+=("$test_count - $1")
 	shift
 	echo "$@" | sed -e 's/^/#	/'
 	test "$immediate" = "" || { EXIT_OK=t; exit 1; }
@@ -784,6 +787,8 @@ test_done() {
 	*)
 		say_color error "# failed $test_failure among $msg"
 		say "1..$test_count"
+		say "Failed tests list:"
+		printf '%s\n' "${failed_tests_list[@]}"
 
 		exit 1 ;;
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Tweak _sharness.sh_ to print a list of any tests that failed at the end
of running
This prevents needing to scroll through the tests to figure out which
specific tests failed.

Move the `JOB_LAUNCH_COMMAND` in _gitlab-ci.yml_, used for launching
unit tests, to _ascent.yml_ in order to prevent hang on LC systems. Ascent
is currently the only system we test on that needs to launch the unit tests this way.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Want to list all failed tests at end of run as the unit and integration testing suites
are getting bigger and it's difficult to scroll through all the tests to find which failed.

Get unit tests run via GitLab CI to run again on system with Slurm.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

Ran all unit and integration tests on systems with LSF and Slurm via GitLab CI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
