### PR TITLE
fix issue 682

### DIFF
--- a/client/src/unifyfs_api_io.c
+++ b/client/src/unifyfs_api_io.c
@@ -163,6 +163,13 @@ unifyfs_rc unifyfs_dispatch_io(unifyfs_handle fshdl,
     size_t n_sync = 0;
     for (size_t i = 0; i < nreqs; i++) {
         req = reqs + i;
+
+        /* set initial request result and state */
+        req->state = UNIFYFS_IOREQ_STATE_INVALID;
+        req->result.error = UNIFYFS_SUCCESS;
+        req->result.count = 0;
+        req->result.rc = 0;
+
         switch (req->op) {
         case UNIFYFS_IOREQ_NOP:
             break;
@@ -182,6 +189,7 @@ unifyfs_rc unifyfs_dispatch_io(unifyfs_handle fshdl,
             break;
         default:
             LOGERR("invalid ioreq operation");
+            req->result.error = EINVAL;
             return EINVAL;
         }
     }


### PR DESCRIPTION
### Description

Simple update to make sure we initialize the `result` and `state` fields of each `unifyfs_io_request` structure passed to `unifyfs_dispatch_io()`

### Motivation and Context

See #682

### How Has This Been Tested?

Tested in Ubuntu Docker.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
