### PR TITLE
Define _STAT_VER if it's not already defined

### DIFF
--- a/client/src/unifyfs-sysio.c
+++ b/client/src/unifyfs-sysio.c
@@ -814,6 +814,16 @@ int UNIFYFS_WRAP(fstat)(int fd, struct stat* buf)
  * instead of using the absolute value 3.
  */
 
+/*
+ * NOTE 2: As of glibc-2.33, _STAT_VER is no longer defined in bits/stat.h.
+ * __xstat is also no longer declared in stat.h, but it still exists in the
+ * library, so HAVE___XSTAT will be true.  (The same goes for __lxstat &
+ * __fxstat.)  In such a case, we have to define _STAT_VER ourselves.
+ */
+#ifndef _STAT_VER
+  #define _STAT_VER 3
+#endif
+
 #ifdef HAVE___XSTAT
 int UNIFYFS_WRAP(__xstat)(int vers, const char* path, struct stat* buf)
 {


### PR DESCRIPTION
As of glibc v2.33, _STAT_VER is no longer defined.  This commit adds
code to #define it to 3 if it's not already defined.

Fixes issue #687

<!--- Provide a general summary of your changes in the Title above -->

### Description
This is a very simple change:  If the symbol isn't already defined, then just define it to 3.

### Motivation and Context
We need this change because newer versions of glibc (starting at v2.33) no longer define the symbol.  (See issue #687.)

### How Has This Been Tested?
Tested on a Fedora 34 VM.  (The "enterprise class" Linux distros haven't a new enough glibc yet.)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the UnifyFS code style requirements.
- [N/A ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
- [x ] All commit messages are properly formatted.
