### PR TITLE
avoid request signal if RM thread exiting

### DIFF
--- a/server/src/unifyfs_request_manager.c
+++ b/server/src/unifyfs_request_manager.c
@@ -159,9 +159,9 @@ reqmgr_thrd_t* unifyfs_rm_thrd_create(int app_id, int client_id)
     thrd_ctrl->client_id = client_id;
 
     /* initialize flow control flags */
-    thrd_ctrl->exit_flag              = 0;
-    thrd_ctrl->exited                 = 0;
-    thrd_ctrl->waiting_for_work       = 0;
+    thrd_ctrl->exit_flag = 0;
+    thrd_ctrl->exited = 0;
+    thrd_ctrl->waiting_for_work = 0;
 
     /* launch request manager thread */
     rc = pthread_create(&(thrd_ctrl->thrd), NULL,
@@ -262,7 +262,7 @@ int rm_release_read_req(reqmgr_thrd_t* thrd_ctrl,
 static void signal_new_requests(reqmgr_thrd_t* reqmgr)
 {
     pid_t this_thread = unifyfs_gettid();
-    if (this_thread != reqmgr->tid) {
+    if ((!reqmgr->exit_flag) && (this_thread != reqmgr->tid)) {
         /* signal reqmgr to begin processing the requests we just added */
         LOGDBG("signaling new requests");
         pthread_cond_signal(&reqmgr->thrd_cond);
@@ -1637,11 +1637,11 @@ void* request_manager_thread(void* arg)
         rc = rm_heartbeat(thrd_ctrl);
         if (rc != UNIFYFS_SUCCESS) {
             /* detected failure of our client, time to exit */
-            break;
+            thrd_ctrl->exit_flag = 1;
         }
 
         /* bail out if we've been told to exit */
-        if (thrd_ctrl->exit_flag == 1) {
+        if (thrd_ctrl->exit_flag) {
             break;
         }
     }


### PR DESCRIPTION
### Description

Potential fix by avoid pthread condition operations for request manager threads that are in the process of being shut down.

### Motivation and Context

See issue #691 

### How Has This Been Tested?

Tested in Ubuntu docker.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
