### PR TITLE
Install unifyfs-stage in bin

### DIFF
--- a/docs/run.rst
+++ b/docs/run.rst
@@ -194,10 +194,9 @@ and/or transferring results out to be verified before the job terminates.
 UnifyFS Stage Executable
 ^^^^^^^^^^^^^^^^^^^^^^^^
 
-``$UNIFYFS_INSTALL/libexec/unifyfs-stage``
-
 The ``start``/``terminate`` transfer API stage functionality can also be used
-via the stand-alone application ``unifyfs-stage``.
+via the stand-alone application ``unifyfs-stage``.  This application is installed
+in the same directory as the ``unifyfs`` utility (``$UNIFYFS_INSTALL/bin``).
 
 This application can be run at any time within a job to transfer new data into
 or results out of UnifyFS.
@@ -206,7 +205,7 @@ as an argument to use this approach.
 
 .. code-block:: Bash
 
-    [prompt]$ ./unifyfs-stage --help
+    [prompt]$ unifyfs-stage --help
 
     Usage: unifyfs-stage [OPTION]... <manifest file>
 
@@ -241,12 +240,12 @@ Examples:
 .. code-block:: Bash
     :caption: Serial Transfer
 
-    $ srun -N 1 -n 1 $UNIFYFS_INSTALL/libexec/unifyfs-stage $MY_MANIFEST_FILE
+    $ srun -N 1 -n 1 unifyfs-stage $MY_MANIFEST_FILE
 
 .. code-block:: Bash
     :caption: Parallel Transfer
 
-    $ srun -N 4 -n 8 $UNIFYFS_INSTALL/libexec/unifyfs-stage --parallel $MY_MANIFEST_FILE
+    $ srun -N 4 -n 8 unifyfs-stage --parallel $MY_MANIFEST_FILE
 
 Transfer Executable
 ^^^^^^^^^^^^^^^^^^^

--- a/t/ci/800-stage-tests.sh
+++ b/t/ci/800-stage-tests.sh
@@ -28,7 +28,7 @@
 test_description="UnifyFS Stage-in+Stage-out tests"
 
 # utility checking to make sure everything's in place.
-STAGE_EXE=${UNIFYFS_EXAMPLES}/unifyfs-stage
+STAGE_EXE=${UNIFYFS_BIN}/unifyfs-stage
 test_expect_success "unify-stage executable exists" '
      test_path_is_file $STAGE_EXE
 '

--- a/util/unifyfs-stage/src/Makefile.am
+++ b/util/unifyfs-stage/src/Makefile.am
@@ -1,4 +1,4 @@
-libexec_PROGRAMS = unifyfs-stage
+bin_PROGRAMS = unifyfs-stage
 
 noinst_HEADERS = unifyfs-stage.h
 


### PR DESCRIPTION
The unifyfs-stage util is expected to be called by users.  As such, it
should be installed in the bin dir rather than libexec.

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Changes a single line in `util/unifyfs-stage/src/Makefile.am` so that `unifyfs-stage` is installed to the `bin` directory.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See issue #709 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Tested by running `make install` (on my Ubuntu workstation) and verifying the location of the installed util.  Also ran `make check` and made sure the change didn't break any existing tests.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
- [x ] All commit messages are properly formatted.
