### PR TITLE
fix issue 675

### DIFF
--- a/server/src/unifyfs_p2p_rpc.c
+++ b/server/src/unifyfs_p2p_rpc.c
@@ -567,7 +567,8 @@ int unifyfs_invoke_find_extents_rpc(int gfid,
     unifyfs_file_attr_t attrs;
     int ret = sm_get_fileattr(gfid, &attrs);
     if (ret == UNIFYFS_SUCCESS) {
-        if (attrs.is_laminated || (owner_rank == glb_pmi_rank)) {
+        if ((owner_rank == glb_pmi_rank) ||
+            (attrs.is_laminated && attrs.is_shared)) {
             /* do local lookup */
             ret = sm_find_extents(gfid, (size_t)num_extents, extents,
                                   num_chunks, chunks);


### PR DESCRIPTION
### Description

For non-shared files, we don't broadcast file extents to all servers upon lamination. However, remote clients should still be able to read non-shared files once they are laminated. This fixes a bug where we assumed that if any file was laminated, we had the extent metadata at the local server.

### Motivation and Context
See Issue #675


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
