### PR TITLE
Docs: New limitations and verifyio docs plus edits

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6,7 +6,7 @@ This section describes how to use the UnifyFS API in an application.
 
 .. Attention:: **Fortran Compatibility**
 
-   ``unifyfs_mount`` and ``unifyfs_unmount`` are now usable  with GFortran.
+   ``unifyfs_mount`` and ``unifyfs_unmount`` are usable with GFortran.
    There is a known ifort_issue_ with the Intel Fortran compiler as well as an
    xlf_issue_ with the IBM Fortran compiler. Other Fortran compilers are
    currently unknown.
@@ -15,9 +15,19 @@ This section describes how to use the UnifyFS API in an application.
    include the ``+fortran`` variant, or configure UnifyFS with the
    ``--enable-fortran`` option if building manually.
 
----------------------------
-Include the UnifyFS header
----------------------------
+.. rubric:: Transparent Mount Caveat
+
+MPI applications that take advantage of the :ref:`transparent mounting
+<auto-mount-label>` feature (through configuring with ``--enable-mpi-mount`` or
+with ``+auto-mount`` through Spack) do not need to be modified in any way in
+order to use UnifyFS. Move on to the :doc:`link` section next as this step can
+be skipped.
+
+-----
+
+--------------------------
+Include the UnifyFS Header
+--------------------------
 
 In C or C++ applications, include ``unifyfs.h``. See writeread.c_ for a full
 example.
@@ -35,9 +45,9 @@ full example.
 
     include 'unifyfsf.h'
 
----------------------------
+--------
 Mounting
----------------------------
+--------
 
 UnifyFS implements a file system in user space, which the system has no knowledge about.
 The UnifyFS library intecepts and handles I/O calls whose path matches a prefix that is defined by the user.
@@ -65,9 +75,9 @@ Here, ``/unifyfs`` is the path prefix for UnifyFS to intercept.
 The ``rank`` parameter specifies the MPI rank of the calling process.
 The ``size`` parameter specifies the number of MPI ranks in the user job.
 
----------------------------
+----------
 Unmounting
----------------------------
+----------
 
 When the application is done using UnifyFS, it should call ``unifyfs_unmount``.
 

--- a/docs/assumptions.rst
+++ b/docs/assumptions.rst
@@ -1,13 +1,13 @@
-================
+=========================
 Assumptions and Semantics
-================
+=========================
 
 In this section, we provide assumptions we make about the behavior of
 applications that use UnifyFS and about the file system semantics of UnifyFS.
 
----------------------------
+-------------------
 System Requirements
----------------------------
+-------------------
 
 The system requirements to run UnifyFS are:
 
@@ -17,9 +17,11 @@ The system requirements to run UnifyFS are:
     - The system must support the ability for UnifyFS user-level server processes
       to run concurrently with user application processes on compute nodes.
 
----------------------------
+----------
+
+--------------------
 Application Behavior
----------------------------
+--------------------
 
 UnifyFS is specifically designed to support the bulk synchronous I/O pattern
 that is typical in HPC applications, e.g., checkpoint/restart or output dumps.
@@ -40,12 +42,13 @@ the performance might be slower and the user may
 have to take additional steps to ensure correct execution of the application
 with UnifyFS.
 For more information on this topic, refer to the section on
-:ref:`commit consistency semantics in UnifyFS <commit_consistency_label>`_.
+:ref:`commit consistency semantics in UnifyFS <commit_consistency_label>`.
 
+----------
 
----------------------------
+-----------------
 Consistency Model
----------------------------
+-----------------
 
 The UnifyFS file system does not support strict POSIX consistency semantics.
 (Please see
@@ -58,10 +61,10 @@ modified by the application.
 These two consistency models provide opportunities for UnifyFS to
 provide better performance for the I/O operations of HPC applications.
 
-'''''''''''''''''''''''''''
-Commit Consistency Semantics in UnifyFS
-'''''''''''''''''''''''''''
 .. _commit_consistency_label:
+'''''''''''''''''''''''''''''''''''''''
+Commit Consistency Semantics in UnifyFS
+'''''''''''''''''''''''''''''''''''''''
 
 Commit consistency semantics require
 explicit "commit" operations to be performed before updates to a file
@@ -153,11 +156,12 @@ and multiple processes write concurrently to the same file offset or to an
 overlapping region, the result is undefined and may
 reflect the result of a mixture of the processes' operations to that offset or region.
 
-.. How can users check that their application is correctly synchronized? Will we have the checker scripts ready?
+The :doc:`VerifyIO <verifyio>` tool can be used to determine whether an
+application is correctly synchronized.
 
-'''''''''''''''''''''''''''
+'''''''''''''''''''''''''''''''''''''''''''
 Lamination Consistency Semantics in UnifyFS
-'''''''''''''''''''''''''''
+'''''''''''''''''''''''''''''''''''''''''''
 
 The other consistency model that UnifyFS employs is called "lamination
 semantics" which is intended to be applied once a file is done being modified
@@ -202,9 +206,11 @@ metadata and file data between compute nodes on every write.
 Also, since file contents cannot change after lamination,
 aggressive caching may be used during the read phase with minimal locking.
 
----------------------------
+----------
+
+--------------------
 File System Behavior
----------------------------
+--------------------
 
 The following summarize the behavior of UnifyFS under our
 consistency model.

--- a/docs/build.rst
+++ b/docs/build.rst
@@ -1,26 +1,34 @@
-========================
+=============
 Build UnifyFS
-========================
+=============
 
 This section describes how to build UnifyFS and its dependencies.
 There are three options:
 
-* build both UnifyFS and its dependencies with Spack,
+* build both UnifyFS and dependencies with Spack,
 * build the dependencies with Spack, but build UnifyFS with autotools
 * build the dependencies with a bootstrap script, and build UnifyFS with autotools
 
----------------------------
+----------
 
----------------------------------------------
-Build UnifyFS and its dependencies with Spack
----------------------------------------------
+-----------------------------------------
+Build UnifyFS and Dependencies with Spack
+-----------------------------------------
 
 One may install UnifyFS and its dependencies with Spack_.
 If you already have Spack, make sure you have the latest release.
 If you use a clone of the Spack develop branch, be sure to pull the latest changes.
 
-.. _build-label:
+.. warning:: **Thallium, Mochi Suite, and SDS Repo Users**
 
+    The available and UnifyFS-compatible Mochi-Margo versions that are in the
+    ``mochi-margo`` Spack package do not match up with the latest/default
+    versions in the Mochi Suite, SDS Repo, and ``mochi-thallium`` Spack
+    packages. It is likely that a different version of ``mochi-margo`` will need
+    to be specified in the install command of UnifyFS (E.g.: ``spack install
+    unifyfs ^mochi-margo@0.9.6``).
+
+.. _build-label:
 Install Spack
 *************
 
@@ -33,8 +41,8 @@ Install Spack
 Use `Spack's shell support`_ to add Spack to your ``PATH`` and enable use of the
 ``spack`` command.
 
-Build UnifyFS and its dependencies
-**********************************
+Build and Install UnifyFS
+*************************
 
 .. code-block:: Bash
 
@@ -44,11 +52,9 @@ Build UnifyFS and its dependencies
 If the most recent changes on the development branch ('dev') of UnifyFS are
 desired, then do ``spack install unifyfs@develop``.
 
-.. Edit the following admonition if the default of variants are changed or when
-   new variants are added.
-
 Include or remove variants with Spack when installing UnifyFS when a custom
-build is desired. Run ``spack info unifyfs`` for more info.
+build is desired. Run ``spack info unifyfs`` for more information on available
+variants.
 
 .. table:: UnifyFS Build Variants
    :widths: auto
@@ -58,9 +64,6 @@ build is desired. Run ``spack info unifyfs`` for more info.
                (``spack install <package>``)
    ==========  =============================  =======  ===========================
    Auto-mount  ``unifyfs+auto-mount``         True     Enable transparent mounting
-   HDF5        ``unifyfs+hdf5``               False    Build with parallel HDF5
-
-               ``unifyfs+hdf5 ^hdf5~mpi``     False    Build with serial HDF5
    Fortran     ``unifyfs+fortran``            False    Enable Fortran support
    PMI         ``unifyfs+pmi``                False    Enable PMI2 support
    PMIx        ``unifyfs+pmix``               False    Enable PMIx support
@@ -78,10 +81,10 @@ build is desired. Run ``spack info unifyfs`` for more info.
     Run ``spack spec -I unifyfs`` before installing to see what Spack is going
     to do.
 
----------------------------
+----------
 
 -----------------------------------------------------------
-Build dependencies with Spack, build UnifyFS with autotools
+Build Dependencies with Spack, Build UnifyFS with Autotools
 -----------------------------------------------------------
 
 One can install the UnifyFS dependencies with Spack and build UnifyFS
@@ -92,7 +95,7 @@ Take advantage of `Spack Environments`_ to streamline this process.
 
 .. _spack-build-label:
 
-Build the dependencies
+Build the Dependencies
 **********************
 
 Once Spack is installed on your system (see :ref:`above <build-label>`),
@@ -101,13 +104,13 @@ the UnifyFS dependencies can then be installed.
 .. code-block:: Bash
 
     $ spack install gotcha
-    $ spack install mochi-margo ^libfabric fabrics=rxm,sockets,tcp
+    $ spack install mochi-margo@0.9.6 ^libfabric fabrics=rxm,sockets,tcp
     $ spack install spath~mpi
 
 .. tip::
 
-    You can run ``spack install --only=dependencies unifyfs`` to install all
-    UnifyFS dependencies without installing UnifyFS.
+    Run ``spack install --only=dependencies unifyfs`` to install all UnifyFS
+    dependencies without installing UnifyFS itself.
 
     Keep in mind this will also install all the build dependencies and
     dependencies of dependencies if you haven't already installed them through
@@ -118,7 +121,7 @@ Build UnifyFS
 *************
 
 Download the latest UnifyFS release from the Releases_ page or clone the develop
-branch from the UnifyFS repository
+branch ('dev') from the UnifyFS repository
 `https://github.com/LLNL/UnifyFS <https://github.com/LLNL/UnifyFS>`_.
 
 Load the dependencies into your environment and then
@@ -149,21 +152,21 @@ Alternatively, UnifyFS can be configured using ``CPPFLAGS`` and ``LDFLAGS``:
 To see all available build configuration options, run ``./configure --help``
 after ``./autogen.sh`` has been run.
 
----------------------------
+----------
 
 ------------------------------------------------------------------
-Build dependencies with bootstrap and build UnifyFS with autotools
+Build Dependencies with Bootstrap and Build UnifyFS with Autotools
 ------------------------------------------------------------------
 
 Download the latest UnifyFS release from the Releases_ page or clone the develop
-branch from the UnifyFS repository
+branch ('dev') from the UnifyFS repository
 `https://github.com/LLNL/UnifyFS <https://github.com/LLNL/UnifyFS>`_.
 
 Build the Dependencies
 **********************
 
 UnifyFS requires MPI, GOTCHA, Margo and OpenSSL.
-References to these dependencies can be found on our :doc:`dependencies` page.
+References to these dependencies can be found on the :doc:`dependencies` page.
 
 A bootstrap.sh_ script in the UnifyFS source distribution downloads and installs
 all dependencies.  Simply run the script in the top level directory of the
@@ -212,14 +215,14 @@ after ``./autogen.sh`` has been run.
     On Cray systems, the detection of MPI compiler wrappers requires passing the
     following flags to the configure command: ``MPICC=cc MPIFC=ftn``
 
----------------------------
+----------
 
 -----------------
 Configure Options
 -----------------
 
-When building UnifyFS with autotools,
-a number of options are available to configure its functionality.
+When building UnifyFS with autotools, a number of options are available to
+configure its functionality.
 
 Fortran
 *******
@@ -272,6 +275,7 @@ relative paths within an application. To enable, use the ``--with-spath``
 configure option or provide the appropriate ``CPPFLAGS`` and ``LDFLAGS`` at
 configure time.
 
+.. _auto-mount-label:
 Transparent Mounting for MPI Applications
 *****************************************
 

--- a/docs/contribute-ways.rst
+++ b/docs/contribute-ways.rst
@@ -1,5 +1,5 @@
 ******************
-Ways to Contribute
+Contributing Guide
 ******************
 
 *First of all, thank you for taking the time to contribute!*
@@ -102,6 +102,18 @@ able to quickly identify and resolve issues.
 Documentation
 =============
 
+As UnifyFS is continually improved and updated, it is easy for documentation to
+become out-of-date. Any contributions to the documentation, no matter how
+small, is always greatly appreciated. If you are not in a position to update
+the documentation yourself, please notify us via the `mailing list`_ of
+anything you notice that is missing or needs to be changed.
+
+---------------
+
+***********************
+Developer Documentation
+***********************
+
 Here is our current documentation of how the internals of UnifyFS function for
 several basic operations.
 
@@ -113,15 +125,9 @@ several basic operations.
    :align: left
    :alt: UnifyFS Developer's Documentation
 
-:download:`Download slides <slides/UnifyFS-developers-documentation.pdf>`.
+:download:`Download PDF <slides/UnifyFS-developers-documentation.pdf>`.
 
 |
-
-As UnifyFS is continually improved and updated, it is easy for documentation to
-become out-of-date. Any contributions to the documentation, no matter how
-small, is always greatly appreciated. If you are not in a position to update
-the documentation yourself, please notify us via the `mailing list`_ of
-anything you notice that needs to be changed.
 
 .. explicit external hyperlink targets
 

--- a/docs/dependencies.rst
+++ b/docs/dependencies.rst
@@ -10,12 +10,12 @@ Required
 
 - `GOTCHA <https://github.com/LLNL/GOTCHA/releases>`_ version 1.0.3 (or later)
 
-- `Margo <https://github.com/mochi-hpc/mochi-margo/releases>`_ version 0.9.6 (or later) and its dependencies:
+- `Margo <https://github.com/mochi-hpc/mochi-margo/releases>`_ version 0.9.6 - version 0.9.9 and its dependencies:
 
   - `Argobots <https://github.com/pmodels/argobots/releases>`_ version 1.1 (or later)
   - `Mercury <https://github.com/mercury-hpc/mercury/releases>`_ version 2.0.1 (or later)
 
-    - `libfabric <https://github.com/ofiwg/libfabric>`_ or `bmi <https://github.com/radix-io/bmi/>`_
+    - `libfabric <https://github.com/ofiwg/libfabric>`_ (avoid versions 1.13 and 1.13.1) or `bmi <https://github.com/radix-io/bmi/>`_
 
   - `JSON-C <https://github.com/json-c/json-c>`_
 
@@ -33,3 +33,33 @@ Optional
 --------
 
 - `spath <https://github.com/ecp-veloc/spath>`_ for normalizing relative paths
+
+----------
+
+===================
+UnifyFS Error Codes
+===================
+
+Wherever sensible, UnifyFS uses the error codes defined in POSIX `errno.h
+<https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/errno.h.html>`_.
+
+UnifyFS specific error codes are defined as follows:
+
+.. table::
+    :widths: auto
+
+    =====  =========  ======================================
+    Value  Error      Description
+    =====  =========  ======================================
+    1001   BADCONFIG  Configuration has invalid setting
+    1002   GOTCHA     Gotcha operation error
+    1003   KEYVAL     Key-value store operation error
+    1004   MARGO      Mercury/Argobots operation error
+    1005   MDHIM      MDHIM operation error
+    1006   META       Metadata store operation error
+    1007   NYI        Not yet implemented
+    1008   PMI        PMI2/PMIx error
+    1009   SHMEM      Shared memory region init/access error
+    1010   THREAD     POSIX thread operation failed
+    1011   TIMEOUT    Timed out
+    =====  =========  ======================================

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -1,14 +1,14 @@
-********
-Examples
-********
+****************
+Example Programs
+****************
 
 There are several examples_ available on ways to use UnifyFS. These examples
 build into static, GOTCHA, and pure POSIX (not linked with UnifyFS) versions
 depending on how they are linked. Several of the example programs are also used
 in the UnifyFS :doc:`intregraton testing <testing>`.
 
-Examples Locations
-==================
+Locations of Examples
+=====================
 
 The example programs can be found in two locations, where UnifyFS is built and
 where UnifyFS is installed.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,13 +14,21 @@ UnifyFS: A file system for burst buffers
    overview
    definitions
    assumptions
+   limitations
    build
    api
    link
    configuration
    run
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Reference
+
    examples
    library_api
+   dependencies
+   verifyio
 
 .. toctree::
    :maxdepth: 2
@@ -31,16 +39,6 @@ UnifyFS: A file system for burst buffers
    testing
    wrappers
    add-rpcs
-
-.. toctree::
-   :maxdepth: 2
-   :caption: Dependencies
-
-.. toctree::
-   :maxdepth: 2
-   :caption: Reference
-
-   dependencies
 
 ==================
 Indices and tables

--- a/docs/limitations.rst
+++ b/docs/limitations.rst
@@ -1,0 +1,186 @@
+===========================
+Limitations and Workarounds
+===========================
+
+-------------------
+General Limitations
+-------------------
+
+.. rubric:: Synchronization Across Processes
+
+Any overlapping write operations or simultaneous read and write operations
+require proper synchronization within UnifyFS. This includes ensuring updates to
+a file are visible by other processes as well as proper inter-process
+communication to enforce ordering of conflicting I/O operations. Refer to the
+section on
+:ref:`commit consistency semantics in UnifyFS <commit_consistency_label>`
+for more detail.
+
+.. rubric:: File Locking
+
+UnifyFS does not support file locking (calls to ``fcntl()``). This results in
+some less obvious limitations when using some I/O libraries with UnifyFS
+(:ref:`see below <file-lock-label>`).
+
+.. warning::
+
+    Any calls to ``fcntl()`` are not even intercepted by UnifyFS and calls to
+    such will be ignored, resulting in silent errors and possible data
+    corruption. Running the application through :doc:`VerifyIO <verifyio>` can
+    help determine if any file locking calls are made.
+
+----------
+
+---------------------------
+MPI-IO and HDF5 Limitations
+---------------------------
+
+Synchronization
+***************
+
+Applications that make use of inter-process communication (e.g., MPI) to enforce
+a particular order of potentially conflicting I/O operations from multiple
+processes must properly use synchronization calls (e.g., ``MPI_File_sync()``) to
+avoid possible data corruption. Within UnifyFS, this requires use of the
+:ref:`"sync-barrier-sync" construct <sync-barrier-sync-label>` to ensure proper
+synchronization.
+
+Properly synchronizing includes doing so between any less obvious MPI-I/O calls
+that also imply a write/read. For example, ``MPI_File_set_size()`` and
+``MPI_File_preallocate()`` act as write operations and ``MPI_File_get_size()``
+acts as a read operation. There may be other implied write/read calls as well.
+
+.. TODO: Mention use/need of ``romio_visibility_immediate`` hint once available.
+.. https://github.com/pmodels/mpich/issues/5902
+
+Synchronization Workarounds
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If your application does not adhere to proper syncronization requirements there
+are four workaround options available to still allow UnifyFS intregration.
+
+UnifyFS Sync-per-write Configuration (``client.write_sync``)
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+UnifyFS provided config option that makes UnifyFS act more “POSIX like” by
+forcing a metadata sync to the server after **every** write operation. Set
+``UNIFYFS_CLIENT_WRITE_SYNC=ON`` to enable this option.
+
+**Cost:** Can cause a significant decrease in write performance as the amount of
+file sync operations that are performed will be far more than necessary.
+
+Manually Add Sync Operations
+""""""""""""""""""""""""""""
+
+Edit the application code and manually add the proper synchronization calls
+everywhere necessary. For example, wherever an ``MPI_File_sync()`` is required,
+the "sync-barrier-sync" construct needs to be used.
+
+.. _sync-barrier-sync-label:
+
+.. code-block:: C
+    :caption: Sync-barrier-sync Construct
+
+    MPI_File_sync() //flush newly written bytes from MPI library to file system
+    MPI_Barrier()   //ensure all ranks have finished the previous sync
+    MPI_File_sync() //invalidate read cache in MPI library
+
+.. Note::
+
+    The "barrier" in "sync-barrier-sync" can be replaced by a send-recv or
+    certain collectives that are guaranteed to be synchronized. See the "Note on
+    the third step" in the `VerifyIO README`_ for more information.
+
+**Cost:** If making edits to the application source code is an option, the
+amount of time and effort required to track down all the places that proper
+synchonization calls are needed can be very labor intensive.
+:doc:`VerifyIO <verifyio>` can help with in this effort.
+
+HDF5 FILE_SYNC
+""""""""""""""
+
+HDF5 provided config option that forces HDF5 to add an ``MPI_File_sync()`` call
+after every collective write operation when needed by the underlying MPI-IO
+driver. Set ``HDF5_DO_MPI_FILE_SYNC=1`` to enable this option.
+
+.. Note::
+
+    This option will soon be available in the `HDF5 develop branch`_ as well as
+    in the next HDF5 release.
+
+**Cost:** Can cause a significant decrease in write performance as the amount of
+file sync operations performed will likely be more than necessary. Similar to,
+but potentially more efficient than, the ``WRITE_SYNC`` workaround as less
+overall file syncs may be performed in comparision, but still likely more than
+needed.
+
+ROMIO Driver Hint
+"""""""""""""""""
+
+A ROMIO provided hint that will cause the ROMIO driver (in a supported MPI
+library) to add an ``MPI_Barrier()`` call and an additional ``MPI_File_sync()``
+call after each already existing ``MPI_File_sync()`` call within the
+application. In other words, this hint converts each existing
+``MPI_File_sync()`` call into the "sync-barrier-sync" construct. Enable the
+``romio_synchronizing_flush`` hint to use this workaround.
+
+**Cost:** Potentially more efficient that the ``WRITE_SYNC`` and HDF5
+``FILE_SYNC`` workarounds as this will cause the application to use the
+synchronization construct required by UnifyFS everywhere the application already
+intends them to occur (i.e., whenever there is already an ``MPI_File_sync()``).
+However, if (1) any existing ``MPI_File_sync()`` calls are only meant to make
+data visible to the other processes (rather than to avoid potential conflicts)
+or (2) the application contains a mix of lone ``MPI_File_sync()`` calls along
+with the "sync-barrier-sync" construct, then this approach will result in more
+syncs than necessary.
+
+----------
+
+.. _file-lock-label:
+File Locking
+************
+
+UnifyFS not supporting file locks results in some I/O library features to not
+work with UnifyFS.
+
+.. topic:: Atomicity
+
+    ROMIO uses ``fcntl()`` to implement atomicity. It is recommended to disable
+    atomicity when integrating with UnifyFS. To disable, run
+    ``MPI_File_set_atomicity(fh, 0)``.
+
+.. topic:: Data Sieving
+
+    It is recommended to disable data sieving when integrating with UnifyFS.
+    Even with locking support, use of data sieving will drastically increase the
+    time and space overhead within UnifyFS, significantly decreasing application
+    performance. For ROMIO, set the hints ``romio_ds_write disable`` and
+    ``romio_ds_read disable`` to disable data sieving.
+
+.. topic:: Shared File Pointers
+
+    Avoid using shared file pointers in MPI-I/O under UnifyFS as they require
+    file locking to implement.
+    Functions that use shared file pointers include:
+
+    - ``MPI_File_write_shared()``
+    - ``MPI_File_read_shared()``
+    - ``MPI_File_write_ordered()``
+    - ``MPI_File_read_ordered()``
+
+File Locking Workarounds
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+UnifyFS doesn't provide any direct workarounds for anything that requires file
+locking. Simply disable atomicity and data sieving and avoid using shared file
+pointers to get around this.
+
+In the future, UnifyFS may add support for file locking. However, it is strongly
+suggested to avoid file locking unless the application cannot run properly
+without its use. Enabling file lock support within UnifyFS will result in
+decreased I/O performance for the application.
+
+.. explicit external hyperlink targets
+
+.. _HDF5 develop branch: https://github.com/HDFGroup/hdf5
+.. _VerifyIO README: https://github.com/uiuc-hpc/Recorder/tree/pilgrim/tools/verifyio#note-on-the-third-step

--- a/docs/verifyio.rst
+++ b/docs/verifyio.rst
@@ -1,0 +1,327 @@
+=========================================
+VerifyIO: Determine UnifyFS Compatibility
+=========================================
+
+----------------------
+Recorder and  VerifyIO
+----------------------
+
+VerifyIO_ can be used to determine an application's compatibility with UnifyFS
+as well as aid in narrowing down what an application may need to change to
+become compatible with UnifyFS.
+
+VerifyIO is a tool within the Recorder_ tracing framework that takes the
+application traces from Recorder and determines whether I/O synchronization is
+correct based on the underlying file system semantics (e.g., POSIX, commit) and
+synchronization semantics (e.g., POSIX, MPI).
+
+Run VerifyIO with commit semantics on the application's traces to determine
+compatibility with UnifyFS.
+
+----------
+
+--------------
+VerifyIO Guide
+--------------
+
+To use VerifyIO, the Recorder library needs to be installed. See the `Recorder
+README`_ for full instructions on how to build, run, and use Recorder.
+
+Build
+*****
+
+Clone the ``pilgrim`` (default) branch of Recorder:
+
+.. code-block:: Bash
+    :caption: Clone
+
+    $ git clone https://github.com/uiuc-hpc/Recorder.git
+
+Determine the install locations of the MPI-IO and HDF5 libraries being used by
+the application and pass those paths to Recorder at configure time.
+
+.. code-block:: Bash
+    :caption: Configure, Make, and Install
+
+    $ deps_prefix="${mpi_install};${hdf5_install}"
+    $ mkdir -p build install
+
+    $ cd build
+    $ cmake -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_PREFIX_PATH=$deps_prefix ../Recorder
+    $ make
+    $ make install
+
+    # Capture Recorder source code and install locations
+    $ export RECORDER_SRC=/path/to/Recorder/source/code
+    $ export RECORDER_ROOT=/path/to/Recorder/install
+
+Python3 and the ``recorder-viz`` and ``networkx`` packages are also required to
+run the final VerifyIO verification code.
+
+.. code-block:: Bash
+    :caption: Install Python Packages
+
+    $ module load python/3.x.x
+    $
+    $ pip3 install recorder-viz --user
+    $ pip3 install networkx --user
+
+Run
+***
+
+Before capturing application traces, it is recommended to disable data sieving
+as VerifyIO will flag this as incompatible under commit semantics.
+
+.. code-block:: Bash
+    :caption: Disable Data Sieving
+
+    echo -e "romio_ds_write disable\nromio_ds_read disable" > /path/to/romio_hints
+    export ROMIO_HINTS=/path/to/romio_hints
+    export ROMIO_PRINT_HINTS=1   #optional
+
+
+Run the application with Recorder to capture the traces using the appropriate
+environment variable export option for the available workload manager.
+
+.. code-block:: Bash
+    :caption: Capture Traces
+
+    srun -N $nnodes -n $nprocs --export=ALL,LD_PRELOAD=$RECORDER_ROOT/lib/librecorder.so example_app_executable
+
+Recorder places the trace files in a folder within the current working directory
+named ``hostname-username-appname-pid-starttime``.
+
+.. _recorder2text-label:
+If desired (e.g., for debugging), use the recorder2text tool to generate
+human-readable traces from the captured trace files.
+
+.. code-block:: Bash
+    :caption: Generate Human-readable Traces
+
+    $RECORDER_ROOT/bin/recorder2text /path/to/traces &> recorder2text.out
+
+This will generate text-format traces in the folder ``path/to/traces/_text``.
+
+Next, run the Recorder conflict detector to capture **potential** conflicts. The
+``--semantics=`` option needs to match the semantics of the intended underlying
+file system. In the case of UnifyFS, use ``commit`` semantics.
+
+.. code-block:: Bash
+    :caption: Capture Potential Conflicts
+
+    $RECORDER_ROOT/bin/conflict_detector /path/to/traces --semantics=commit &> conflict_detector_commit.out
+
+The potential conflicts will be recorded to the file
+``path/to/traces/conflicts.txt``.
+
+Lastly, run VerifyIO with the traces and potential conflicts to determine
+whether all I/O operations are properly synchronized under the desired standard
+(e.g., POSIX, MPI).
+
+.. code-block:: Bash
+    :caption: Run VerifyIO
+
+    # Evaluate using POSIX standard
+    python3 $RECORDER_SRC/tools/verifyio/verifyio.py /path/to/traces /path/to/traces/conflicts.txt --semantics=posix &> verifyio_commit_results.posix
+
+    # Evaluate using MPI standard
+    python3 $RECORDER_SRC/tools/verifyio/verifyio.py /path/to/traces /path/to/traces/conflicts.txt --semantics=mpi &> verifyio_commit_results.mpi
+
+Interpreting Results
+********************
+
+In the event VerifyIO shows an incompatibility, or the results are not clear,
+don't hesitate to contact the UnifyFS team `mailing list`_ for aid in
+determining a solution.
+
+Conflict Detector Results
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When there are no potential conflicts, the conflict detector output simply
+states as much:
+
+.. code-block:: none
+
+    [prompt]$ cat conflict_detector_commit.out
+    Check potential conflicts under Commit Semantics
+    ...
+    No potential conflict found for file /path/to/example_app_outfile
+
+When potential conflicts exist, the conflict detector prints a list of each
+conflicting pair. For each operation within a pair, the output contains the
+process rank, sequence ID, offset the conflict occurred at, number of bytes
+affected by the operation, and whether the operation was a write or a read.
+This format is printed at the top of the output.
+
+.. code-block:: none
+
+    [prompt]$ cat conflict_detector_commit.out
+    Check potential conflicts under Commit Semantics
+    Format:
+    Filename, io op1(rank-seqId, offset, bytes, isRead), io op2(rank-seqId, offset, bytes, isRead)
+
+    /path/to/example_app_outfile, op1(0-244, 0, 800, write), op2(0-255, 0, 96, write)
+    /path/to/example_app_outfile, op1(0-92, 4288, 2240, write), op2(0-148, 4288, 2216, read)
+    /path/to/example_app_outfile, op1(1-80, 6528, 2240, write), op2(1-136, 6528, 2216, read)
+    ...
+    /path/to/example_app_outfile, op1(0-169, 18480, 4888, write), op2(3-245, 18848, 14792, read)
+    /path/to/example_app_outfile, op1(0-169, 18480, 4888, write), op2(3-246, 18848, 14792, write)
+    /path/to/example_app_outfile, op1(0-231, 18480, 16816, write), op2(3-245, 18848, 14792, read)
+    /path/to/example_app_outfile, Read-after-write (RAW): D-2,S-5, Write-after-write (WAW): D-1,S-2
+
+The final line printed contains a summary of all the potential conflicts.
+This consists of the total number of read-after-write (RAW) and
+write-after-write (WAW) potentially conflicting operations performed by
+different processes (D-#) or the same process (S-#).
+
+VerifyIO Results
+^^^^^^^^^^^^^^^^
+
+VerifyIO takes the traces and potential conflicts and checks if each conflicting pair is properly synchronized. Refer to the `VerifyIO README <VerifyIO>`_ for a
+description on what determines proper synchronization for a conflicting I/O
+pair.
+
+Compatible with UnifyFS
+"""""""""""""""""""""""
+
+In the event that there are no potential conflicts, or each potential conflict
+pair was performed by the same rank, VerifyIO will report the application as
+being properly synchronized and therefore compatible with UnifyFS.
+
+.. code-block:: none
+
+    [prompt]$ cat verifyio_commit_results.posix
+    Rank: 0, intercepted calls: 79, accessed files: 5
+    Rank: 1, intercepted calls: 56, accessed files: 2
+    Building happens-before graph
+    Nodes: 46, Edges: 84
+
+    Properly synchronized under posix semantics
+
+
+    [prompt]$ cat verifyio_commit_results.mpi
+    Rank: 0, intercepted calls: 79, accessed files: 5
+    Rank: 1, intercepted calls: 56, accessed files: 2
+    Building happens-before graph
+    Nodes: 46, Edges: 56
+
+    Properly synchronized under mpi semantics
+
+When there are potential conflicts from different ranks but the proper
+synchronization has occurred, VerifyIO will also report the application as being
+properly synchronized.
+
+.. code-block:: none
+
+    [prompt]$ cat verifyio_commit_results.posix
+    Rank: 0, intercepted calls: 510, accessed files: 8
+    Rank: 1, intercepted calls: 482, accessed files: 5
+    Rank: 2, intercepted calls: 481, accessed files: 5
+    Rank: 3, intercepted calls: 506, accessed files: 5
+    Building happens-before graph
+    Nodes: 299, Edges: 685
+    Conflicting I/O operations: 0-169-write <--> 3-245-read, properly synchronized: True
+    Conflicting I/O operations: 0-169-write <--> 3-246-write, properly synchronized: True
+
+    Properly synchronized under posix semantics
+
+Incompatible with UnifyFS
+"""""""""""""""""""""""""
+
+In the event there are potential conflicts from different ranks but the proper
+synchronization has **not** occurred, VerifyIO will report the application as
+not being properly synchronized and therefore incompatible [*]_ with UnifyFS.
+
+Each operation involved in the conflicting pair is listed in the format
+``rank-sequenceID-operation`` followed by the whether that pair is properly
+synchronized.
+
+.. code-block:: none
+
+    [prompt]$ cat verifyio_commit_results.mpi
+    Rank: 0, intercepted calls: 510, accessed files: 8
+    Rank: 1, intercepted calls: 482, accessed files: 5
+    Rank: 2, intercepted calls: 481, accessed files: 5
+    Rank: 3, intercepted calls: 506, accessed files: 5
+    Building happens-before graph
+    Nodes: 299, Edges: 427
+    0-169-write --> 3-245-read, properly synchronized: False
+    0-169-write --> 3-246-write, properly synchronized: False
+
+    Not properly synchronized under mpi semantics
+
+.. [*] Incompatible here does not mean the application cannot work with UnifyFS
+   at all, just under the default configuration. There are
+   :doc:`workarounds <limitations>` available that could very easily change this
+   result (VerifyIO plans to have options to run under the assumption some
+   workarounds are in place). Should your outcome be an incompatible result,
+   please contact the UnifyFS `mailing list`_ for aid in finding a solution.
+
+.. rubric:: Debugging a Conflict
+
+The :ref:`recorder2text output <recorder2text-label>` can be used to aid in
+narrowing down where/what is causing a conflicting pair. In the incompatible
+example above, the first pair is a ``write()`` from rank 0 with the sequence ID
+of 169 and a ``read()`` from rank 3 with the sequence ID of 245.
+
+The sequence IDs correspond to the order in which functions were called by that
+particular rank. In the recorder2text output, this ID will then correspond to
+line numbers, but off by +1 (i.e., seqID 169 -> line# 170).
+
+.. code-block:: none
+    :caption: recorder2text output
+    :emphasize-lines: 6,14
+
+        #rank 0
+        ...
+    167 0.1440291 0.1441011 MPI_File_write_at_all 1 1 ( 0-0 0 %p 1 MPI_TYPE_UNKNOWN [0_0] )
+    168 0.1440560 0.1440679 fcntl 2 0 ( /path/to/example_app_outfile 7 1 )
+    169 0.1440700 0.1440750 pread 2 0 ( /path/to/example_app_outfile %p 4888 18480 )
+    170 0.1440778 0.1440909 pwrite 2 0 ( /path/to/example_app_outfile %p 4888 18480 )
+    171 0.1440918 0.1440987 fcntl 2 0 ( /path/to/example_app_outfile 6 2 )
+        ...
+
+        #rank 3
+        ...
+    244 0.1539204 0.1627174 MPI_File_write_at_all 1 1 ( 0-0 0 %p 1 MPI_TYPE_UNKNOWN [0_0] )
+    245 0.1539554 0.1549513 fcntl 2 0 ( /path/to/example_app_outfile 7 1 )
+    246 0.1549534 0.1609544 pread 2 0 ( /path/to/example_app_outfile %p 14792 18848 )
+    247 0.1609572 0.1627053 pwrite 2 0 (/path/to/example_app_outfile %p 14792 18848 )
+    248 0.1627081 0.1627152 fcntl 2 0 ( /path/to/example_app_outfile 6 2 )
+        ...
+
+Note that in this example the ``pread()``/``pwrite()`` calls from rank 3 operate
+on overlapping bytes from the ``pwrite()`` call from rank 0. For this example,
+data sieving was left enabled which results in "fcntl-pread-pwrite-fcntl" I/O
+sequences. Refer to :doc:`limitations` for more on the file locking limitations
+of UnifyFS.
+
+The format of the recorder2text output is: ``<start-time> <end-time>
+<func-name> <call-level> <func-type> (func-parameters)``
+
+.. Note::
+
+    The ``<call-level>`` value indicates whether the function was called
+    directly by the application or by an I/O library. The ``<func-type>`` value
+    shows the Recorder-tracked function type.
+
+    +-------+------------------------------------+-+-------+-----------------+
+    | Value | Call Level                         | | Value | Function Type   |
+    +=======+====================================+=+=======+=================+
+    | 0     | Called by application directly     | | 0     | RECORDER_POSIX  |
+    +-------+------------------------------------+ +-------+-----------------+
+    | 1     | - Called by HDF5                   | | 1     | RECORDER_MPIIO  |
+    |       | - Called by MPI (no HDF5)          | +-------+-----------------+
+    |       |                                    | | 2     | RECORDER_MPI    |
+    +-------+------------------------------------+ +-------+-----------------+
+    | 2     | Called by MPI, which was called by | | 3     | RECORDER_HDF5   |
+    |       | HDF5                               | +-------+-----------------+
+    |       |                                    | | 4     | RECORDER_FTRACE |
+    +-------+------------------------------------+-+-------+-----------------+
+
+.. explicit external hyperlink targets
+
+.. _mailing list: ecp-unifyfs@exascaleproject.org
+.. _Recorder: https://github.com/uiuc-hpc/Recorder
+.. _Recorder README: https://github.com/uiuc-hpc/Recorder/blob/pilgrim/README.md
+.. _VerifyIO: https://github.com/uiuc-hpc/Recorder/tree/pilgrim/tools/verifyio#note-on-the-third-step


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->

**Note:** For easier reviewing, how the rendered version will look can be viewed [here](https://camstan-test-docs-unifycr.readthedocs.io/en/latest/).

Adjust the table of contents layout by moving documentation
containing additional information to the middle Reference section
in order to keep the User Guide less cluttered. Moved the Contributing
section to the bottom.

New documentation:

- Limitation and Workarounds of UnifyFS
- How to Use VerifyIO to Determine Compatibility with UnifyFS

Additional Edits:

- Add a caveat about skipping the header and mount/unmount APIs when
  using the auto-mount feature
- Link to VerifyIO under Semantics section
- Add mochi-margo warning for Thallium/Mochi Suite/SDS Repo users
    - Addresses documentation request from #718
- Place Developer Documentation under new top-level header so it
  appears on the table of contents
- Add reference section on UnifyFS Error Codes
- Minor wording and formatting edits

### Motivation and Context
Documentation for recent milestone as well as some needed edits for upcoming release

### How Has This Been Tested?
Rendered in test documentation repo.
- https://camstan-test-docs-unifycr.readthedocs.io/en/latest/

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] ~~I have added tests to cover my changes.~~
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
