### PR TITLE
fix for serial transfer from non-zero rank client

### DIFF
--- a/client/src/posix_client.c
+++ b/client/src/posix_client.c
@@ -872,10 +872,8 @@ int unifyfs_transfer_file(const char* src,
         return -EINVAL;
     }
 
-    /* TODO: Fix parallel transfer logic
-     * for both serial and parallel transfers, use rank 0 client to
-     * create the destination file */
-    if (0 == client_rank) {
+    /* create the destination file */
+    if ((UNIFYFS_TRANSFER_SERIAL == mode) || (0 == client_rank)) {
         errno = 0;
         int create_flags = O_CREAT | O_WRONLY | O_TRUNC;
         int dst_mode;


### PR DESCRIPTION
### Motivation and Context

When using the `unifyfs-stage` utility in serial mode for multi-node jobs (either directly or via the `unifyfs` utility staging support), and more than one file is present in the manifest file, the file transfers for non-rank 0 clients would fail due to a bug in our logic for creating the destination file. 

### How Has This Been Tested?

Tested on OLCF Summit.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
