### PR TITLE
use flexible arrays

### DIFF
--- a/common/src/tinyexpr.c
+++ b/common/src/tinyexpr.c
@@ -84,7 +84,7 @@ typedef struct state {
 static te_expr *new_expr(const int type, const te_expr *parameters[]) {
     const int arity = ARITY(type);
     const int psize = sizeof(void*) * arity;
-    const int size = (sizeof(te_expr) - sizeof(void*)) + psize + (IS_CLOSURE(type) ? sizeof(void*) : 0);
+    const int size = sizeof(te_expr) + psize + (IS_CLOSURE(type) ? sizeof(void*) : 0);
     te_expr *ret = malloc(size);
     memset(ret, 0, size);
     if (arity && parameters) {

--- a/common/src/tinyexpr.h
+++ b/common/src/tinyexpr.h
@@ -35,7 +35,7 @@ extern "C" {
 typedef struct te_expr {
     int type;
     union {double value; const double *bound; const void *function;};
-    void *parameters[1];
+    void *parameters[];
 } te_expr;
 
 


### PR DESCRIPTION
newer gcc-11 will complain about overrunning arrays if we don't use the
C99 standard "flexible array" notation


### Description
the 'tinyexpr' library used an old school "grow this last member of a struct" approach.  gcc-11 flags that as an array overrun.  

### Motivation and Context
Since Unify build with Werror (we can talk more about that later...), when I build with gcc-11 the array overrun warnings cause the build to fail

### How Has This Been Tested?
Tested on my laptop.  

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted.
