### PR TITLE
Add server.local_extents mode

### DIFF
--- a/common/src/unifyfs_configurator.h
+++ b/common/src/unifyfs_configurator.h
@@ -71,7 +71,7 @@
     UNIFYFS_CFG_CLI(unifyfs, mountpoint, STRING, /unifyfs, "mountpoint directory", NULL, 'm', "specify full path to desired mountpoint") \
     UNIFYFS_CFG(client, cwd, STRING, NULLSTRING, "current working directory", NULL) \
     UNIFYFS_CFG(client, fsync_persist, BOOL, on, "persist written data to storage on fsync()", NULL) \
-    UNIFYFS_CFG(client, local_extents, BOOL, off, "track extents to service reads of local data", NULL) \
+    UNIFYFS_CFG(client, local_extents, BOOL, off, "cache extents within client to service local reads without consulting local server", NULL) \
     UNIFYFS_CFG(client, max_files, INT, UNIFYFS_CLIENT_MAX_FILES, "client max file count", NULL) \
     UNIFYFS_CFG(client, write_index_size, INT, UNIFYFS_CLIENT_WRITE_INDEX_SIZE, "write metadata index buffer size", NULL) \
     UNIFYFS_CFG(client, write_sync, BOOL, off, "sync every write to server", NULL) \
@@ -90,6 +90,7 @@
     UNIFYFS_CFG_CLI(runstate, dir, STRING, RUNDIR, "runstate file directory", configurator_directory_check, 'R', "specify full path to directory to contain server-local state") \
     UNIFYFS_CFG_CLI(server, hostfile, STRING, NULLSTRING, "server hostfile name", NULL, 'H', "specify full path to server hostfile") \
     UNIFYFS_CFG_CLI(server, init_timeout, INT, UNIFYFS_DEFAULT_INIT_TIMEOUT, "timeout of waiting for server initialization", NULL, 't', "timeout in seconds to wait for servers to be ready for clients") \
+    UNIFYFS_CFG(server, local_extents, BOOL, off, "use server extents to service local reads without consulting file owner", NULL) \
     UNIFYFS_CFG(server, max_app_clients, INT, UNIFYFS_SERVER_MAX_APP_CLIENTS, "maximum number of clients per application", NULL) \
     UNIFYFS_CFG_CLI(sharedfs, dir, STRING, NULLSTRING, "shared file system directory", configurator_directory_check, 'S', "specify full path to directory to contain server shared files") \
 

--- a/configure.ac
+++ b/configure.ac
@@ -402,6 +402,8 @@ AC_CONFIG_FILES([Makefile
                  util/scripts/lsfcsm/Makefile
                  util/unifyfs/Makefile
                  util/unifyfs/src/Makefile
+                 util/unifyfs-api-client/Makefile
+                 util/unifyfs-api-client/src/Makefile
                  util/unifyfs-stage/Makefile
                  util/unifyfs-stage/src/Makefile])
 

--- a/examples/src/multi-write.c
+++ b/examples/src/multi-write.c
@@ -61,7 +61,7 @@ int check_file(char* file)
     int fd;
     int rc;
     int matched = 0;
-    fd = open(file, O_RDONLY, 0222);
+    fd = open(file, O_RDONLY);
 
     memset(tmpbuf, 0, sizeof(tmpbuf));
     rc = read(fd, tmpbuf, sizeof(tmpbuf));
@@ -159,12 +159,13 @@ int do_test(test_cfg* cfg)
         }
         close(fds[i]);
 
-        rc = chmod(file[i], 0444);
-        if (rc != 0) {
-            printf("%s failed to chmod, rc = %d\n", file[i], rc);
-            exit(1);
+        if (cfg->laminate) {
+            rc = chmod(file[i], 0444);
+            if (rc != 0) {
+                printf("%s failed to chmod, rc = %d\n", file[i], rc);
+                exit(1);
+            }
         }
-
     }
 
     /* Verify the writes to the files match the values in bigbuf[] */

--- a/examples/src/read.c
+++ b/examples/src/read.c
@@ -207,7 +207,7 @@ int main(int argc, char* argv[])
     timer_start_barrier(cfg, &time_check);
     rc = check_read_req_batch(cfg, num_reqs, reqs);
     if (rc) {
-        test_abort(cfg, rc);
+        test_print_once(cfg, "ERROR: data check failed!");
     }
     timer_stop_barrier(cfg, &time_check);
     test_print_verbose_once(cfg, "DEBUG: finished data check");
@@ -236,8 +236,8 @@ int main(int argc, char* argv[])
                         "I/O block size:            %.2lf KiB\n"
                         "I/O request size:          %.2lf KiB\n"
                         "Number of processes:       %d\n"
-                        "Each process wrote:        %.2lf MiB\n"
-                        "Total data written:        %.2lf MiB\n"
+                        "Each process read:         %.2lf MiB\n"
+                        "Total data read:           %.2lf MiB\n"
                         "File stat time:            %.6lf sec\n"
                         "File open time:            %.6lf sec\n"
                         "Maximum read time:         %.6lf sec\n"

--- a/examples/src/testutil.h
+++ b/examples/src/testutil.h
@@ -131,6 +131,7 @@ typedef struct {
     int io_pattern;    /* N1 or NN */
     int io_check;      /* use lipsum to verify data */
     int io_shuffle;    /* read and write different extents */
+    int laminate;      /* laminate file after writing */
     int pre_wr_trunc;  /* truncate file before writing */
     int post_wr_trunc; /* truncate file after writing */
     int use_aio;       /* use asynchronous IO */
@@ -239,6 +240,7 @@ void test_config_print(test_cfg* cfg)
     fprintf(fp, "\t io_pattern  = %s\n", io_pattern_str(cfg->io_pattern));
     fprintf(fp, "\t io_check    = %d\n", cfg->io_check);
     fprintf(fp, "\t io_shuffle  = %d\n", cfg->io_shuffle);
+    fprintf(fp, "\t laminate    = %d\n", cfg->laminate);
     fprintf(fp, "\t pre_trunc   = %d\n", cfg->pre_wr_trunc);
     fprintf(fp, "\t post_trunc  = %d\n", cfg->post_wr_trunc);
     fprintf(fp, "\t use_aio     = %d\n", cfg->use_aio);
@@ -523,9 +525,10 @@ int test_is_static(const char* program)
 
 // common options for all tests
 
-static const char* test_short_opts = "Ab:c:dD:f:hklLm:Mn:No:p:PrSt:T:uUvVx";
+static const char* test_short_opts = "aAb:c:dD:f:hklLm:Mn:No:p:PrSt:T:uUvVx";
 
 static const struct option test_long_opts[] = {
+    { "library-api", 0, 0, 'a' },
     { "aio", 0, 0, 'A' },
     { "blocksize", 1, 0, 'b' },
     { "chunksize", 1, 0, 'c' },
@@ -534,7 +537,7 @@ static const struct option test_long_opts[] = {
     { "file", 1, 0, 'f' },
     { "help", 0, 0, 'h' },
     { "check", 0, 0, 'k' },
-    { "library-api", 0, 0, 'l' },
+    { "laminate", 0, 0, 'l' },
     { "listio", 0, 0, 'L' },
     { "mount", 1, 0, 'm' },
     { "mpiio", 0, 0, 'M' },
@@ -560,6 +563,8 @@ static const char* test_usage_str =
     "Usage: %s [options...]\n"
     "\n"
     "Available options:\n"
+    " -a, --library-api                use UnifyFS library API instead of POSIX I/O\n"
+    "                                  (default: off)\n"
     " -A, --aio                        use asynchronous I/O instead of read|write\n"
     "                                  (default: off)\n"
     " -b, --blocksize=<bytes>          I/O block size\n"
@@ -574,7 +579,7 @@ static const char* test_usage_str =
     "                                  (default: 'testfile')\n"
     " -k, --check                      check data contents upon read\n"
     "                                  (default: off)\n"
-    " -l, --library-api                use UnifyFS library API instead of POSIX I/O\n"
+    " -l, --laminate                   laminate file after writing all data\n"
     "                                  (default: off)\n"
     " -L, --listio                     use lio_listio instead of read|write\n"
     "                                  (default: off)\n"

--- a/examples/src/write-transfer.c
+++ b/examples/src/write-transfer.c
@@ -297,14 +297,16 @@ int main(int argc, char* argv[])
         "DEBUG: finished sync (elapsed=%.6lf sec)",
         time_sync.elapsed_sec_all);
 
-    // laminate
-    test_print_verbose_once(cfg, "DEBUG: laminating target file");
-    rc = write_laminate(cfg, target_file);
-    if (rc) {
-        test_abort(cfg, rc);
+    if (cfg->laminate) {
+        // laminate
+        test_print_verbose_once(cfg, "DEBUG: laminating target file");
+        rc = write_laminate(cfg, target_file);
+        if (rc) {
+            test_abort(cfg, rc);
+        }
     }
 
-    // stat file post-laminate
+    // stat file
     test_print_verbose_once(cfg, "DEBUG: calling stat() on target file");
     stat_cmd(cfg, target_file);
 

--- a/examples/src/write.c
+++ b/examples/src/write.c
@@ -221,14 +221,16 @@ int main(int argc, char* argv[])
     free(reqs);
     reqs = NULL;
 
-    // laminate
-    timer_start_barrier(cfg, &time_laminate);
-    rc = write_laminate(cfg, target_file);
-    if (rc) {
-        test_abort(cfg, rc);
+    if (cfg->laminate) {
+        // laminate
+        timer_start_barrier(cfg, &time_laminate);
+        rc = write_laminate(cfg, target_file);
+        if (rc) {
+            test_abort(cfg, rc);
+        }
+        timer_stop_barrier(cfg, &time_laminate);
+        test_print_verbose_once(cfg, "DEBUG: finished laminate");
     }
-    timer_stop_barrier(cfg, &time_laminate);
-    test_print_verbose_once(cfg, "DEBUG: finished laminate");
 
     // timer to wrap all parts of write operation
     timer_stop_barrier(cfg, &time_create2laminate);

--- a/examples/src/writeread.c
+++ b/examples/src/writeread.c
@@ -308,24 +308,26 @@ int main(int argc, char* argv[])
             time_stat_pre2.elapsed_sec_all);
     }
 
-    // laminate
-    timer_start_barrier(cfg, &time_laminate);
-    rc = write_laminate(cfg, target_file);
-    if (rc) {
-        test_abort(cfg, rc);
-    }
-    timer_stop_barrier(cfg, &time_laminate);
-    test_print_verbose_once(cfg,
-        "DEBUG: finished laminate (elapsed=%.6lf sec)",
-        time_laminate.elapsed_sec_all);
+    if (cfg->laminate) {
+        // laminate
+        timer_start_barrier(cfg, &time_laminate);
+        rc = write_laminate(cfg, target_file);
+        if (rc) {
+            test_abort(cfg, rc);
+        }
+        timer_stop_barrier(cfg, &time_laminate);
+        test_print_verbose_once(cfg,
+            "DEBUG: finished laminate (elapsed=%.6lf sec)",
+            time_laminate.elapsed_sec_all);
 
-    // stat file post-laminate
-    timer_start_barrier(cfg, &time_stat_post);
-    stat_cmd(cfg, target_file);
-    timer_stop_barrier(cfg, &time_stat_post);
-    test_print_verbose_once(cfg,
-        "DEBUG: finished stat post-laminate (elapsed=%.6lf sec)",
-        time_stat_post.elapsed_sec_all);
+        // stat file post-laminate
+        timer_start_barrier(cfg, &time_stat_post);
+        stat_cmd(cfg, target_file);
+        timer_stop_barrier(cfg, &time_stat_post);
+        test_print_verbose_once(cfg,
+            "DEBUG: finished stat post-laminate (elapsed=%.6lf sec)",
+            time_stat_post.elapsed_sec_all);
+    }
 
     // post-write cleanup
     free(wr_buf);

--- a/server/src/extent_tree.h
+++ b/server/src/extent_tree.h
@@ -168,7 +168,8 @@ int extent_tree_get_chunk_list(
     unsigned long offset,            /* starting logical offset */
     unsigned long len,               /* length of extent */
     unsigned int* n_chunks,          /* [out] number of chunks returned */
-    chunk_read_req_t** chunks);      /* [out] extent array */
+    chunk_read_req_t** chunks,       /* [out] chunk array */
+    int* extent_covered);            /* [out] set=1 if extent fully covered */
 
 /* dump method for debugging extent trees */
 static inline

--- a/server/src/unifyfs_global.h
+++ b/server/src/unifyfs_global.h
@@ -74,9 +74,14 @@ typedef struct {
     int pmi_rank;
 } server_info_t;
 
-extern size_t glb_num_servers; /* number of entries in glb_servers array */
+/* number of entries in glb_servers array */
+extern size_t glb_num_servers;
 
-extern struct unifyfs_inode_tree* global_inode_tree; /* global inode tree */
+/* global inode tree */
+extern struct unifyfs_inode_tree* global_inode_tree;
+
+/* flag to control the use of server local extents for faster local reads */
+extern bool use_server_local_extents;
 
 // NEW READ REQUEST STRUCTURES
 typedef enum {

--- a/server/src/unifyfs_inode.h
+++ b/server/src/unifyfs_inode.h
@@ -170,12 +170,14 @@ int unifyfs_inode_laminate(int gfid);
  *
  * @param[out] n_chunks  number of output chunk locations
  * @param[out] chunks    array of output chunk locations
+ * @param[out] full_coverage  set to 1 if chunks fully cover extent
  *
  * @return UNIFYFS_SUCCESS, or error code
  */
 int unifyfs_inode_get_extent_chunks(unifyfs_inode_extent_t* extent,
                                     unsigned int* n_chunks,
-                                    chunk_read_req_t** chunks);
+                                    chunk_read_req_t** chunks,
+                                    int* full_coverage);
 
 /**
  * @brief Get chunk locations for an array of file extents
@@ -183,15 +185,17 @@ int unifyfs_inode_get_extent_chunks(unifyfs_inode_extent_t* extent,
  * @param n_extents  number of input extents
  * @param extents    array or requested extents
  *
- * @param[out] n_locs     number of output chunk locations
- * @param[out] chunklocs  array of output chunk locations
+ * @param[out] n_locs         number of output chunk locations
+ * @param[out] chunklocs      array of output chunk locations
+ * @param[out] full_coverage  set to 1 if chunks fully cover extents
  *
  * @return UNIFYFS_SUCCESS, or error code
  */
 int unifyfs_inode_resolve_extent_chunks(unsigned int n_extents,
                                         unifyfs_inode_extent_t* extents,
                                         unsigned int* n_locs,
-                                        chunk_read_req_t** chunklocs);
+                                        chunk_read_req_t** chunklocs,
+                                        int* full_coverage);
 
 /**
  * @brief calls extents_tree_span, which will do:

--- a/server/src/unifyfs_server.c
+++ b/server/src/unifyfs_server.c
@@ -53,6 +53,8 @@ size_t glb_num_servers;     // size of glb_servers array
 
 unifyfs_cfg_t server_cfg;
 
+bool use_server_local_extents; // = false
+
 /* arraylist to track failed clients */
 arraylist_t* failed_clients; // = NULL
 
@@ -314,6 +316,14 @@ int main(int argc, char* argv[])
         rc = configurator_bool_val(server_cfg.log_on_error, &enable);
         if ((0 == rc) && enable) {
             unifyfs_set_log_on_error();
+        }
+    }
+
+    if (server_cfg.server_local_extents != NULL) {
+        bool enable = false;
+        rc = configurator_bool_val(server_cfg.server_local_extents, &enable);
+        if ((0 == rc) && enable) {
+            use_server_local_extents = true;
         }
     }
 

--- a/server/src/unifyfs_service_manager.h
+++ b/server/src/unifyfs_service_manager.h
@@ -86,7 +86,8 @@ int sm_find_extents(int gfid,
                     size_t num_extents,
                     unifyfs_inode_extent_t* extents,
                     unsigned int* out_num_chunks,
-                    chunk_read_req_t** out_chunks);
+                    chunk_read_req_t** out_chunks,
+                    int* full_coverage);
 
 int sm_transfer(int client_server,
                 int client_app,

--- a/util/Makefile.am
+++ b/util/Makefile.am
@@ -1,1 +1,1 @@
-SUBDIRS = scripts unifyfs unifyfs-stage
+SUBDIRS = scripts unifyfs unifyfs-api-client unifyfs-stage

--- a/util/unifyfs-api-client/Makefile.am
+++ b/util/unifyfs-api-client/Makefile.am
@@ -1,0 +1,1 @@
+SUBDIRS = src

--- a/util/unifyfs-api-client/src/Makefile.am
+++ b/util/unifyfs-api-client/src/Makefile.am
@@ -1,0 +1,29 @@
+libexec_PROGRAMS = \
+  unifyfs-laminate \
+  unifyfs-remove
+
+CLEANFILES = $(libexec_PROGRAMS)
+
+# Compiler/linker flags
+
+AM_CFLAGS = -Wall -Werror
+
+api_client_cppflags = \
+   $(AM_CPPFLAGS) \
+   -I$(top_srcdir)/client/src \
+   -I$(top_srcdir)/common/src
+
+api_client_ldadd   = $(top_builddir)/client/src/libunifyfs_api.la
+api_client_ldflags = $(AM_LDFLAGS) -static
+
+# Per-target flags begin here
+
+unifyfs_laminate_CPPFLAGS = $(api_client_cppflags)
+unifyfs_laminate_LDADD    = $(api_client_ldadd)
+unifyfs_laminate_LDFLAGS  = $(api_client_ldflags)
+unifyfs_laminate_SOURCES  = unifyfs-laminate.c
+
+unifyfs_remove_CPPFLAGS = $(api_client_cppflags)
+unifyfs_remove_LDADD    = $(api_client_ldadd)
+unifyfs_remove_LDFLAGS  = $(api_client_ldflags)
+unifyfs_remove_SOURCES  = unifyfs-remove.c

--- a/util/unifyfs-api-client/src/unifyfs-laminate.c
+++ b/util/unifyfs-api-client/src/unifyfs-laminate.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2021, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2021, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyFS.
+ * For details, see https://github.com/LLNL/UnifyFS.
+ * Please read https://github.com/LLNL/UnifyFS/LICENSE for full license text.
+ */
+
+#include <stdio.h>
+#include "unifyfs_api.h"
+
+static void usage(char* arg0)
+{
+    fprintf(stderr, "USAGE: %s <mountpoint> <file-path1> [<file-path2> ...]\n",
+            arg0);
+    fflush(stderr);
+}
+
+int main(int argc, char** argv)
+{
+    if (argc < 3) {
+        fprintf(stderr, "USAGE ERROR: expected two or more arguments!\n");
+        usage(argv[0]);
+        return -1;
+    }
+
+    char* mountpt = argv[1];
+
+    unifyfs_handle fshdl;
+    unifyfs_rc urc = unifyfs_initialize(mountpt, NULL, 0, &fshdl);
+    if (UNIFYFS_SUCCESS != urc) {
+        fprintf(stderr, "UNIFYFS ERROR: init failed at mountpoint %s - %s\n",
+                mountpt, unifyfs_rc_enum_description(urc));
+        return 1;
+    }
+
+    for (int i = 2; i < argc; i++) {
+        char* filepath = argv[i];
+        urc = unifyfs_laminate(fshdl, filepath);
+        if (UNIFYFS_SUCCESS != urc) {
+            fprintf(stderr, "UNIFYFS ERROR: failed to laminate file %s - %s\n",
+                    filepath, unifyfs_rc_enum_description(urc));
+            return 2;
+        }
+    }
+
+    urc = unifyfs_finalize(fshdl);
+    if (UNIFYFS_SUCCESS != urc) {
+        fprintf(stderr, "UNIFYFS ERROR: failed to finalize - %s\n",
+                unifyfs_rc_enum_description(urc));
+        return 3;
+    }
+
+    return 0;
+}

--- a/util/unifyfs-api-client/src/unifyfs-remove.c
+++ b/util/unifyfs-api-client/src/unifyfs-remove.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2021, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2021, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyFS.
+ * For details, see https://github.com/LLNL/UnifyFS.
+ * Please read https://github.com/LLNL/UnifyFS/LICENSE for full license text.
+ */
+
+#include <stdio.h>
+#include "unifyfs_api.h"
+
+static void usage(char* arg0)
+{
+    fprintf(stderr, "USAGE: %s <mountpoint> <file-path1> [<file-path2> ...]\n",
+            arg0);
+    fflush(stderr);
+}
+
+int main(int argc, char** argv)
+{
+    if (argc < 3) {
+        fprintf(stderr, "USAGE ERROR: expected two arguments!\n");
+        usage(argv[0]);
+        return -1;
+    }
+
+    char* mountpt = argv[1];
+
+    unifyfs_handle fshdl;
+    unifyfs_rc urc = unifyfs_initialize(mountpt, NULL, 0, &fshdl);
+    if (UNIFYFS_SUCCESS != urc) {
+        fprintf(stderr, "UNIFYFS ERROR: init failed at mountpoint %s - %s\n",
+                mountpt, unifyfs_rc_enum_description(urc));
+        return 1;
+    }
+
+    for (int i = 2; i < argc; i++) {
+        char* filepath = argv[i];
+        urc = unifyfs_remove(fshdl, filepath);
+        if (UNIFYFS_SUCCESS != urc) {
+            fprintf(stderr, "UNIFYFS ERROR: failed to remove file %s - %s\n",
+                    filepath, unifyfs_rc_enum_description(urc));
+            return 2;
+        }
+    }
+
+    urc = unifyfs_finalize(fshdl);
+    if (UNIFYFS_SUCCESS != urc) {
+        fprintf(stderr, "UNIFYFS ERROR: failed to finalize - %s\n",
+                unifyfs_rc_enum_description(urc));
+        return 3;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
### Description

Restores the server option `server.local_extents` to utilize cached local extents for servicing local reads without consulting the file owner. The server will bypass the owner extents lookup rpc only when the local extent metadata completely covers the requested file extent. This option applies to all clients of the server, and assumes that clients on different nodes do not use overlapping writes to the same extents.

Also:
* add `-l|--laminate` as config option to examples testutil, and update write examples accordingly
* add utility clients for library api-based laminate and remove

### How Has This Been Tested?

Tested on OLCF Summit.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
