### PR TITLE
Fix various memory leaks

### DIFF
--- a/server/src/margo_server.c
+++ b/server/src/margo_server.c
@@ -446,6 +446,8 @@ int margo_server_rpc_finalize(void)
             }
         }
 
+        free(server_infos);
+
         /* shut down margo */
         LOGDBG("finalizing server-server margo");
         margo_finalize(ctx->svr_mid);

--- a/server/src/unifyfs_inode.c
+++ b/server/src/unifyfs_inode.c
@@ -51,8 +51,6 @@ struct unifyfs_inode* unifyfs_inode_alloc(int gfid, unifyfs_file_attr_t* attr)
     return ino;
 }
 
-static int unifyfs_inode_destroy(struct unifyfs_inode* ino);
-
 /**
  * @brief read lock the inode for ro access.
  *
@@ -122,7 +120,6 @@ static int int_cmp_fn(const void* a, const void* b)
     return ai - bi;
 }
 
-static
 int unifyfs_inode_destroy(struct unifyfs_inode* ino)
 {
     int ret = UNIFYFS_SUCCESS;

--- a/server/src/unifyfs_inode.h
+++ b/server/src/unifyfs_inode.h
@@ -55,6 +55,15 @@ struct unifyfs_inode {
 int unifyfs_inode_create(int gfid, unifyfs_file_attr_t* attr);
 
 /**
+ * @brief delete an inode and all its contents
+ *
+ * @param ino  inode to destroy
+ *
+ * @return 0 on success, errno otherwise
+ */
+int unifyfs_inode_destroy(struct unifyfs_inode* ino);
+
+/**
  * @brief update the attributes of file with @gfid. The attributes are
  * selectively updated with unifyfs_file_attr_update() function (see
  * common/unifyfs_meta.h).

--- a/server/src/unifyfs_inode_tree.c
+++ b/server/src/unifyfs_inode_tree.c
@@ -189,19 +189,19 @@ void unifyfs_inode_tree_clear(
     while ((node = unifyfs_inode_tree_iter(tree, node))) {
         if (oldnode) {
             RB_REMOVE(rb_inode_tree, &tree->head, oldnode);
-            if (oldnode->extents != NULL) {
-                extent_tree_destroy(oldnode->extents);
+            int rc = unifyfs_inode_destroy(oldnode);
+            if (rc) {
+                LOGERR("Error %d from unifyfs_inode_destroy()", rc);
             }
-            free(oldnode);
         }
         oldnode = node;
     }
     if (oldnode) {
         RB_REMOVE(rb_inode_tree, &tree->head, oldnode);
-        if (oldnode->extents != NULL) {
-            extent_tree_destroy(oldnode->extents);
+        int rc = unifyfs_inode_destroy(oldnode);
+        if (rc) {
+            LOGERR("Error %d from unifyfs_inode_destroy()", rc);
         }
-        free(oldnode);
     }
 
     unifyfs_inode_tree_unlock(tree);

--- a/server/src/unifyfs_service_manager.c
+++ b/server/src/unifyfs_service_manager.c
@@ -273,6 +273,12 @@ int svcmgr_fini(void)
             arraylist_free(sm->svc_reqs);
         }
 
+        int abt_err = ABT_mutex_free(&(sm->reqs_sync));
+        if (ABT_SUCCESS != abt_err) {
+            /* All we can really do here is log the error */
+            LOGERR("Error code returned from ABT_mutex_free(): %d", abt_err);
+        }
+
         if (sm->initialized) {
             pthread_mutex_destroy(&(sm->thrd_lock));
             pthread_cond_destroy(&(sm->thrd_cond));


### PR DESCRIPTION
Fix a variety of individual memory leaks in unifyfsd

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

* Removed 'static' descriptor from unifyfs_inode_destroy() so it could be
called from unifyfs_inode_tree_clear() and then call it from
unifyfs_inode_tree_clear() instead of free'ing components of the inodes
manually.
* Error handling conditions in unifyfs_rm_thrd_create() didn't always
free  everything they should.
* In process_metaset_rpc(), properly free requests created by
create_mountpoint_dir().  (See detailed comments in the code.)
* In unifyfs_exit(), free the appconfigs_abt_sync mutex and finalize the
config variables.
* In svcmgr_fini(), free the sm->reqs_sync mutex.
* In cleanup_app_client(), before freeing the reqmgr struct, free the
reqmgr->client_reqs and reqmgr->client_callbacks arraylists and the
reqmgr->reqs_sync mutex.
* In margo_server_rpc_finalize(), free the server_infos struct.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes issue #660 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Tested by running unifyfsd with Valgrind and then running some simple clients (all on an Ubuntu workstation).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [X] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] All commit messages are properly formatted.
