### PR TITLE
Integration tests: use unifyfs module if available

### DIFF
--- a/t/ci/002-start-server.sh
+++ b/t/ci/002-start-server.sh
@@ -54,8 +54,14 @@ test_expect_success "unifyfsd hasn't started yet" '
     process_is_not_running unifyfsd 10
 '
 
-$UNIFYFS_BIN/unifyfs start -c -d -S $UNIFYFS_SHAREDFS_DIR \
-    -e $UNIFYFS_BIN/unifyfsd &> ${UNIFYFS_LOG_DIR}/unifyfs.start.out
+# UNIFYFS_BIN envar is set if not using unifyfs module
+if [[ -n $UNIFYFS_BIN ]]; then
+    $UNIFYFS_CLU start -c -d -S $UNIFYFS_SHAREDFS_DIR \
+        -e $UNIFYFS_BIN/unifyfsd &> ${UNIFYFS_LOG_DIR}/unifyfs.start.out
+else
+    $UNIFYFS_CLU start -c -d -S $UNIFYFS_SHAREDFS_DIR \
+        &> ${UNIFYFS_LOG_DIR}/unifyfs.start.out
+fi
 
 test_expect_success "unifyfsd started" '
     process_is_running unifyfsd 10 ||

--- a/t/ci/990-stop-server.sh
+++ b/t/ci/990-stop-server.sh
@@ -24,7 +24,7 @@ test_expect_success "unifyfsd is still running" '
     process_is_running unifyfsd 10
 '
 
-$UNIFYFS_BIN/unifyfs terminate -d &> ${UNIFYFS_LOG_DIR}/unifyfs.terminate.out
+$UNIFYFS_CLU terminate -d &> ${UNIFYFS_LOG_DIR}/unifyfs.terminate.out
 
 test_expect_success "unifyfsd has stopped" '
     process_is_not_running unifyfsd 10


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Adjust UnifyFS integration tests to prefer the `unifyfs` module if it is a recognized command-line utility.

Otherwise default to user provided `$UNIFYFS_INSTALL` envar or a simple search if not provided.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Use a system installed UnifyFS module for running integration tests

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
