### PR TITLE
fix re-initialization of API client config

### DIFF
--- a/client/src/unifyfs.c
+++ b/client/src/unifyfs.c
@@ -383,14 +383,16 @@ int unifyfs_client_init(unifyfs_client* client)
         // print log messages to stderr
         unifyfs_log_open(NULL);
 
-        // initialize configuration
+        // initialize configuration (if not already done)
         unifyfs_cfg_t* client_cfg = &(client->cfg);
-        rc = unifyfs_config_init(client_cfg, 0, NULL, 0, NULL);
-        if (rc) {
-            LOGERR("failed to initialize configuration.");
-            return UNIFYFS_FAILURE;
+        if (client_cfg->ptype != UNIFYFS_CLIENT) {
+            rc = unifyfs_config_init(client_cfg, 0, NULL, 0, NULL);
+            if (rc) {
+                LOGERR("failed to initialize configuration.");
+                return UNIFYFS_FAILURE;
+            }
+            client_cfg->ptype = UNIFYFS_CLIENT;
         }
-        client_cfg->ptype = UNIFYFS_CLIENT;
 
         // set log level from config
         char* cfgval = client_cfg->log_verbosity;


### PR DESCRIPTION
### Description

Fixes a bug reported by Hari@LLNL via email. Essentially, any configuration options passed to `unifyfs_initialize()` were being overwritten to the default values.

### How Has This Been Tested?

Tested on Ubuntu docker.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
