### PR TITLE
update CRUISE license

### DIFF
--- a/LICENSE.CRUISE
+++ b/LICENSE.CRUISE
@@ -2,36 +2,67 @@
 Copyright and BSD License
 ---------------------
 
-Copyright (c) 2017, Lawrence Livermore National Security, LLC.
-Produced at the Lawrence Livermore National Laboratory.
-
-Copyright (c) 2017, Florida State University.
-Contributions from the Computer Architecture and Systems Research Laboratory (CASTL)
-at the Department of Computer Science.
-
+Copyright (c) 2014, Lawrence Livermore National Security, LLC.
+Produced at the Lawrence Livermore National Laboratory
 Written by
-	Teng Wang tw15g@my.fsu.edu
-	Adam Moody moody20@llnl.gov
-	Weikuan Yu wyu3@fsu.edu
-	Kento Sato kento@llnl.gov
-	Kathryn Mohror kathryn@llnl.gov
-LLNL-CODE-728877.
-
+  Raghunath Rajachandrasekar <rajachan@cse.ohio-state.edu>
+  Kathryn Mohror <kathryn@llnl.gov>
+  Adam Moody <moody20@llnl.gov>
+LLNL-CODE-642432.
 All rights reserved.
-This file is part of CRUISE. For details, see https://github.com/llnl/cruise.
-Permission is hereby granted, free of charge, to any person obtaining a copy of this
-software and associated documentation files (the "Software"),
-to deal in the Software without restriction, including without limitation the rights to use,
-copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
-to permit persons to whom the Software is furnished to do so, subject to the following
-conditions:
+This file is part of CRUISE.
+For details, see https://github.com/hpc/cruise
 
-The above copyright notice and this permission notice shall be included in all copies or substantial
-portions of the Software.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
-ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
-OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+  - Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the disclaimer below.
+
+  - Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the disclaimer (as noted
+    below) in the documentation and/or other materials provided with
+    the distribution.
+
+  - Neither the name of the LLNS/LLNL nor the names of its
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL LAWRENCE
+LIVERMORE NATIONAL SECURITY, LLC, THE U.S. DEPARTMENT OF ENERGY OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+---------------------
+Additional BSD Notice
+---------------------
+
+1. This notice is required to be provided under our contract with the
+   U.S. Department of Energy (DOE). This work was produced at Lawrence
+   Livermore National Laboratory under Contract No. DE-AC52-07NA27344
+   with the DOE.
+
+2. Neither the United States Government nor Lawrence Livermore
+   National Security, LLC nor any of their employees, makes any
+   warranty, express or implied, or assumes any liability or
+   responsibility for the accuracy, completeness, or usefulness of
+   any information, apparatus, product, or process disclosed, or
+   represents that its use would not infringe privately-owned rights.
+
+3. Also, reference herein to any specific commercial products, process,
+   or services by trade name, trademark, manufacturer or otherwise does
+   not necessarily constitute or imply its endorsement, recommendation,
+   or favoring by the United States Government or Lawrence Livermore
+   National Security, LLC. The views and opinions of authors expressed
+   herein do not necessarily state or reflect those of the United States
+   Government or Lawrence Livermore National Security, LLC, and shall
+   not be used for advertising or product endorsement purposes.


### PR DESCRIPTION
For some reason the CRUISE license was actually the BurstFS license. Updated the file with the correct license text from the CRUISE repo: https://github.com/LLNL/cruise/blob/master/COPYRIGHT

<!--- Provide a general summary of your changes in the Title above -->

### Description
Simple text change to license

### Motivation and Context
We want to have the correct license in the repository for CRUISE

### How Has This Been Tested?
N/A

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [x ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
