### PR TITLE
Set rpc timeout

### DIFF
--- a/client/src/margo_client.c
+++ b/client/src/margo_client.c
@@ -80,7 +80,7 @@ static void register_client_rpcs(client_rpc_context_t* ctx)
 }
 
 /* initialize margo client-server rpc */
-int unifyfs_client_rpc_init(void)
+int unifyfs_client_rpc_init(double timeout_msecs)
 {
     hg_return_t hret;
 
@@ -115,6 +115,9 @@ int unifyfs_client_rpc_init(void)
         free(svr_addr_string);
         return UNIFYFS_FAILURE;
     }
+
+    /* timeout value to use on rpc operations */
+    ctx->timeout = timeout_msecs;
 
     /* initialize margo */
     int use_progress_thread = 1;
@@ -219,9 +222,11 @@ static hg_handle_t create_handle(hg_id_t id)
     return handle;
 }
 
-static int forward_to_server(hg_handle_t hdl, void* input_ptr)
+static int forward_to_server(
+    hg_handle_t hdl,
+    void* input_ptr,
+    double timeout_msec)
 {
-    double timeout_msec = UNIFYFS_MARGO_CLIENT_SERVER_TIMEOUT_MSEC;
     hg_return_t hret = margo_forward_timed(hdl, input_ptr, timeout_msec);
     if (hret != HG_SUCCESS) {
         LOGERR("margo_forward_timed() failed - %s", HG_Error_to_string(hret));
@@ -251,7 +256,8 @@ int invoke_client_mount_rpc(unifyfs_client* client)
 
     /* call rpc function */
     LOGDBG("invoking the mount rpc function in client");
-    int rc = forward_to_server(handle, &in);
+    double timeout = client_rpc_context->timeout;
+    int rc = forward_to_server(handle, &in, timeout);
     if (rc != UNIFYFS_SUCCESS) {
         LOGERR("forward of mount rpc to server failed");
         margo_destroy(handle);
@@ -333,7 +339,8 @@ int invoke_client_attach_rpc(unifyfs_client* client)
 
     /* call rpc function */
     LOGDBG("invoking the attach rpc function in client");
-    int rc = forward_to_server(handle, &in);
+    double timeout = client_rpc_context->timeout;
+    int rc = forward_to_server(handle, &in, timeout);
     if (rc != UNIFYFS_SUCCESS) {
         LOGERR("forward of attach rpc to server failed");
         margo_destroy(handle);
@@ -380,7 +387,8 @@ int invoke_client_unmount_rpc(unifyfs_client* client)
 
     /* call rpc function */
     LOGDBG("invoking the unmount rpc function in client");
-    int rc = forward_to_server(handle, &in);
+    double timeout = client_rpc_context->timeout;
+    int rc = forward_to_server(handle, &in, timeout);
     if (rc != UNIFYFS_SUCCESS) {
         LOGERR("forward of unmount rpc to server failed");
         margo_destroy(handle);
@@ -439,7 +447,8 @@ int invoke_client_metaset_rpc(unifyfs_client* client,
     /* call rpc function */
     LOGDBG("invoking the metaset rpc function in client - gfid:%d file:%s",
            in.attr.gfid, in.attr.filename);
-    int rc = forward_to_server(handle, &in);
+    double timeout = client_rpc_context->timeout;
+    int rc = forward_to_server(handle, &in, timeout);
     if (rc != UNIFYFS_SUCCESS) {
         LOGERR("forward of metaset rpc to server failed");
         margo_destroy(handle);
@@ -486,7 +495,8 @@ int invoke_client_metaget_rpc(unifyfs_client* client,
 
     /* call rpc function */
     LOGDBG("invoking the metaget rpc function in client");
-    int rc = forward_to_server(handle, &in);
+    double timeout = client_rpc_context->timeout;
+    int rc = forward_to_server(handle, &in, timeout);
     if (rc != UNIFYFS_SUCCESS) {
         LOGERR("forward of metaget rpc to server failed");
         margo_destroy(handle);
@@ -541,7 +551,8 @@ int invoke_client_filesize_rpc(unifyfs_client* client,
 
     /* call rpc function */
     LOGDBG("invoking the filesize rpc function in client");
-    int rc = forward_to_server(handle, &in);
+    double timeout = client_rpc_context->timeout;
+    int rc = forward_to_server(handle, &in, timeout);
     if (rc != UNIFYFS_SUCCESS) {
         LOGERR("forward of filesize rpc to server failed");
         margo_destroy(handle);
@@ -596,7 +607,8 @@ int invoke_client_transfer_rpc(unifyfs_client* client,
 
     /* call rpc function */
     LOGDBG("invoking the transfer rpc function in client");
-    int rc = forward_to_server(handle, &in);
+    double timeout = client_rpc_context->timeout;
+    int rc = forward_to_server(handle, &in, timeout);
     if (rc != UNIFYFS_SUCCESS) {
         LOGERR("forward of transfer rpc to server failed");
         margo_destroy(handle);
@@ -644,7 +656,8 @@ int invoke_client_truncate_rpc(unifyfs_client* client,
 
     /* call rpc function */
     LOGDBG("invoking the truncate rpc function in client");
-    int rc = forward_to_server(handle, &in);
+    double timeout = client_rpc_context->timeout;
+    int rc = forward_to_server(handle, &in, timeout);
     if (rc != UNIFYFS_SUCCESS) {
         LOGERR("forward of truncate rpc to server failed");
         margo_destroy(handle);
@@ -690,7 +703,8 @@ int invoke_client_unlink_rpc(unifyfs_client* client,
 
     /* call rpc function */
     LOGDBG("invoking the unlink rpc function in client");
-    int rc = forward_to_server(handle, &in);
+    double timeout = client_rpc_context->timeout;
+    int rc = forward_to_server(handle, &in, timeout);
     if (rc != UNIFYFS_SUCCESS) {
         LOGERR("forward of unlink rpc to server failed");
         margo_destroy(handle);
@@ -736,7 +750,8 @@ int invoke_client_laminate_rpc(unifyfs_client* client,
 
     /* call rpc function */
     LOGDBG("invoking the laminate rpc function in client");
-    int rc = forward_to_server(handle, &in);
+    double timeout = client_rpc_context->timeout;
+    int rc = forward_to_server(handle, &in, timeout);
     if (rc != UNIFYFS_SUCCESS) {
         LOGERR("forward of laminate rpc to server failed");
         margo_destroy(handle);
@@ -782,7 +797,8 @@ int invoke_client_sync_rpc(unifyfs_client* client,
 
     /* call rpc function */
     LOGINFO("invoking the sync rpc function in client");
-    int rc = forward_to_server(handle, &in);
+    double timeout = client_rpc_context->timeout;
+    int rc = forward_to_server(handle, &in, timeout);
     if (rc != UNIFYFS_SUCCESS) {
         LOGERR("forward of sync rpc to server failed");
         margo_destroy(handle);
@@ -841,7 +857,8 @@ int invoke_client_mread_rpc(unifyfs_client* client,
 
     /* call rpc function */
     LOGDBG("invoking the mread rpc function in client");
-    int rc = forward_to_server(handle, &in);
+    double timeout = client_rpc_context->timeout;
+    int rc = forward_to_server(handle, &in, timeout);
     if (rc != UNIFYFS_SUCCESS) {
         LOGERR("forward of mread rpc to server failed");
         margo_destroy(handle);

--- a/client/src/margo_client.h
+++ b/client/src/margo_client.h
@@ -52,10 +52,11 @@ typedef struct ClientRpcContext {
     hg_addr_t client_addr;
     hg_addr_t svr_addr;
     client_rpcs_t rpcs;
+    double timeout; /* timeout to wait on rpc, in millisecs */
 } client_rpc_context_t;
 
 
-int unifyfs_client_rpc_init(void);
+int unifyfs_client_rpc_init(double timeout_msecs);
 
 int unifyfs_client_rpc_finalize(void);
 

--- a/client/src/unifyfs_api.c
+++ b/client/src/unifyfs_api.c
@@ -171,6 +171,16 @@ unifyfs_rc unifyfs_initialize(const char* mountpoint,
     client->max_write_index_entries =
         client->write_index_size / sizeof(unifyfs_index_t);
 
+    /* Timeout to wait on rpc calls to server, in milliseconds */
+    double timeout_msecs = UNIFYFS_MARGO_CLIENT_SERVER_TIMEOUT_MSEC;
+    cfgval = client_cfg->margo_client_timeout;
+    if (cfgval != NULL) {
+        rc = configurator_int_val(cfgval, &l);
+        if (rc == 0) {
+            timeout_msecs = (double)l;
+        }
+    }
+
     // initialize k-v store access
     int kv_rank = 0;
     int kv_nranks = 1;
@@ -181,7 +191,7 @@ unifyfs_rc unifyfs_initialize(const char* mountpoint,
     }
 
     /* open rpc connection to server */
-    rc = unifyfs_client_rpc_init();
+    rc = unifyfs_client_rpc_init(timeout_msecs);
     if (rc != UNIFYFS_SUCCESS) {
         LOGERR("failed to initialize client RPC");
         return rc;

--- a/common/src/unifyfs_configurator.c
+++ b/common/src/unifyfs_configurator.c
@@ -404,7 +404,8 @@ char* getenv_helper(const char* section,
         ndx += sprintf(envname + ndx, "_%u", mentry);
 
     //fprintf(stderr, "UNIFYFS CONFIG DEBUG: checking env var %s\n", envname);
-    return getenv(envname);
+    char* val = getenv(envname);
+    return val;
 }
 
 

--- a/common/src/unifyfs_configurator.h
+++ b/common/src/unifyfs_configurator.h
@@ -85,8 +85,10 @@
     UNIFYFS_CFG(logio, spill_size, INT, UNIFYFS_LOGIO_SPILL_SIZE, "log-based I/O spillover file size", NULL) \
     UNIFYFS_CFG(logio, spill_dir, STRING, NULLSTRING, "spillover directory", configurator_directory_check) \
     UNIFYFS_CFG(margo, client_pool_size, INT, UNIFYFS_MARGO_POOL_SZ, "size of server's ULT pool for client-server RPCs", NULL) \
+    UNIFYFS_CFG(margo, client_timeout, INT, UNIFYFS_MARGO_CLIENT_SERVER_TIMEOUT_MSEC, "timeout in milliseconds for client-server RPCs", NULL) \
     UNIFYFS_CFG(margo, lazy_connect, BOOL, on, "wait until first communication with server to resolve its connection address", NULL) \
     UNIFYFS_CFG(margo, server_pool_size, INT, UNIFYFS_MARGO_POOL_SZ, "size of server's ULT pool for server-server RPCs", NULL) \
+    UNIFYFS_CFG(margo, server_timeout, INT, UNIFYFS_MARGO_SERVER_SERVER_TIMEOUT_MSEC, "timeout in milliseconds for server-server RPCs", NULL) \
     UNIFYFS_CFG(margo, tcp, BOOL, on, "use TCP for server-to-server margo RPCs", NULL) \
     UNIFYFS_CFG(meta, range_size, INT, UNIFYFS_META_DEFAULT_SLICE_SZ, "metadata range size", NULL) \
     UNIFYFS_CFG_CLI(runstate, dir, STRING, RUNDIR, "runstate file directory", configurator_directory_check, 'R', "specify full path to directory to contain server-local state") \

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -116,11 +116,13 @@ files.
 .. table:: ``[margo]`` section - margo server NA settings
    :widths: auto
 
-   ===  ====  =================================================================================
-   Key  Type  Description
-   ===  ====  =================================================================================
-   tcp  BOOL  Use TCP for server-to-server rpcs (default: on, turn off to enable libfabric RMA)
-   ===  ====  =================================================================================
+   ==============  ====  =================================================================================
+   Key             Type  Description
+   ==============  ====  =================================================================================
+   tcp             BOOL  Use TCP for server-to-server rpcs (default: on, turn off to enable libfabric RMA)
+   client_timeout  INT   timeout in milliseconds for rpcs between client and server (default: 5000)
+   server_timeout  INT   timeout in milliseconds for rpcs between servers (default: 15000)
+   ==============  ====  =================================================================================
 
 .. table:: ``[runstate]`` section - server runstate settings
    :widths: auto

--- a/server/src/margo_server.c
+++ b/server/src/margo_server.c
@@ -30,6 +30,10 @@ bool margo_use_tcp = true;
 bool margo_lazy_connect; // = false
 int  margo_client_server_pool_sz = UNIFYFS_MARGO_POOL_SZ;
 int  margo_server_server_pool_sz = UNIFYFS_MARGO_POOL_SZ;
+double margo_client_server_timeout_msec =
+    UNIFYFS_MARGO_CLIENT_SERVER_TIMEOUT_MSEC;
+double margo_server_server_timeout_msec =
+    UNIFYFS_MARGO_SERVER_SERVER_TIMEOUT_MSEC;
 int  margo_use_progress_thread = 1;
 
 // records pmi rank, server address string, and server address
@@ -657,7 +661,7 @@ static hg_handle_t create_client_handle(hg_id_t id,
 
 static int forward_to_client(hg_handle_t hdl, void* input_ptr)
 {
-    double timeout_msec = UNIFYFS_MARGO_CLIENT_SERVER_TIMEOUT_MSEC;
+    double timeout_msec = margo_client_server_timeout_msec;
     hg_return_t hret = margo_forward_timed(hdl, input_ptr, timeout_msec);
     if (hret != HG_SUCCESS) {
         LOGERR("margo_forward_timed() failed - %s", HG_Error_to_string(hret));

--- a/server/src/margo_server.h
+++ b/server/src/margo_server.h
@@ -70,6 +70,8 @@ extern bool margo_use_tcp;
 extern bool margo_lazy_connect;
 extern int  margo_client_server_pool_sz;
 extern int  margo_server_server_pool_sz;
+extern double margo_client_server_timeout_msec;
+extern double margo_server_server_timeout_msec;
 
 int margo_server_rpc_init(void);
 int margo_server_rpc_finalize(void);

--- a/server/src/unifyfs_group_rpc.c
+++ b/server/src/unifyfs_group_rpc.c
@@ -54,7 +54,7 @@ static int forward_child_request(void* input_ptr,
     int ret = UNIFYFS_SUCCESS;
 
     /* call rpc function */
-    double timeout_ms = UNIFYFS_MARGO_SERVER_SERVER_TIMEOUT_MSEC;
+    double timeout_ms = margo_server_server_timeout_msec;
     hg_return_t hret = margo_iforward_timed(chdl, input_ptr, timeout_ms, creq);
     if (hret != HG_SUCCESS) {
         LOGERR("failed to forward request(%p) - %s", creq,

--- a/server/src/unifyfs_p2p_rpc.c
+++ b/server/src/unifyfs_p2p_rpc.c
@@ -59,7 +59,7 @@ int forward_p2p_request(void* input_ptr,
     int rc = UNIFYFS_SUCCESS;
 
     /* call rpc function */
-    double timeout_ms = UNIFYFS_MARGO_SERVER_SERVER_TIMEOUT_MSEC;
+    double timeout_ms = margo_server_server_timeout_msec;
     hg_return_t hret = margo_iforward_timed(req->handle, input_ptr,
                                             timeout_ms, &(req->request));
     if (hret != HG_SUCCESS) {

--- a/server/src/unifyfs_server.c
+++ b/server/src/unifyfs_server.c
@@ -416,6 +416,16 @@ int main(int argc, char* argv[])
 
     LOGDBG("initializing RPC service");
 
+    rc = configurator_int_val(server_cfg.margo_client_timeout, &l);
+    if (0 == rc) {
+        margo_client_server_timeout_msec = (double) l;
+    }
+
+    rc = configurator_int_val(server_cfg.margo_server_timeout, &l);
+    if (0 == rc) {
+        margo_server_server_timeout_msec = (double) l;
+    }
+
     rc = configurator_int_val(server_cfg.margo_client_pool_size, &l);
     if (0 == rc) {
         margo_client_server_pool_sz = l;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This adds two configurator options to set timeouts for client-server and server-server RPCs.
```
UNIFYFS_MARGO_CLIENT_TIMEOUT
UNIFYFS_MARGO_SERVER_TIMEOUT
```

One use case is to increase these values to some big number when running UnifyFS under a debugger.  Having a config option avoids the need to change the hardcoded value and recompile.

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
