### PR TITLE
disallow unifyfs_create() of existing file

### DIFF
--- a/client/src/unifyfs_fid.h
+++ b/client/src/unifyfs_fid.h
@@ -35,7 +35,7 @@ int unifyfs_fid_free(unifyfs_client* client,
  * Returns the new fid, or negative error value */
 int unifyfs_fid_create_file(unifyfs_client* client,
                             const char* path,
-                            int exclusive);
+                            int private);
 
 /* Add a new directory and initialize metadata.
  * Returns the new fid, or a negative error value */

--- a/t/api/create-open-remove.c
+++ b/t/api/create-open-remove.c
@@ -32,6 +32,7 @@ int api_create_open_remove_test(char* unifyfs_root,
     int t2_flags = 0;
     unifyfs_gfid t1_gfid = UNIFYFS_INVALID_GFID;
     unifyfs_gfid t2_gfid = UNIFYFS_INVALID_GFID;
+    unifyfs_gfid dummy_gfid = UNIFYFS_INVALID_GFID;
 
     int rc = unifyfs_create(*fshdl, t1_flags, testfile1, &t1_gfid);
     ok(rc == UNIFYFS_SUCCESS && t1_gfid != UNIFYFS_INVALID_GFID,
@@ -41,6 +42,11 @@ int api_create_open_remove_test(char* unifyfs_root,
     rc = unifyfs_create(*fshdl, t2_flags, testfile2, &t2_gfid);
     ok(rc == UNIFYFS_SUCCESS && t2_gfid != UNIFYFS_INVALID_GFID,
        "%s:%d unifyfs_create(%s) is successful: rc=%d (%s)",
+       __FILE__, __LINE__, testfile2, rc, unifyfs_rc_enum_description(rc));
+
+    rc = unifyfs_create(*fshdl, t2_flags, testfile2, &dummy_gfid);
+    ok(rc != UNIFYFS_SUCCESS && dummy_gfid == UNIFYFS_INVALID_GFID,
+       "%s:%d unifyfs_create(%s) for existing file fails: rc=%d (%s)",
        __FILE__, __LINE__, testfile2, rc, unifyfs_rc_enum_description(rc));
 
     diag("Finished API create tests");


### PR DESCRIPTION
### Description

Duplicate creation is only disallowed for the same client that did the original `unifyfs_create()`.
Also, add a unit test for this case.

### Motivation and Context

See issue #690 

### How Has This Been Tested?

Tested on Ubuntu docker.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
