### PR TITLE
update margo usage to avoid runtime hangs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -130,7 +130,7 @@ before_install:
 install:
   - . $HOME/spack/share/spack/setup-env.sh
   - spack install gotcha@1.0.3 && spack load gotcha@1.0.3
-  - spack install mochi-margo ^mercury~boostsys ^libfabric fabrics=rxm,sockets,tcp && spack load argobots && spack load mercury && spack load mochi-margo
+  - spack install mochi-margo@0.9.6 ^mercury~boostsys ^libfabric fabrics=rxm,sockets,tcp && spack load argobots && spack load mercury && spack load mochi-margo
   - spack install spath~mpi && spack load spath
   # prepare build environment
   - GOTCHA_INSTALL=$(spack location -i gotcha)

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -47,10 +47,10 @@ if [ $use_old_margo -eq 1 ]; then
     mercury_version="v1.0.1"
     margo_version="v0.4.3"
 else
-    argobots_version="v1.0.1"
-    libfabric_version="v1.11.1"
-    mercury_version="v2.0.0"
-    margo_version="v0.9.1"
+    argobots_version="v1.1"
+    libfabric_version="v1.12.1"
+    mercury_version="v2.0.1"
+    margo_version="v0.9.6"
     repos+=(https://github.com/json-c/json-c.git)
 fi
 
@@ -120,7 +120,7 @@ if [ "$automake_sub_version" -lt "15" ]; then
     popd
 
     # build automake
-    echo "### building automake v1.15 ###"
+    echo "### building automake ###"
     pushd automake-1.15
         ./configure --prefix=$INSTALL_DIR
         make
@@ -148,8 +148,9 @@ else
 fi
 
 echo "### building GOTCHA ###"
+gotcha_version="1.0.3"
 cd GOTCHA
-git checkout 1.0.3
+git checkout $gotcha_version
 mkdir -p build && cd build
 cmake -DCMAKE_INSTALL_PREFIX="$INSTALL_DIR" ..
 make -j $make_nproc && make install

--- a/common/src/unifyfs_configurator.h
+++ b/common/src/unifyfs_configurator.h
@@ -71,7 +71,7 @@
     UNIFYFS_CFG_CLI(unifyfs, mountpoint, STRING, /unifyfs, "mountpoint directory", NULL, 'm', "specify full path to desired mountpoint") \
     UNIFYFS_CFG(client, cwd, STRING, NULLSTRING, "current working directory", NULL) \
     UNIFYFS_CFG(client, fsync_persist, BOOL, on, "persist written data to storage on fsync()", NULL) \
-    UNIFYFS_CFG(client, local_extents, BOOL, off, "cache extents within client to service local reads without consulting local server", NULL) \
+    UNIFYFS_CFG(client, local_extents, BOOL, off, "use client-cached extents to service local reads without consulting local server", NULL) \
     UNIFYFS_CFG(client, max_files, INT, UNIFYFS_CLIENT_MAX_FILES, "client max file count", NULL) \
     UNIFYFS_CFG(client, write_index_size, INT, UNIFYFS_CLIENT_WRITE_INDEX_SIZE, "write metadata index buffer size", NULL) \
     UNIFYFS_CFG(client, write_sync, BOOL, off, "sync every write to server", NULL) \
@@ -84,13 +84,15 @@
     UNIFYFS_CFG(logio, shmem_size, INT, UNIFYFS_LOGIO_SHMEM_SIZE, "log-based I/O shared memory region size", NULL) \
     UNIFYFS_CFG(logio, spill_size, INT, UNIFYFS_LOGIO_SPILL_SIZE, "log-based I/O spillover file size", NULL) \
     UNIFYFS_CFG(logio, spill_dir, STRING, NULLSTRING, "spillover directory", configurator_directory_check) \
-    UNIFYFS_CFG(margo, lazy_connect, BOOL, off, "wait until first communication with server to resolve its connection address", NULL) \
+    UNIFYFS_CFG(margo, client_pool_size, INT, UNIFYFS_MARGO_POOL_SZ, "size of server's ULT pool for client-server RPCs", NULL) \
+    UNIFYFS_CFG(margo, lazy_connect, BOOL, on, "wait until first communication with server to resolve its connection address", NULL) \
+    UNIFYFS_CFG(margo, server_pool_size, INT, UNIFYFS_MARGO_POOL_SZ, "size of server's ULT pool for server-server RPCs", NULL) \
     UNIFYFS_CFG(margo, tcp, BOOL, on, "use TCP for server-to-server margo RPCs", NULL) \
     UNIFYFS_CFG(meta, range_size, INT, UNIFYFS_META_DEFAULT_SLICE_SZ, "metadata range size", NULL) \
     UNIFYFS_CFG_CLI(runstate, dir, STRING, RUNDIR, "runstate file directory", configurator_directory_check, 'R', "specify full path to directory to contain server-local state") \
     UNIFYFS_CFG_CLI(server, hostfile, STRING, NULLSTRING, "server hostfile name", NULL, 'H', "specify full path to server hostfile") \
     UNIFYFS_CFG_CLI(server, init_timeout, INT, UNIFYFS_DEFAULT_INIT_TIMEOUT, "timeout of waiting for server initialization", NULL, 't', "timeout in seconds to wait for servers to be ready for clients") \
-    UNIFYFS_CFG(server, local_extents, BOOL, off, "use server extents to service local reads without consulting file owner", NULL) \
+    UNIFYFS_CFG(server, local_extents, BOOL, off, "use server-cached extents to service local reads without consulting file owner", NULL) \
     UNIFYFS_CFG(server, max_app_clients, INT, UNIFYFS_SERVER_MAX_APP_CLIENTS, "maximum number of clients per application", NULL) \
     UNIFYFS_CFG_CLI(sharedfs, dir, STRING, NULLSTRING, "shared file system directory", configurator_directory_check, 'S', "specify full path to directory to contain server shared files") \
 

--- a/common/src/unifyfs_const.h
+++ b/common/src/unifyfs_const.h
@@ -52,12 +52,17 @@
 #define UNIFYFS_CLIENT_WRITE_INDEX_SIZE (20 * MIB)
 #define UNIFYFS_CLIENT_MAX_READ_COUNT 1000     /* max # active read requests */
 #define UNIFYFS_CLIENT_READ_TIMEOUT_SECONDS 60
-#define UNIFYFS_CLIENT_MAX_ACTIVE_REQUESTS 64  /* max concurrent client reqs */
+#define UNIFYFS_CLIENT_MAX_ACTIVE_REQUESTS 256 /* max concurrent client reqs */
 
 // Log-based I/O Default Values
 #define UNIFYFS_LOGIO_CHUNK_SIZE (4 * MIB)
 #define UNIFYFS_LOGIO_SHMEM_SIZE (256 * MIB)
 #define UNIFYFS_LOGIO_SPILL_SIZE (4 * GIB)
+
+// Margo Default Values
+#define UNIFYFS_MARGO_POOL_SZ 4
+#define UNIFYFS_MARGO_CLIENT_SERVER_TIMEOUT_MSEC  5000  /*  5.0 sec */
+#define UNIFYFS_MARGO_SERVER_SERVER_TIMEOUT_MSEC 15000  /* 15.0 sec */
 
 // Metadata Default Values
 #define UNIFYFS_META_DEFAULT_SLICE_SZ MIB    /* data slice size for metadata */
@@ -67,7 +72,7 @@
 #define UNIFYFS_SERVER_MAX_DATA_TX_SIZE (4 * MIB) /* to-client transmit size */
 #define UNIFYFS_SERVER_MAX_NUM_APPS 64   /* max # apps/mountpoints supported */
 #define UNIFYFS_SERVER_MAX_APP_CLIENTS 256  /* max # clients per application */
-#define UNIFYFS_SERVER_MAX_READS 2000     /* max server read reqs per reqmgr */
+#define UNIFYFS_SERVER_MAX_READS 2048   /* max # server read reqs per reqmgr */
 
 // Utilities
 #define UNIFYFS_DEFAULT_INIT_TIMEOUT 120    /* server init timeout (seconds) */

--- a/docs/dependencies.rst
+++ b/docs/dependencies.rst
@@ -6,16 +6,16 @@ UnifyFS Dependencies
 Required
 --------
 
-- `Automake <https://ftp.gnu.org/gnu/automake/>`_ version 1.15 or later
+- `Automake <https://ftp.gnu.org/gnu/automake/>`_ version 1.15 (or later)
 
-- `GOTCHA <https://github.com/LLNL/GOTCHA/releases>`_ version 1.0.3
+- `GOTCHA <https://github.com/LLNL/GOTCHA/releases>`_ version 1.0.3 (or later)
 
-- `Margo <https://github.com/mochi-hpc/mochi-margo/releases>`_ version 0.9.1 and its dependencies:
+- `Margo <https://github.com/mochi-hpc/mochi-margo/releases>`_ version 0.9.6 (or later) and its dependencies:
 
-  - `Argobots <https://github.com/pmodels/argobots/releases/tag/v1.0.1>`_ version 1.0.1
-  - `Mercury <https://github.com/mercury-hpc/mercury/releases/tag/v2.0.0>`_ version 2.0.0
+  - `Argobots <https://github.com/pmodels/argobots/releases>`_ version 1.1 (or later)
+  - `Mercury <https://github.com/mercury-hpc/mercury/releases>`_ version 2.0.1 (or later)
 
-    - `libfabric <https://github.com/ofiwg/libfabric>`_ and/or `bmi <https://github.com/radix-io/bmi/>`_
+    - `libfabric <https://github.com/ofiwg/libfabric>`_ or `bmi <https://github.com/radix-io/bmi/>`_
 
   - `JSON-C <https://github.com/json-c/json-c>`_
 
@@ -25,9 +25,8 @@ Required
 
     Margo uses pkg-config to ensure it compiles and links correctly with all of
     its dependencies' libraries. When building manually, you'll need to set the
-    ``PKG_CONFIG_PATH`` environment variable and include in
-    that variable the paths for the ``.pc`` files for Mercury, Argobots, and
-    Margo separated by colons.
+    ``PKG_CONFIG_PATH`` environment variable to include the paths of the
+    directories containing the ``.pc`` files for Mercury, Argobots, and Margo.
 
 --------
 Optional

--- a/server/src/extent_tree.c
+++ b/server/src/extent_tree.c
@@ -26,109 +26,94 @@
 #undef MAX
 #define MAX(a, b) (a > b ? a : b)
 
-int compare_func(
-    struct extent_tree_node* node1,
-    struct extent_tree_node* node2)
+int etn_compare_func(struct extent_tree_node* node1,
+                     struct extent_tree_node* node2)
 {
-    if (node1->start > node2->end) {
+    if (node1->extent.start > node2->extent.end) {
         return 1;
-    } else if (node1->end < node2->start) {
+    } else if (node1->extent.end < node2->extent.start) {
         return -1;
     } else {
+        /* any overlap is considered as "equal" */
         return 0;
     }
 }
 
-RB_PROTOTYPE(ext_tree, extent_tree_node, entry, compare_func)
-RB_GENERATE(ext_tree, extent_tree_node, entry, compare_func)
+RB_PROTOTYPE(ext_tree, extent_tree_node, entry, etn_compare_func)
+RB_GENERATE(ext_tree, extent_tree_node, entry, etn_compare_func)
 
 /* Returns 0 on success, positive non-zero error code otherwise */
-int extent_tree_init(struct extent_tree* extent_tree)
+int extent_tree_init(struct extent_tree* tree)
 {
-    memset(extent_tree, 0, sizeof(*extent_tree));
-    pthread_rwlock_init(&extent_tree->rwlock, NULL);
-    RB_INIT(&extent_tree->head);
+    memset(tree, 0, sizeof(*tree));
+    pthread_rwlock_init(&(tree->rwlock), NULL);
+    RB_INIT(&(tree->head));
     return 0;
 }
 
 /*
  * Remove and free all nodes in the extent_tree.
  */
-void extent_tree_destroy(struct extent_tree* extent_tree)
+void extent_tree_destroy(struct extent_tree* tree)
 {
-    extent_tree_clear(extent_tree);
-    pthread_rwlock_destroy(&extent_tree->rwlock);
+    extent_tree_clear(tree);
+    pthread_rwlock_destroy(&(tree->rwlock));
 }
 
 /* Allocate a node for the range tree.  Free node with free() when finished */
-static struct extent_tree_node* extent_tree_node_alloc(
-    unsigned long start, /* logical starting offset of extent */
-    unsigned long end,   /* logical ending offset of extent */
-    int svr_rank,        /* rank of server hosting data */
-    int app_id,          /* application id (namespace) on server rank */
-    int cli_id,          /* client rank on server rank */
-    unsigned long pos)   /* physical offset of data in log */
+static
+struct extent_tree_node* extent_tree_node_alloc(extent_metadata* extent)
 {
     /* allocate a new node structure */
     struct extent_tree_node* node = calloc(1, sizeof(*node));
-    if (!node) {
-        return NULL;
+    if (NULL != node) {
+        memcpy(&(node->extent), extent, sizeof(*extent));
     }
-
-    /* record logical range and physical offset */
-    node->start    = start;
-    node->end      = end;
-    node->svr_rank = svr_rank;
-    node->app_id   = app_id;
-    node->cli_id   = cli_id;
-    node->pos      = pos;
-
     return node;
 }
 
 /*
  * Given two start/end ranges, return a new range from start1/end1 that
- * does not overlap start2/end2.  The non-overlapping range is stored
- * in new_start/new_end.   If there are no non-overlapping ranges,
- * return 1 from this function, else return 0.  If there are two
- * non-overlapping ranges, return the first one in new_start/new_end.
+ * does not overlap start2/end2. The non-overlapping range is stored
+ * in range_start/range_end. If there are no non-overlapping ranges,
+ * return 1 from this function, else return 0. If there are two
+ * non-overlapping ranges, return the first one in range_start/range_end.
  */
 static int get_non_overlapping_range(
     unsigned long start1, unsigned long end1,
-    long start2, long end2,
-    long* new_start, long* new_end)
+    unsigned long start2, unsigned long end2,
+    unsigned long* range_start, unsigned long* range_end)
 {
     /* this function is only called when we know that segment 1
      * and segment 2 overlap with each other, find first portion
      * of segment 1 that does not overlap with segment 2, if any */
     if (start1 < start2) {
-        /* Segment 1 inlcudes a portion before segment 2 starts
-         * return start/end of that leading portion of segment 1
+        /* Segment 1 includes a portion before segment 2 starts.
+         * Set range to start/end of that leading portion of segment 1
          *
          * s1-------e1
          *     s2--------e2
          *   ---- non-overlap
          */
-        *new_start = start1;
-        *new_end   = start2 - 1;
+        *range_start = start1;
+        *range_end   = start2 - 1;
         return 0;
     } else if (end1 > end2) {
         /* Segment 1 does not start before segment 2,
-         * but segment 1 extends past end of segment 2
-         * return start/end of trailing portion of segment 1
+         * but segment 1 extends past end of segment 2.
+         * Set range to start/end of trailing portion of segment 1
          *
          *       s1-----e1
          *  s2-------e2
          *           --- non-overlap
          */
-        *new_start = end2 + 1;
-        *new_end   = end1;
+        *range_start = end2 + 1;
+        *range_end   = end1;
         return 0;
     }
 
-    /* Segment 2 completely envelops segment 1
-     * nothing left of segment 1 to return
-     * so return 1 to indicate this case
+    /* Segment 2 completely envelops segment 1.
+     * Return 1 to indicate this case
      *
      *    s1-------e1
      * s2-------------e2
@@ -139,142 +124,145 @@ static int get_non_overlapping_range(
 /*
  * Add an entry to the range tree.  Returns 0 on success, nonzero otherwise.
  */
-int extent_tree_add(
-    struct extent_tree* extent_tree, /* tree to add new extent item */
-    unsigned long start, /* logical starting offset of extent */
-    unsigned long end,   /* logical ending offset of extent */
-    int svr_rank,        /* rank of server hosting data */
-    int app_id,          /* application id (namespace) on server rank */
-    int cli_id,          /* client rank on server rank */
-    unsigned long pos)   /* physical offset of data in log */
+int extent_tree_add(struct extent_tree* tree,
+                    struct extent_metadata* extent)
 {
     /* assume we'll succeed */
-    int rc = 0;
+    int ret = 0;
 
     /* Create node to define our new range */
-    struct extent_tree_node* node = extent_tree_node_alloc(
-        start, end, svr_rank, app_id, cli_id, pos);
+    struct extent_tree_node* node = extent_tree_node_alloc(extent);
     if (!node) {
         return ENOMEM;
     }
 
     /* lock the tree so we can modify it */
-    extent_tree_wrlock(extent_tree);
+    extent_tree_wrlock(tree);
 
     /* Try to insert our range into the RB tree.  If it overlaps with any other
      * range, then it is not inserted, and the overlapping range node is
-     * returned in 'overlap'.  If 'overlap' is NULL, then there were no
+     * returned in 'conflict'.  If 'conflict' is NULL, then there were no
      * overlaps, and our range was successfully inserted. */
-    struct extent_tree_node* overlap;
-    while ((overlap = RB_INSERT(ext_tree, &extent_tree->head, node))) {
-        /* Our range overlaps with another range (in 'overlap'). Is there any
-         * any part of 'overlap' that does not overlap our range?  If so,
-         * delete the old 'overlap' and insert the smaller, non-overlapping
-         * range. */
-        long new_start = 0;
-        long new_end   = 0;
-        int ret = get_non_overlapping_range(overlap->start, overlap->end,
-            start, end, &new_start, &new_end);
-        if (ret) {
+    struct extent_tree_node* conflict;
+    while ((conflict = RB_INSERT(ext_tree, &tree->head, node)) != NULL) {
+        /* Our range overlaps with another range (in 'conflict'). Is there any
+         * any part of 'conflict' that is outside our range?  If so, delete
+         * the old 'conflict' and insert the smaller, non-overlapping range */
+        unsigned long new_start = 0;
+        unsigned long new_end   = 0;
+        unsigned long new_pos   = 0;
+        int rc = get_non_overlapping_range(conflict->extent.start,
+                                           conflict->extent.end,
+                                           extent->start, extent->end,
+                                           &new_start, &new_end);
+        if (rc) {
             /* The new range we are adding completely covers the existing
-             * range in the tree defined in overlap.
-             * We can't find a non-overlapping range.
+             * range in the tree defined in 'conflict'.
              * Delete the existing range. */
-            RB_REMOVE(ext_tree, &extent_tree->head, overlap);
-            free(overlap);
-            extent_tree->count--;
+            RB_REMOVE(ext_tree, &tree->head, conflict);
+            free(conflict);
+            tree->count--;
         } else {
-            /* Part of the old range was non-overlapping.  Split the old range
-             * into two ranges: one for the non-overlapping section, and one for
-             * the remaining section.  The non-overlapping section gets
-             * inserted without issue.  The remaining section will be processed
-             * on the next pass of this while() loop. */
-            struct extent_tree_node* resized = extent_tree_node_alloc(
-                new_start, new_end,
-                overlap->svr_rank, overlap->app_id, overlap->cli_id,
-                overlap->pos + (new_start - overlap->start));
-            if (!resized) {
+            /* Part of the old range 'conflict' was non-overlapping. Create a
+             * new smaller extent for that non-overlap portion. */
+            new_pos = conflict->extent.log_pos +
+                      (new_start - conflict->extent.start);
+            extent_metadata non_overlap_extent = {
+                .start    = new_start,
+                .end      = new_end,
+                .log_pos  = new_pos,
+                .svr_rank = conflict->extent.svr_rank,
+                .app_id   = conflict->extent.app_id,
+                .cli_id   = conflict->extent.cli_id
+            };
+            struct extent_tree_node* non_overlap =
+                extent_tree_node_alloc(&non_overlap_extent);
+            if (NULL == non_overlap) {
                 /* failed to allocate memory for range node,
                  * bail out and release lock without further
                  * changing state of extent tree */
                 free(node);
-                rc = ENOMEM;
+                ret = ENOMEM;
                 goto release_add;
             }
 
-            /* if the non-overlapping part came from the front
-             * portion of the existing range, then there is a
-             * trailing portion of the existing range to add back
-             * to be considered again in the next loop iteration */
-            struct extent_tree_node* remaining = NULL;
-            if (resized->end < overlap->end) {
-                /* There's still a remaining section after the non-overlapping
-                 * part.  Add it in. */
-                remaining = extent_tree_node_alloc(
-                    resized->end + 1, overlap->end,
-                    overlap->svr_rank, overlap->app_id, overlap->cli_id,
-                    overlap->pos + (resized->end + 1 - overlap->start));
-                if (!remaining) {
+            /* If the non-overlapping part came from the front portion of
+             * 'conflict', create an extent that covers the tail portion */
+            struct extent_tree_node* conflict_tail = NULL;
+            if (non_overlap_extent.end < conflict->extent.end) {
+                new_start = non_overlap_extent.end + 1;
+                new_end   = conflict->extent.end;
+                new_pos   = conflict->extent.log_pos +
+                            (new_start - conflict->extent.start);
+                extent_metadata tail_extent = {
+                    .start    = new_start,
+                    .end      = new_end,
+                    .log_pos  = new_pos,
+                    .svr_rank = conflict->extent.svr_rank,
+                    .app_id   = conflict->extent.app_id,
+                    .cli_id   = conflict->extent.cli_id
+                };
+                conflict_tail = extent_tree_node_alloc(&tail_extent);
+                if (NULL == conflict_tail) {
                     /* failed to allocate memory for range node,
                      * bail out and release lock without further
                      * changing state of extent tree */
                     free(node);
-                    free(resized);
-                    rc = ENOMEM;
+                    free(non_overlap);
+                    ret = ENOMEM;
                     goto release_add;
                 }
             }
 
-            /* Remove our old range and release it */
-            RB_REMOVE(ext_tree, &extent_tree->head, overlap);
-            free(overlap);
-            extent_tree->count--;
+            /* Remove old range 'conflict' and release it */
+            RB_REMOVE(ext_tree, &tree->head, conflict);
+            free(conflict);
+            tree->count--;
 
-            /* Insert the non-overlapping part of the new range */
-            RB_INSERT(ext_tree, &extent_tree->head, resized);
-            extent_tree->count++;
+            /* Insert the non-overlapping part of the old range */
+            RB_INSERT(ext_tree, &tree->head, non_overlap);
+            tree->count++;
 
-            /* if we have a trailing portion, insert range for that,
-             * and increase our extent count since we just turned one
-             * range entry into two */
-            if (remaining != NULL) {
-                RB_INSERT(ext_tree, &extent_tree->head, remaining);
-                extent_tree->count++;
+            /* If we have a tail portion, insert it and increase our extent
+             * count since we just turned one range entry into two */
+            if (conflict_tail != NULL) {
+                RB_INSERT(ext_tree, &tree->head, conflict_tail);
+                tree->count++;
             }
         }
     }
 
     /* increment segment count in the tree for the
      * new range we just added */
-    extent_tree->count++;
+    tree->count++;
 
     /* update max ending offset if end of new range
      * we just inserted is larger */
-    extent_tree->max = MAX(extent_tree->max, end);
+    tree->max = MAX(tree->max, extent->end);
 
     /* get temporary pointer to the node we just added */
     struct extent_tree_node* target = node;
 
     /* check whether we can coalesce new extent with any preceding extent */
-    struct extent_tree_node* prev = RB_PREV(
-        ext_tree, &extent_tree->head, target);
-    if (prev != NULL && prev->end + 1 == target->start) {
-        /* found a extent that ends just before the new extent starts,
+    struct extent_tree_node* prev = RB_PREV(ext_tree, &tree->head, target);
+    if ((NULL != prev) && (prev->extent.end + 1 == target->extent.start)) {
+        /* found an extent that ends just before the new extent starts,
          * check whether they are also contiguous in the log */
-        unsigned long pos_end = prev->pos + (prev->end - prev->start + 1);
-        if (prev->svr_rank == target->svr_rank &&
-            prev->cli_id   == target->cli_id   &&
-            prev->app_id   == target->app_id   &&
-            pos_end        == target->pos) {
+        unsigned long pos_next = prev->extent.log_pos +
+                                 extent_length(&(prev->extent));
+        if ((prev->extent.svr_rank == target->extent.svr_rank) &&
+            (prev->extent.cli_id   == target->extent.cli_id)   &&
+            (prev->extent.app_id   == target->extent.app_id)   &&
+            (pos_next              == target->extent.log_pos)) {
             /* the preceding extent describes a log position adjacent to
              * the extent we just added, so we can merge them,
              * append entry to previous by extending end of previous */
-            prev->end = target->end;
+            prev->extent.end = target->extent.end;
 
             /* delete new extent from the tree and free it */
-            RB_REMOVE(ext_tree, &extent_tree->head, target);
+            RB_REMOVE(ext_tree, &tree->head, target);
             free(target);
-            extent_tree->count--;
+            tree->count--;
 
             /* update target to point at previous extent since we just
              * merged our new extent into it */
@@ -283,56 +271,63 @@ int extent_tree_add(
     }
 
     /* check whether we can coalesce new extent with any trailing extent */
-    struct extent_tree_node* next = RB_NEXT(
-        ext_tree, &extent_tree->head, target);
-    if (next != NULL && target->end + 1 == next->start) {
+    struct extent_tree_node* next = RB_NEXT(ext_tree, &tree->head,
+                                            target);
+    if ((NULL != next) && (target->extent.end + 1 == next->extent.start)) {
         /* found a extent that starts just after the new extent ends,
          * check whether they are also contiguous in the log */
-        unsigned long pos_end = target->pos + (target->end - target->start + 1);
-        if (target->svr_rank == next->svr_rank &&
-            target->cli_id   == next->cli_id   &&
-            target->app_id   == next->app_id   &&
-            pos_end          == next->pos) {
+        unsigned long pos_next = target->extent.log_pos +
+                                 extent_length(&(target->extent));
+        if (target->extent.svr_rank == next->extent.svr_rank &&
+            target->extent.cli_id   == next->extent.cli_id   &&
+            target->extent.app_id   == next->extent.app_id   &&
+            pos_next                == next->extent.log_pos) {
             /* the target extent describes a log position adjacent to
              * the next extent, so we can merge them,
              * append entry to target by extending end of to cover next */
-            target->end = next->end;
+            target->extent.end = next->extent.end;
 
             /* delete next extent from the tree and free it */
-            RB_REMOVE(ext_tree, &extent_tree->head, next);
+            RB_REMOVE(ext_tree, &tree->head, next);
             free(next);
-            extent_tree->count--;
+            tree->count--;
         }
     }
 
 release_add:
 
     /* done modifying the tree */
-    extent_tree_unlock(extent_tree);
+    extent_tree_unlock(tree);
 
-    return rc;
+    return ret;
 }
 
 /* search tree for entry that overlaps with given start/end
  * offsets, return first overlapping entry if found, NULL otherwise,
  * assumes caller has lock on tree */
 struct extent_tree_node* extent_tree_find(
-    struct extent_tree* extent_tree, /* tree to search */
+    struct extent_tree* tree, /* tree to search */
     unsigned long start, /* starting offset to search */
     unsigned long end)   /* ending offset to search */
 {
     /* Create a range of just our starting byte offset */
-    struct extent_tree_node* node = extent_tree_node_alloc(
-        start, start, 0, 0, 0, 0);
-    if (!node) {
+    extent_metadata start_byte = {
+        .start    = start,
+        .end      = start,
+        .log_pos  = 0,
+        .svr_rank = 0,
+        .app_id   = 0,
+        .cli_id   = 0
+    };
+    struct extent_tree_node* node = extent_tree_node_alloc(&start_byte);
+    if (NULL == node) {
         return NULL;
     }
 
     /* search tree for either a range that overlaps with
      * the target range (starting byte), or otherwise the
      * node for the next biggest starting byte */
-    struct extent_tree_node* next = RB_NFIND(
-        ext_tree, &extent_tree->head, node);
+    struct extent_tree_node* next = RB_NFIND(ext_tree, &tree->head, node);
 
     free(node);
 
@@ -340,7 +335,7 @@ struct extent_tree_node* extent_tree_find(
      * byte offset, but it would be the range with the lowest
      * starting offset after the target starting offset, check whether
      * this overlaps our end offset */
-    if (next && next->start <= end) {
+    if ((NULL != next) && (next->extent.start <= end)) {
         return next;
     }
 
@@ -369,21 +364,21 @@ int extent_tree_truncate(
 
     /* iterate backwards until we find an extent below
      * the truncated size */
-    while (node != NULL && node->end >= size) {
+    while ((NULL != node) && (node->extent.end >= size)) {
         /* found an extent whose ending offset is equal to or
-         * extends beyond the truncated size,
+         * extends beyond the truncated size.
          * check whether the full extent is beyond the truncated
          * size or whether the new size falls within this extent */
-        if (node->start >= size) {
+        if (node->extent.start >= size) {
             /* the start offset is also beyond the truncated size,
-             * meaning the entire range is beyond the truncated size,
-             * get pointer to next previous extent in tree */
+             * meaning the entire range is beyond the truncated size.
+             * get pointer to previous extent in tree */
             struct extent_tree_node* oldnode = node;
             node = RB_PREV(ext_tree, &tree->head, node);
 
             /* remove this node from the tree and release it */
             LOGDBG("removing node [%lu, %lu] due to truncate=%lu",
-                   node->start, node->end, size);
+                   node->extent.start, node->extent.end, size);
             RB_REMOVE(ext_tree, &tree->head, oldnode);
             free(oldnode);
 
@@ -391,8 +386,9 @@ int extent_tree_truncate(
             tree->count--;
         } else {
             /* the range of this node overlaps with the truncated size
-             * so just update its end to be the new size */
-            node->end = size - 1;
+             * so just update its end to be the new last byte offset */
+            unsigned long last_byte = size - 1;
+            node->extent.end = last_byte;
             break;
         }
     }
@@ -400,7 +396,7 @@ int extent_tree_truncate(
     /* update maximum offset in tree */
     if (node != NULL) {
         /* got at least one extent left, update maximum field */
-        tree->max = node->end;
+        tree->max = node->extent.end;
     } else {
         /* no extents left in the tree, set max back to 0 */
         tree->max = 0;
@@ -419,27 +415,27 @@ int extent_tree_truncate(
  *
  * This is meant to be called in a loop, like:
  *
- *    extent_tree_rdlock(extent_tree);
+ *    extent_tree_rdlock(tree);
  *
  *    struct extent_tree_node *node = NULL;
- *    while ((node = extent_tree_iter(extent_tree, node))) {
- *       printf("[%d-%d]", node->start, node->end);
+ *    while ((node = extent_tree_iter(tree, node))) {
+ *       printf("[%d-%d]", node->extent.start, node->extent.end);
  *    }
  *
- *    extent_tree_unlock(extent_tree);
+ *    extent_tree_unlock(tree);
  *
  * Note: this function does no locking, and assumes you're properly locking
  * and unlocking the extent_tree before doing the iteration (see
  * extent_tree_rdlock()/extent_tree_wrlock()/extent_tree_unlock()).
  */
 struct extent_tree_node* extent_tree_iter(
-    struct extent_tree* extent_tree,
+    struct extent_tree* tree,
     struct extent_tree_node* start)
 {
     struct extent_tree_node* next = NULL;
-    if (start == NULL) {
+    if (NULL == start) {
         /* Initial case, no starting node */
-        next = RB_MIN(ext_tree, &extent_tree->head);
+        next = RB_MIN(ext_tree, &tree->head);
         return next;
     }
 
@@ -447,14 +443,14 @@ struct extent_tree_node* extent_tree_iter(
      * We were given a valid start node.  Look it up to start our traversal
      * from there.
      */
-    next = RB_FIND(ext_tree, &extent_tree->head, start);
-    if (!next) {
+    next = RB_FIND(ext_tree, &tree->head, start);
+    if (NULL == next) {
         /* Some kind of error */
         return NULL;
     }
 
     /* Look up our next node */
-    next = RB_NEXT(ext_tree, &extent_tree->head, start);
+    next = RB_NEXT(ext_tree, &tree->head, start);
 
     return next;
 }
@@ -464,9 +460,9 @@ struct extent_tree_node* extent_tree_iter(
  * extent_tree_iter().  All the other extent_tree functions provide their
  * own locking.
  */
-void extent_tree_rdlock(struct extent_tree* extent_tree)
+void extent_tree_rdlock(struct extent_tree* tree)
 {
-    int rc = pthread_rwlock_rdlock(&extent_tree->rwlock);
+    int rc = pthread_rwlock_rdlock(&(tree->rwlock));
     if (rc) {
         LOGERR("pthread_rwlock_rdlock() failed - rc=%d", rc);
     }
@@ -477,9 +473,9 @@ void extent_tree_rdlock(struct extent_tree* extent_tree)
  * extent_tree_iter().  All the other extent_tree functions provide their
  * own locking.
  */
-void extent_tree_wrlock(struct extent_tree* extent_tree)
+void extent_tree_wrlock(struct extent_tree* tree)
 {
-    int rc = pthread_rwlock_wrlock(&extent_tree->rwlock);
+    int rc = pthread_rwlock_wrlock(&(tree->rwlock));
     if (rc) {
         LOGERR("pthread_rwlock_wrlock() failed - rc=%d", rc);
     }
@@ -490,9 +486,9 @@ void extent_tree_wrlock(struct extent_tree* extent_tree)
  * extent_tree_iter().  All the other extent_tree functions provide their
  * own locking.
  */
-void extent_tree_unlock(struct extent_tree* extent_tree)
+void extent_tree_unlock(struct extent_tree* tree)
 {
-    int rc = pthread_rwlock_unlock(&extent_tree->rwlock);
+    int rc = pthread_rwlock_unlock(&(tree->rwlock));
     if (rc) {
         LOGERR("pthread_rwlock_unlock() failed - rc=%d", rc);
     }
@@ -502,68 +498,68 @@ void extent_tree_unlock(struct extent_tree* extent_tree)
  * Remove all nodes in extent_tree, but keep it initialized so you can
  * extent_tree_add() to it.
  */
-void extent_tree_clear(struct extent_tree* extent_tree)
+void extent_tree_clear(struct extent_tree* tree)
 {
     struct extent_tree_node* node = NULL;
     struct extent_tree_node* oldnode = NULL;
 
-    extent_tree_wrlock(extent_tree);
+    extent_tree_wrlock(tree);
 
-    if (RB_EMPTY(&extent_tree->head)) {
+    if (RB_EMPTY(&tree->head)) {
         /* extent_tree is empty, nothing to do */
-        extent_tree_unlock(extent_tree);
+        extent_tree_unlock(tree);
         return;
     }
 
     /* Remove and free each node in the tree */
-    while ((node = extent_tree_iter(extent_tree, node))) {
-        if (oldnode) {
-            RB_REMOVE(ext_tree, &extent_tree->head, oldnode);
+    while ((node = extent_tree_iter(tree, node)) != NULL) {
+        if (NULL != oldnode) {
+            RB_REMOVE(ext_tree, &tree->head, oldnode);
             free(oldnode);
         }
         oldnode = node;
     }
-    if (oldnode) {
-        RB_REMOVE(ext_tree, &extent_tree->head, oldnode);
+    if (NULL != oldnode) {
+        RB_REMOVE(ext_tree, &tree->head, oldnode);
         free(oldnode);
     }
 
-    extent_tree->count = 0;
-    extent_tree->max   = 0;
-    extent_tree_unlock(extent_tree);
+    tree->count = 0;
+    tree->max   = 0;
+    extent_tree_unlock(tree);
 }
 
 /* Return the number of segments in the segment tree */
-unsigned long extent_tree_count(struct extent_tree* extent_tree)
+unsigned long extent_tree_count(struct extent_tree* tree)
 {
-    extent_tree_rdlock(extent_tree);
-    unsigned long count = extent_tree->count;
-    extent_tree_unlock(extent_tree);
+    extent_tree_rdlock(tree);
+    unsigned long count = tree->count;
+    extent_tree_unlock(tree);
     return count;
 }
 
 /* Return the maximum ending logical offset in the tree */
-unsigned long extent_tree_max_offset(struct extent_tree* extent_tree)
+unsigned long extent_tree_max_offset(struct extent_tree* tree)
 {
-    extent_tree_rdlock(extent_tree);
-    unsigned long max = extent_tree->max;
-    extent_tree_unlock(extent_tree);
+    extent_tree_rdlock(tree);
+    unsigned long max = tree->max;
+    extent_tree_unlock(tree);
     return max;
 }
 
-/* given an extent tree and starting and ending logical offsets,
- * fill in key/value entries that overlap that range, returns at
- * most max entries starting from lowest starting offset,
- * sets outnum with actual number of entries returned */
+/* Given an extent tree and starting and ending logical offsets,
+ * fill in key/value entries that overlap that range.
+ * Returns at most max entries starting from lowest starting offset.
+ * Sets outnum with actual number of entries returned */
 int extent_tree_span(
-    struct extent_tree* extent_tree, /* extent tree to search */
-    int gfid,                        /* global file id we're looking in */
-    unsigned long start,             /* starting logical offset */
-    unsigned long end,               /* ending logical offset */
-    int max,                         /* maximum number of key/vals to return */
-    void* _keys,             /* array of length max for output keys */
-    void* _vals,             /* array of length max for output values */
-    int* outnum)                     /* number of entries returned */
+    struct extent_tree* tree, /* extent tree to search */
+    int gfid,                 /* global file id we're looking in */
+    unsigned long start,      /* starting logical offset */
+    unsigned long end,        /* ending logical offset */
+    int max,                  /* maximum number of key/vals to return */
+    void* _keys,              /* array of length max for output keys */
+    void* _vals,              /* array of length max for output values */
+    int* outnum)              /* number of entries returned */
 {
     unifyfs_key_t* keys = (unifyfs_key_t*) _keys;
     unifyfs_val_t* vals = (unifyfs_val_t*) _vals;
@@ -572,40 +568,40 @@ int extent_tree_span(
     *outnum = 0;
 
     /* lock the tree for reading */
-    extent_tree_rdlock(extent_tree);
+    extent_tree_rdlock(tree);
 
     int count = 0;
-    struct extent_tree_node* next = extent_tree_find(extent_tree, start, end);
-    while (next != NULL       &&
-           next->start <= end &&
-           count < max) {
-        /* got an entry that overlaps with given span */
+    struct extent_tree_node* next = extent_tree_find(tree, start, end);
+    while ((NULL != next) &&
+           (next->extent.start <= end) &&
+           (count < max)) {
+        /* got an entry that overlaps with given range */
 
         /* fill in key */
         unifyfs_key_t* key = &keys[count];
         key->gfid   = gfid;
-        key->offset = next->start;
+        key->offset = next->extent.start;
 
         /* fill in value */
         unifyfs_val_t* val = &vals[count];
-        val->addr           = next->pos;
-        val->len            = next->end - next->start + 1;
-        val->delegator_rank = next->svr_rank;
-        val->app_id         = next->app_id;
-        val->rank           = next->cli_id;
+        val->addr           = next->extent.log_pos;
+        val->len            = next->extent.end - next->extent.start + 1;
+        val->delegator_rank = next->extent.svr_rank;
+        val->app_id         = next->extent.app_id;
+        val->rank           = next->extent.cli_id;
 
         /* increment the number of key/values we found */
         count++;
 
         /* get the next element in the tree */
-        next = extent_tree_iter(extent_tree, next);
+        next = extent_tree_iter(tree, next);
     }
 
     /* return to user the number of key/values we set */
     *outnum = count;
 
     /* done reading the tree */
-    extent_tree_unlock(extent_tree);
+    extent_tree_unlock(tree);
 
     return 0;
 }
@@ -616,39 +612,39 @@ static void chunk_req_from_extent(
     struct extent_tree_node* n,
     chunk_read_req_t* chunk)
 {
-    unsigned long offset = n->start;
-    unsigned long nbytes = n->end - n->start + 1;
-    unsigned long log_offset = n->pos;
-    unsigned long last = req_offset + req_len - 1;
+    unsigned long offset     = n->extent.start;
+    unsigned long nbytes     = n->extent.end - n->extent.start + 1;
+    unsigned long log_offset = n->extent.log_pos;
+    unsigned long last       = req_offset + req_len - 1;
 
+    unsigned long diff;
     if (offset < req_offset) {
-        unsigned long diff = req_offset - offset;
-
+        diff = req_offset - offset;
         offset = req_offset;
         log_offset += diff;
         nbytes -= diff;
     }
 
-    if (n->end > last) {
-        unsigned long diff = n->end - last;
+    if (n->extent.end > last) {
+        diff = n->extent.end - last;
         nbytes -= diff;
     }
 
-    chunk->offset = offset;
-    chunk->nbytes = nbytes;
-    chunk->log_offset = log_offset;
-    chunk->rank = n->svr_rank;
-    chunk->log_client_id = n->cli_id;
-    chunk->log_app_id = n->app_id;
+    chunk->offset        = offset;
+    chunk->nbytes        = nbytes;
+    chunk->log_offset    = log_offset;
+    chunk->rank          = n->extent.svr_rank;
+    chunk->log_client_id = n->extent.cli_id;
+    chunk->log_app_id    = n->extent.app_id;
 }
 
 int extent_tree_get_chunk_list(
-    struct extent_tree* extent_tree, /* extent tree to search */
-    unsigned long offset,            /* starting logical offset */
-    unsigned long len,               /* length of extent */
-    unsigned int* n_chunks,          /* [out] number of chunks returned */
-    chunk_read_req_t** chunks,       /* [out] chunk array */
-    int* extent_covered)             /* [out] set=1 if extent fully covered */
+    struct extent_tree* tree,  /* extent tree to search */
+    unsigned long offset,      /* starting logical offset */
+    unsigned long len,         /* length of extent */
+    unsigned int* n_chunks,    /* [out] number of chunks returned */
+    chunk_read_req_t** chunks, /* [out] chunk array */
+    int* extent_covered)       /* [out] set=1 if extent fully covered */
 {
     int ret = 0;
     unsigned int count = 0;
@@ -663,27 +659,27 @@ int extent_tree_get_chunk_list(
 
     *extent_covered = 0;
 
-    extent_tree_rdlock(extent_tree);
+    extent_tree_rdlock(tree);
 
-    first = extent_tree_find(extent_tree, offset, end);
+    first = extent_tree_find(tree, offset, end);
     next = first;
-    while (next && next->start <= end) {
+    while ((NULL != next) && next->extent.start <= end) {
         count++;
 
         if (!gap_found) {
-            unsigned long curr_start = next->start;
+            unsigned long curr_start = next->extent.start;
             if (next != first) {
                 /* check for a gap between current and previous extent */
                 if ((prev_end + 1) != curr_start) {
                     gap_found = true;
                 }
             }
-            prev_end = next->end;
+            prev_end = next->extent.end;
         }
 
         /* iterate to next extent */
         last = next;
-        next = extent_tree_iter(extent_tree, next);
+        next = extent_tree_iter(tree, next);
     }
 
     *n_chunks = count;
@@ -691,32 +687,32 @@ int extent_tree_get_chunk_list(
         gap_found = true;
         goto out_unlock;
     } else {
-        if ((first->start > offset) || (last->end < end)) {
+        if ((first->extent.start > offset) || (last->extent.end < end)) {
             gap_found = true;
         }
     }
 
     out_chunks = calloc(count, sizeof(*out_chunks));
-    if (!out_chunks) {
+    if (NULL == out_chunks) {
         ret = ENOMEM;
         goto out_unlock;
     }
 
     next = first;
     current = out_chunks;
-    while (next && next->start <= end) {
+    while ((NULL != next) && (next->extent.start <= end)) {
         /* trim out the extent so it does not include the data that is not
          * requested */
         chunk_req_from_extent(offset, len, next, current);
 
-        next = extent_tree_iter(extent_tree, next);
+        next = extent_tree_iter(tree, next);
         current += 1;
     }
 
     *chunks = out_chunks;
 
 out_unlock:
-    extent_tree_unlock(extent_tree);
+    extent_tree_unlock(tree);
 
     if (!gap_found) {
         *extent_covered = 1;

--- a/server/src/extent_tree.h
+++ b/server/src/extent_tree.h
@@ -17,21 +17,28 @@
 
 #include "unifyfs_global.h"
 
+typedef struct extent_metadata {
+    /* extent metadata */
+    unsigned long start;    /* logical offset of extent's first byte */
+    unsigned long end;      /* logical offset of extent's last byte */
+
+    /* logio metadata */
+    unsigned long log_pos;  /* physical offset of data in log */
+    int svr_rank;           /* rank of server hosting the log */
+    int app_id;             /* application id (namespace) of client */
+    int cli_id;             /* rank (on host server) of client */
+} extent_metadata;
+
+#define extent_length(meta_ptr) \
+    ((size_t)1 + ((meta_ptr)->end - (meta_ptr)->start))
+
+#define extent_offset(meta_ptr) \
+    (off_t)((meta_ptr)->start)
+
 struct extent_tree_node {
     RB_ENTRY(extent_tree_node) entry;
-    unsigned long start; /* starting logical offset of range */
-    unsigned long end;   /* ending logical offset of range */
-    int svr_rank;        /* rank of server hosting data */
-    int app_id;          /* application id (namespace) on server rank */
-    int cli_id;          /* client rank on server rank */
-    unsigned long pos;   /* physical offset of data in log */
+    struct extent_metadata extent;
 };
-
-#define extent_tree_node_offset(node_ptr) \
-    ((off_t)(node_ptr)->start)
-
-#define extent_tree_node_length(node_ptr) \
-    ((size_t)1 + ((node_ptr)->end - (node_ptr)->start))
 
 struct extent_tree {
     RB_HEAD(ext_tree, extent_tree_node) head;
@@ -41,47 +48,40 @@ struct extent_tree {
 };
 
 /* Returns 0 on success, positive non-zero error code otherwise */
-int extent_tree_init(struct extent_tree* extent_tree);
+int extent_tree_init(struct extent_tree* tree);
 
 /*
- * Remove all nodes in extent_tree, but keep it initialized so you can
+ * Remove all nodes in tree, but keep it initialized so you can
  * extent_tree_add() to it.
  */
-void extent_tree_clear(struct extent_tree* extent_tree);
+void extent_tree_clear(struct extent_tree* tree);
 
 /*
- * Remove and free all nodes in the extent_tree.
+ * Remove and free all nodes in the tree.
  */
-void extent_tree_destroy(struct extent_tree* extent_tree);
+void extent_tree_destroy(struct extent_tree* tree);
 
 /*
  * Add an entry to the range tree.  Returns 0 on success, nonzero otherwise.
  */
-int extent_tree_add(
-    struct extent_tree* extent_tree, /* tree to add new extent item */
-    unsigned long start, /* logical starting offset of extent */
-    unsigned long end,   /* logical ending offset of extent */
-    int svr_rank,        /* rank of server hosting data */
-    int app_id,          /* application id (namespace) on server rank */
-    int cli_id,          /* client rank on server rank */
-    unsigned long pos    /* physical offset of data in log */
-);
+int extent_tree_add(struct extent_tree* tree,
+                    struct extent_metadata* extent);
 
 /* search tree for entry that overlaps with given start/end
  * offsets, return first overlapping entry if found, NULL otherwise,
  * assumes caller has lock on tree */
 struct extent_tree_node* extent_tree_find(
-    struct extent_tree* extent_tree, /* tree to search */
-    unsigned long start, /* starting offset to search */
-    unsigned long end    /* ending offset to search */
+    struct extent_tree* tree, /* tree to search */
+    unsigned long start,      /* starting offset to search */
+    unsigned long end         /* ending offset to search */
 );
 
 /* truncate extents to use new maximum, discards extent entries
  * that exceed the new truncated size, and rewrites any entry
  * that overlaps */
 int extent_tree_truncate(
-    struct extent_tree* extent_tree, /* tree to truncate */
-    unsigned long size               /* size to truncate extents to */
+    struct extent_tree* tree, /* tree to truncate */
+    unsigned long size        /* size to truncate extents to */
 );
 
 /*
@@ -91,41 +91,41 @@ int extent_tree_truncate(
  *
  * This is meant to be called in a loop, like:
  *
- *    extent_tree_rdlock(extent_tree);
+ *    extent_tree_rdlock(tree);
  *
  *    struct extent_tree_node *node = NULL;
- *    while ((node = extent_tree_iter(extent_tree, node))) {
+ *    while ((node = extent_tree_iter(tree, node))) {
  *       printf("[%d-%d]", node->start, node->end);
  *    }
  *
- *    extent_tree_unlock(extent_tree);
+ *    extent_tree_unlock(tree);
  *
  * Note: this function does no locking, and assumes you're properly locking
- * and unlocking the extent_tree before doing the iteration (see
+ * and unlocking the tree before doing the iteration (see
  * extent_tree_rdlock()/extent_tree_wrlock()/extent_tree_unlock()).
  */
 struct extent_tree_node* extent_tree_iter(
-    struct extent_tree* extent_tree,
+    struct extent_tree* tree,
     struct extent_tree_node* start);
 
 /* Return the number of segments in the segment tree */
-unsigned long extent_tree_count(struct extent_tree* extent_tree);
+unsigned long extent_tree_count(struct extent_tree* tree);
 
 /* Return the maximum ending logical offset in the tree */
-unsigned long extent_tree_max_offset(struct extent_tree* extent_tree);
+unsigned long extent_tree_max_offset(struct extent_tree* tree);
 
 /*
  * Locking functions for use with extent_tree_iter().  They allow you to
  * lock the tree to iterate over it:
  *
- *    extent_tree_rdlock(&extent_tree);
+ *    extent_tree_rdlock(&tree);
  *
  *    struct extent_tree_node *node = NULL;
- *    while ((node = extent_tree_iter(extent_tree, node))) {
+ *    while ((node = extent_tree_iter(tree, node))) {
  *       printf("[%d-%d]", node->start, node->end);
  *    }
  *
- *    extent_tree_unlock(&extent_tree);
+ *    extent_tree_unlock(&tree);
  */
 
 /*
@@ -133,62 +133,62 @@ unsigned long extent_tree_max_offset(struct extent_tree* extent_tree);
  * extent_tree_iter().  All the other extent_tree functions provide their
  * own locking.
  */
-void extent_tree_rdlock(struct extent_tree* extent_tree);
+void extent_tree_rdlock(struct extent_tree* tree);
 
 /*
  * Lock a extent_tree for read/write.  This should only be used for calling
  * extent_tree_iter().  All the other extent_tree functions provide their
  * own locking.
  */
-void extent_tree_wrlock(struct extent_tree* extent_tree);
+void extent_tree_wrlock(struct extent_tree* tree);
 
 /*
  * Unlock a extent_tree for read/write.  This should only be used for calling
  * extent_tree_iter().  All the other extent_tree functions provide their
  * own locking.
  */
-void extent_tree_unlock(struct extent_tree* extent_tree);
+void extent_tree_unlock(struct extent_tree* tree);
 
 /* given an extent tree and starting and ending logical offsets,
  * fill in key/value entries that overlap that range, returns at
  * most max entries starting from lowest starting offset,
  * sets outnum with actual number of entries returned */
 int extent_tree_span(
-    struct extent_tree* extent_tree, /* extent tree to search */
-    int gfid,                        /* global file id we're looking in */
-    unsigned long start,             /* starting logical offset */
-    unsigned long end,               /* ending logical offset */
-    int max,                         /* maximum number of key/vals to return */
-    void* keys,             /* array of length max for output keys */
-    void* vals,             /* array of length max for output values */
-    int* outnum);                    /* number of entries returned */
+    struct extent_tree* tree, /* extent tree to search */
+    int gfid,                 /* global file id we're looking in */
+    unsigned long start,      /* starting logical offset */
+    unsigned long end,        /* ending logical offset */
+    int max,                  /* maximum number of key/vals to return */
+    void* keys,               /* array of length max for output keys */
+    void* vals,               /* array of length max for output values */
+    int* outnum);             /* number of entries returned */
 
 int extent_tree_get_chunk_list(
-    struct extent_tree* extent_tree, /* extent tree to search */
-    unsigned long offset,            /* starting logical offset */
-    unsigned long len,               /* length of extent */
-    unsigned int* n_chunks,          /* [out] number of chunks returned */
-    chunk_read_req_t** chunks,       /* [out] chunk array */
-    int* extent_covered);            /* [out] set=1 if extent fully covered */
+    struct extent_tree* tree,  /* extent tree to search */
+    unsigned long offset,      /* starting logical offset */
+    unsigned long len,         /* length of extent */
+    unsigned int* n_chunks,    /* [out] number of chunks returned */
+    chunk_read_req_t** chunks, /* [out] chunk array */
+    int* extent_covered);      /* [out] set=1 if extent fully covered */
 
 /* dump method for debugging extent trees */
 static inline
-void extent_tree_dump(struct extent_tree* extent_tree)
+void extent_tree_dump(struct extent_tree* tree)
 {
-    if (NULL == extent_tree) {
+    if (NULL == tree) {
         return;
     }
 
-    extent_tree_rdlock(extent_tree);
+    extent_tree_rdlock(tree);
 
     struct extent_tree_node* node = NULL;
-    while ((node = extent_tree_iter(extent_tree, node))) {
+    while ((node = extent_tree_iter(tree, node))) {
         LOGDBG("[%lu-%lu] @ %d(%d:%d) log offset %lu",
-               node->start, node->end, node->svr_rank,
-               node->app_id, node->cli_id, node->pos);
+               node->extent.start, node->extent.end, node->extent.svr_rank,
+               node->extent.app_id, node->extent.cli_id, node->extent.log_pos);
     }
 
-    extent_tree_unlock(extent_tree);
+    extent_tree_unlock(tree);
 }
 
 #endif /* __EXTENT_TREE_H__ */

--- a/server/src/margo_server.h
+++ b/server/src/margo_server.h
@@ -68,6 +68,8 @@ extern ServerRpcContext_t* unifyfsd_rpc_context;
 
 extern bool margo_use_tcp;
 extern bool margo_lazy_connect;
+extern int  margo_client_server_pool_sz;
+extern int  margo_server_server_pool_sz;
 
 int margo_server_rpc_init(void);
 int margo_server_rpc_finalize(void);

--- a/server/src/unifyfs_inode.h
+++ b/server/src/unifyfs_inode.h
@@ -123,25 +123,28 @@ int unifyfs_inode_truncate(int gfid, unsigned long size);
 /**
  * @brief get the local extent array from the target inode
  *
- * @param gfid   the global file identifier
- * @param n      the number of extents, set by this function
- * @param nodes  the pointer to the array of extents, caller should free this
+ * @param gfid     the global file identifier
+ * @param n        pointer to size of the extents array
+ * @param extents  pointer to extents array (caller should free)
  *
  * @return 0 on success, errno otherwise
  */
-int unifyfs_inode_get_extents(int gfid, size_t* n,
-                              struct extent_tree_node** nodes);
+int unifyfs_inode_get_extents(int gfid,
+                              size_t* n,
+                              extent_metadata** extents);
 
 /**
  * @brief add new extents to the inode
  *
- * @param gfid   the global file identifier
- * @param n      the number of new extents in @nodes
- * @param nodes  an array of extents to be added
+ * @param gfid               the global file identifier
+ * @param num_extents        the number of new extents in @nodes
+ * @param extents            an array of extents to be added
  *
  * @return
  */
-int unifyfs_inode_add_extents(int gfid, int n, struct extent_tree_node* nodes);
+int unifyfs_inode_add_extents(int gfid,
+                              int num_extents,
+                              extent_metadata* extents);
 
 /**
  * @brief get the maximum file size from the local extent tree of given file
@@ -166,15 +169,15 @@ int unifyfs_inode_laminate(int gfid);
 /**
  * @brief Get chunks for given file extent
  *
- * @param extent  target file extent
+ * @param extent              target file extent
  *
- * @param[out] n_chunks  number of output chunk locations
- * @param[out] chunks    array of output chunk locations
+ * @param[out] n_chunks       number of output chunk locations
+ * @param[out] chunks         array of output chunk locations
  * @param[out] full_coverage  set to 1 if chunks fully cover extent
  *
  * @return UNIFYFS_SUCCESS, or error code
  */
-int unifyfs_inode_get_extent_chunks(unifyfs_inode_extent_t* extent,
+int unifyfs_inode_get_extent_chunks(unifyfs_extent_t* extent,
                                     unsigned int* n_chunks,
                                     chunk_read_req_t** chunks,
                                     int* full_coverage);
@@ -192,7 +195,7 @@ int unifyfs_inode_get_extent_chunks(unifyfs_inode_extent_t* extent,
  * @return UNIFYFS_SUCCESS, or error code
  */
 int unifyfs_inode_resolve_extent_chunks(unsigned int n_extents,
-                                        unifyfs_inode_extent_t* extents,
+                                        unifyfs_extent_t* extents,
                                         unsigned int* n_locs,
                                         chunk_read_req_t** chunklocs,
                                         int* full_coverage);

--- a/server/src/unifyfs_p2p_rpc.h
+++ b/server/src/unifyfs_p2p_rpc.h
@@ -79,7 +79,7 @@ int invoke_chunk_read_response_rpc(server_chunk_reads_t* scr);
  */
 int unifyfs_invoke_add_extents_rpc(int gfid,
                                    unsigned int num_extents,
-                                   struct extent_tree_node* extents);
+                                   extent_metadata* extents);
 
 /**
  * @brief Find location of extents for target file
@@ -95,7 +95,7 @@ int unifyfs_invoke_add_extents_rpc(int gfid,
  */
 int unifyfs_invoke_find_extents_rpc(int gfid,
                                     unsigned int num_extents,
-                                    unifyfs_inode_extent_t* extents,
+                                    unifyfs_extent_t* extents,
                                     unsigned int* num_chunks,
                                     chunk_read_req_t** chunks);
 

--- a/server/src/unifyfs_request_manager.h
+++ b/server/src/unifyfs_request_manager.h
@@ -61,7 +61,7 @@ typedef struct {
     int num_server_reads;      /* size of remote_reads array */
     chunk_read_req_t* chunks;  /* array of chunk-reads */
     server_chunk_reads_t* remote_reads; /* per-server remote reads array */
-    unifyfs_inode_extent_t extent; /* the requested extent */
+    unifyfs_extent_t extent;   /* the requested extent */
 } server_read_req_t;
 
 /* Request manager state structure - created by main thread for each request

--- a/server/src/unifyfs_service_manager.c
+++ b/server/src/unifyfs_service_manager.c
@@ -504,7 +504,7 @@ int sm_set_fileattr(int gfid,
 
 int sm_add_extents(int gfid,
                    size_t num_extents,
-                   struct extent_tree_node* extents)
+                   extent_metadata* extents)
 {
     int owner_rank = hash_gfid_to_server(gfid);
     int is_owner = (owner_rank == glb_pmi_rank);
@@ -520,7 +520,7 @@ int sm_add_extents(int gfid,
 
 int sm_find_extents(int gfid,
                     size_t num_extents,
-                    unifyfs_inode_extent_t* extents,
+                    unifyfs_extent_t* extents,
                     unsigned int* out_num_chunks,
                     chunk_read_req_t** out_chunks,
                     int* full_coverage)
@@ -530,14 +530,13 @@ int sm_find_extents(int gfid,
     int ret = unifyfs_inode_metaget(gfid, &attrs);
     if (ret == UNIFYFS_SUCCESS) {
         /* do inode extent lookup */
-        unsigned int n_extents = (unsigned int)num_extents;
+        unsigned int n_extents = (unsigned int) num_extents;
         ret = unifyfs_inode_resolve_extent_chunks(n_extents, extents,
                                                   out_num_chunks,
                                                   out_chunks,
                                                   full_coverage);
         if (ret) {
-            LOGERR("failed to find extents for gfid=%d (rc=%d)",
-                   gfid, ret);
+            LOGERR("failed to find extents for gfid=%d (rc=%d)", gfid, ret);
         } else if (*out_num_chunks == 0) {
             LOGDBG("extent lookup for gfid=%d found no matching chunks", gfid);
         }
@@ -813,7 +812,7 @@ static int process_add_extents_rpc(server_rpc_req_t* req)
     int sender = (int) in->src_rank;
     int gfid = (int) in->gfid;
     size_t num_extents = (size_t) in->num_extents;
-    struct extent_tree_node* extents = req->bulk_buf;
+    extent_metadata* extents = req->bulk_buf;
 
     /* add extents */
     LOGDBG("adding %zu extents to gfid=%d from server[%d]",
@@ -848,7 +847,7 @@ static int process_find_extents_rpc(server_rpc_req_t* req)
     int sender = (int) in->src_rank;
     int gfid = (int) in->gfid;
     size_t num_extents = (size_t) in->num_extents;
-    unifyfs_inode_extent_t* extents = req->bulk_buf;
+    unifyfs_extent_t* extents = req->bulk_buf;
 
     LOGDBG("received %zu extent lookups for gfid=%d from server[%d]",
            num_extents, gfid, sender);
@@ -1105,7 +1104,7 @@ static int process_extents_bcast_rpc(server_rpc_req_t* req)
     extent_bcast_in_t* in = req->input;
     int gfid = (int) in->gfid;
     size_t num_extents = (size_t) in->num_extents;
-    struct extent_tree_node* extents = req->bulk_buf;
+    extent_metadata* extents = req->bulk_buf;
 
     LOGDBG("gfid=%d num_extents=%zu", gfid, num_extents);
 
@@ -1153,7 +1152,7 @@ static int process_laminate_bcast_rpc(server_rpc_req_t* req)
     int gfid = (int) in->gfid;
     size_t num_extents = (size_t) in->num_extents;
     unifyfs_file_attr_t* fattr = &(in->attr);
-    struct extent_tree_node* extents = req->bulk_buf;
+    extent_metadata* extents = req->bulk_buf;
 
     LOGDBG("gfid=%d num_extents=%zu", gfid, num_extents);
 

--- a/server/src/unifyfs_service_manager.h
+++ b/server/src/unifyfs_service_manager.h
@@ -80,11 +80,11 @@ int sm_set_fileattr(int gfid,
 
 int sm_add_extents(int gfid,
                    size_t num_extents,
-                   struct extent_tree_node* extents);
+                   extent_metadata* extents);
 
 int sm_find_extents(int gfid,
                     size_t num_extents,
-                    unifyfs_inode_extent_t* extents,
+                    unifyfs_extent_t* extents,
                     unsigned int* out_num_chunks,
                     chunk_read_req_t** out_chunks,
                     int* full_coverage);

--- a/server/src/unifyfs_transfer.h
+++ b/server/src/unifyfs_transfer.h
@@ -35,7 +35,7 @@ typedef struct transfer_thread_args {
     int transfer_id;   /* transfer request id at originating client */
 
     /* local extents to transfer to destination file */
-    struct extent_tree_node* local_extents;
+    extent_metadata* local_extents;
     size_t n_extents;
 
     size_t local_data_sz;         /* total size of local data */


### PR DESCRIPTION
### Description

* use timed versions of RPC forwarding functions, and add configuration settings for client-server and server-server RPC timeouts
* for group RPCs, allow responses in any order
* for RPCs that transfer extent metadata, avoid use of `unifyfs_inode_extent_t` and `extent_tree_node` structures, since they add useless bytes to the transfers

NOTE: due to a bug in prior margo versions, we need to use 0.9.6 or later to use the timed async forwarding

### Motivation and Context

At scales of 256 nodes and larger on Summit, we occasionally observe runtime hangs during various operations, particularly those involving group rpcs. These changes help to reduce any forced ordering of rpc responses, and improve diagnosis of responses never received. They also reduce the amount of data sent during synchronization of file extents.

### How Has This Been Tested?

Tested on Summit up to 1024 nodes (8ppn) using writeread example (with and without lamination), with no hangs observed.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
