### PR TITLE
Documentation: change link command examples

### DIFF
--- a/docs/link.rst
+++ b/docs/link.rst
@@ -37,7 +37,7 @@ you are not building an MPI-enabled application, or if you want explicit
 control over when UnifyFS filesystem is mounted and unmounted, then link
 against ``libunifyfs_gotcha.so``.  In this case, you will also have to add
 calls to ``unifyfs_mount`` and ``unifyfs_unmount`` in the appropriate
-locations in your code. See :doc:`api`.)
+locations in your code. See :doc:`api`.
 
 To intercept I/O calls using gotcha, use the following syntax to link an
 application:

--- a/docs/link.rst
+++ b/docs/link.rst
@@ -38,7 +38,7 @@ C
 .. code-block:: Bash
 
     $ mpicc -o test_write test_write.c \
-        -I<unifyfs>/include -L<unifyfs>/lib -lunifyfs_gotcha \
+        -I<unifyfs>/include -L<unifyfs>/lib -lunifyfs_mpi_gotcha \
         -L<gotcha>/lib64 -lgotcha
 
 Fortran
@@ -47,4 +47,4 @@ Fortran
 .. code-block:: Bash
 
     $ mpif90 -o test_write test_write.F \
-        -I<unifyfs>/include -L<unifyfs>/lib -lunifyfsf -lunifyfs_gotcha
+        -I<unifyfs>/include -L<unifyfs>/lib -lunifyfsf -lunifyfs_mpi_gotcha

--- a/docs/link.rst
+++ b/docs/link.rst
@@ -32,7 +32,7 @@ Dynamic link
 A build of UnifyFS includes two different shared libraries.  Which one you
 should link against depends on your application.  If you wish to take advantage
 of the UnifyFS auto-mount feature (assuming the feature was enabled at
-compile-time), the you should link against ``libunifyfs_mpi_gotcha.so``.  If
+compile-time), then you should link against ``libunifyfs_mpi_gotcha.so``.  If
 you are not building an MPI-enabled application, or if you want explicit
 control over when UnifyFS filesystem is mounted and unmounted, then link
 against ``libunifyfs_gotcha.so``.  (In this case, you will also have to add

--- a/docs/link.rst
+++ b/docs/link.rst
@@ -35,7 +35,7 @@ of the UnifyFS auto-mount feature (assuming the feature was enabled at
 compile-time), then you should link against ``libunifyfs_mpi_gotcha.so``.  If
 you are not building an MPI-enabled application, or if you want explicit
 control over when UnifyFS filesystem is mounted and unmounted, then link
-against ``libunifyfs_gotcha.so``.  (In this case, you will also have to add
+against ``libunifyfs_gotcha.so``.  In this case, you will also have to add
 calls to ``unifyfs_mount`` and ``unifyfs_unmount`` in the appropriate
 locations in your code. See :doc:`api`.)
 

--- a/docs/link.rst
+++ b/docs/link.rst
@@ -29,22 +29,58 @@ To make this easier, UnifyFS installs a unifyfs-config script that one should in
 Dynamic link
 ------------
 
+A build of UnifyFS includes two different shared libraries.  Which one you
+should link against depends on your application.  If you wish to take advantage
+of the UnifyFS auto-mount feature (assuming the feature was enabled at
+compile-time), the you should link against ``libunifyfs_mpi_gotcha.so``.  If
+you are not building an MPI-enabled application, or if you want explicit
+control over when UnifyFS filesystem is mounted and unmounted, then link
+against ``libunifyfs_gotcha.so``.  (In this case, you will also have to add
+calls to ``unifyfs_mount`` and ``unifyfs_unmount`` in the appropriate
+locations in your code. See :doc:`api`.)
+
 To intercept I/O calls using gotcha, use the following syntax to link an
 application:
 
 C
 **************
+For code that uses the auto-mount feature:
 
 .. code-block:: Bash
 
     $ mpicc -o test_write test_write.c \
-        -I<unifyfs>/include -L<unifyfs>/lib -lunifyfs_mpi_gotcha \
-        -L<gotcha>/lib64 -lgotcha
+        -L<unifyfs>/lib -lunifyfs_mpi_gotcha
+
+
+For code that explicitly calls ``unifyfs_mount`` and ``unifyfs_unmount``:
+
+.. code-block:: Bash
+
+    $ mpicc -o test_write test_write.c \
+        -I<unifyfs>/include -L<unifyfs>/lib -lunifyfs_gotcha \
+
+Note the use of the ``-I`` option so that the compiler knows where to find
+the ``unifyfs.h`` header file.
+
 
 Fortran
 **************
+For code that uses the auto-mount feature:
 
 .. code-block:: Bash
 
     $ mpif90 -o test_write test_write.F \
-        -I<unifyfs>/include -L<unifyfs>/lib -lunifyfsf -lunifyfs_mpi_gotcha
+        -L<unifyfs>/lib -lunifyfs_mpi_gotcha
+
+For code that explicitly calls ``unifyfs_mount`` and ``unifyfs_unmount``:
+
+.. code-block:: Bash
+
+    $ mpif90 -o test_write test_write.F \
+        -I<unifyfs>/include -L<unifyfs>/lib -lunifyfsf -lunifyfs_gotcha
+
+Note the use of the ``-I`` option to specify the location of the
+``unifyfsf.h`` header.  Also note the use of the ``unifyfsf`` library.  This
+library  provides the Fortran bindings for the ``unifyfs_mount`` and
+``unifyfs_unmount`` functions.
+

--- a/docs/link.rst
+++ b/docs/link.rst
@@ -57,7 +57,7 @@ For code that explicitly calls ``unifyfs_mount`` and ``unifyfs_unmount``:
 .. code-block:: Bash
 
     $ mpicc -o test_write test_write.c \
-        -I<unifyfs>/include -L<unifyfs>/lib -lunifyfs_gotcha \
+        -I<unifyfs>/include -L<unifyfs>/lib -lunifyfs_gotcha
 
 Note the use of the ``-I`` option so that the compiler knows where to find
 the ``unifyfs.h`` header file.


### PR DESCRIPTION
Change the example link commands to use -lunifyfs_mpi_gotcha instead of -lunifyfs_gotcha.

See issue LLNL/UnifyFS#711.

<!--- Provide a general summary of your changes in the Title above -->

### Description
Change the example link commands to use -lunifyfs_mpi_gotcha instead of -lunifyfs_gotcha.

### Motivation and Context
The docs show linking an MPI-enabled program against the non-MPI version of the library.  Doing so results in a binary that doesn't work correctly.

### How Has This Been Tested?
Rendered the .rst file locally and it looked correct.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
