### PR TITLE
Disable GCC11 warning on call to  PMIx_Get()

### DIFF
--- a/common/src/unifyfs_keyval.c
+++ b/common/src/unifyfs_keyval.c
@@ -379,7 +379,7 @@ int unifyfs_pmix_init(void)
     // (at least) 64 bytes.
     pmix_key_t key;
     strcpy(key, PMIX_JOB_SIZE);
-    rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &valp);
+    rc = PMIx_Get(&proc, key, NULL, 0, &valp);
 
     if (rc != PMIX_SUCCESS) {
         LOGERR("PMIx rank %d: PMIx_Get(JOB_SIZE) failed: %s",

--- a/common/src/unifyfs_keyval.c
+++ b/common/src/unifyfs_keyval.c
@@ -373,23 +373,13 @@ int unifyfs_pmix_init(void)
     strlcpy(proc.nspace, pmix_myproc.nspace, PMIX_MAX_NSLEN);
     proc.rank = PMIX_RANK_WILDCARD;
 
-// This is a kludge for working around a bug in the version of PMIx installed
-// on Summit (which is part of Spectrum MPI 10.4.0.3).  Specifically, gcc 11
-// complains that the 2nd parameter - which is type 'const pmix_key_t', which
-// in turn is 'char [512]' - is longer than the const string that actually gets
-// passed in (which is itself defined in pmix_common.h).
-// It would be nice to limit this to just Summit, but there doesn't seem to be
-// an easy way to do that (no pre-defined macro we can check, for example).
-// Once the bug is fixed and the version on Summit is updated, we can get rid
-// of this test and just use the line in the 'else' clause
-#if (__GNUC__ >= 11)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wstringop-overread"
+    // Note: we do an extra copy because passing PMIX_JOB_SIZE directly to
+    // PMIx_Get() causes gcc 11 to generate a warning due to the fact that
+    // PMIX_JOB_SIZE evaluates to a 14 byte char array while pmix_key_t is
+    // (at least) 64 bytes.
+    pmix_key_t key;
+    strcpy(key, PMIX_JOB_SIZE);
     rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &valp);
-#pragma GCC diagnostic pop
-#else
-    rc = PMIx_Get(&proc, PMIX_JOB_SIZE, NULL, 0, &valp);
-#endif
 
     if (rc != PMIX_SUCCESS) {
         LOGERR("PMIx rank %d: PMIx_Get(JOB_SIZE) failed: %s",

--- a/common/src/unifyfs_keyval.c
+++ b/common/src/unifyfs_keyval.c
@@ -378,7 +378,7 @@ int unifyfs_pmix_init(void)
     // PMIX_JOB_SIZE evaluates to a 14 byte char array while pmix_key_t is
     // (at least) 64 bytes.
     pmix_key_t key;
-    strcpy(key, PMIX_JOB_SIZE);
+    strlcpy(key, PMIX_JOB_SIZE, sizeof(pmix_key_t));
     rc = PMIx_Get(&proc, key, NULL, 0, &valp);
 
     if (rc != PMIX_SUCCESS) {


### PR DESCRIPTION
This PR adds `#pragma` statements to suppress a specific warning generated by gcc 11 when the `PMIx_Get()` function is called.

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
The version of PMIx included with Spectrum MPI defines the PMIx_Get()
function to take a parameter that ends up being a 'const char[512]'.
However, the caller is expected to pass in a static const string that is
less than 512 bytes long.  GCC11 issues a warning about this size
mismatch, and since we build with `-Werror`, that breaks the build.

This commit adds some #pragma lines to disable that particular check
for the call to PMIx_Get() when building with GCC 11.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See issue #715

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Built on Summit with GCC 10.2.0 & 11.2.0

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

Note:  the bug is actually in IBM's implementation of PMIx, not UnifyFS.
### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted.
