### PR TITLE
Add CXXFLAGS to unifyfs-ls

### DIFF
--- a/util/unifyfs-api-client/src/Makefile.am
+++ b/util/unifyfs-api-client/src/Makefile.am
@@ -16,6 +16,10 @@ api_client_cppflags = \
    -I$(top_srcdir)/client/src \
    -I$(top_srcdir)/common/src
 
+api_client_cxxflags = \
+   $(AM_CXXFLAGS) \
+   -std=c++11
+
 api_client_ldadd   = $(top_builddir)/client/src/libunifyfs_api.la
 api_client_ldflags = $(AM_LDFLAGS) -static
 
@@ -27,6 +31,7 @@ unifyfs_laminate_LDFLAGS  = $(api_client_ldflags)
 unifyfs_laminate_SOURCES  = unifyfs-laminate.c
 
 unifyfs_ls_CPPFLAGS = $(api_client_cppflags)
+unifyfs_ls_CXXFLAGS = $(api_client_cxxflags)
 unifyfs_ls_LDADD    = $(api_client_ldadd)
 unifyfs_ls_LDFLAGS  = $(api_client_ldflags)
 unifyfs_ls_SOURCES  = unifyfs-ls.cpp


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->

Add `-std=c++11` CXXFLAGS to the `unifyfs-ls` target in order to build on GCC v4.9.3.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #738 

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

Built successfully locally with GCC v4.9.3

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] ~~I have updated the documentation accordingly.~~
- [x] I have read the **CONTRIBUTING** document.
- [ ] ~~I have added tests to cover my changes.~~
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
