### PR TITLE
Release allocated objects

### DIFF
--- a/client/src/unifyfs_api_io.c
+++ b/client/src/unifyfs_api_io.c
@@ -342,6 +342,10 @@ unifyfs_rc unifyfs_dispatch_io(unifyfs_handle fshdl,
             break;
         }
     }
+    if (rd_reqs) free(rd_reqs);
+    if (wr_reqs) free (wr_reqs);
+    if (tr_reqs) free (tr_reqs);
+    if (s_reqs) free(s_reqs);
 
     return UNIFYFS_SUCCESS;
 }


### PR DESCRIPTION
Valgrind flags these allocations as
==1655690== 10,486,400 (640 direct, 10,485,760 indirect) bytes in 1 blocks are definitely lost in loss record 35 of 35
==1655690==    at 0x483DD99: calloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==1655690==    by 0x4879CBC: unifyfs_dispatch_io (unifyfs_api_io.c:200)
==1655690==    by 0x109662: main (unify-example.c:46)

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

I'm just testing on my laptop, running the simple example from readthedocs

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x  Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ x] All commit messages are properly formatted.
