### PR TITLE
Use PMIX_JOB_SIZE instead of PMIX_UNIV_SIZE

### DIFF
--- a/common/src/unifyfs_keyval.c
+++ b/common/src/unifyfs_keyval.c
@@ -368,17 +368,18 @@ int unifyfs_pmix_init(void)
     kv_max_keylen = PMIX_MAX_KEYLEN;
     kv_max_vallen = PMIX_MAX_VALLEN;
 
-    /* get PMIx universe size */
+    /* get PMIx job size */
     PMIX_PROC_CONSTRUCT(&proc);
-    (void)strncpy(proc.nspace, pmix_myproc.nspace, PMIX_MAX_NSLEN);
+    strlcpy(proc.nspace, pmix_myproc.nspace, PMIX_MAX_NSLEN);
     proc.rank = PMIX_RANK_WILDCARD;
-    rc = PMIx_Get(&proc, PMIX_UNIV_SIZE, NULL, 0, &valp);
+    rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &valp);
     if (rc != PMIX_SUCCESS) {
-        LOGERR("PMIx rank %d: PMIx_Get(UNIV_SIZE) failed: %s",
+        LOGERR("PMIx rank %d: PMIx_Get(JOB_SIZE) failed: %s",
                pmix_myproc.rank, PMIx_Error_string(rc));
         return (int)UNIFYFS_ERROR_PMI;
     }
     pmix_univ_nprocs = (size_t) valp->data.uint32;
+    LOGDBG("PMIX_JOB_SIZE: %d", pmix_univ_nprocs);
 
     kv_myrank = pmix_myproc.rank;
     kv_nranks = (int)pmix_univ_nprocs;
@@ -447,7 +448,7 @@ static int unifyfs_pmix_lookup(const char* key,
     }
 
     /* set key to lookup */
-    strncpy(pmix_key, key, sizeof(pmix_key));
+    strlcpy(pmix_key, key, sizeof(pmix_key));
     PMIX_PDATA_CREATE(pdata, 1);
     PMIX_PDATA_LOAD(&pdata[0], &pmix_myproc, pmix_key, NULL, PMIX_STRING);
 
@@ -498,7 +499,7 @@ static int unifyfs_pmix_publish(const char* key,
     }
 
     /* set key-val and modify publish behavior */
-    strncpy(pmix_key, key, sizeof(pmix_key));
+    strlcpy(pmix_key, key, sizeof(pmix_key));
     range = PMIX_RANGE_GLOBAL;
     ninfo = 2;
     PMIX_INFO_CREATE(info, ninfo);


### PR DESCRIPTION
The PMIX_UNIV_SIZE value is the number of allocated slots in the job
whereas the PMIX_JOB_SIZE is the number of actual processes that have
been started.  When trying to calculate how many instances of unifyfsd
to expect, PMIX_JOB_SIZE is the correct value.

See issue LLNL/Unifyfs#707

<!--- Provide a general summary of your changes in the Title above -->

### Description
This changes the PMIx init code to use PMIX_JOB_SIZE instead of PMIX_UNIV_SIZE.  It also replaces strncpy() with strlcpy() in a few places.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See #707 
### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ x] All commit messages are properly formatted.
