### PR TITLE
Fixes to enable running on OLCF Crusher/Frontier

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,8 +5,10 @@ CONFIG = ordered
 ACLOCAL_AMFLAGS = -I m4
 
 pkgconfigdir = @pkgconfigdir@
-pkgconfig_DATA = client/unifyfs.pc \
-		 client/unifyfs-api.pc
+pkgconfig_DATA = \
+  client/unifyfs.pc \
+  client/unifyfs-api.pc \
+  client/unifyfs-static.pc
 
 CLEANFILES =
 

--- a/client/src/Makefile.am
+++ b/client/src/Makefile.am
@@ -44,15 +44,13 @@ CLIENT_COMMON_CPPFLAGS = \
 
 CLIENT_COMMON_CFLAGS = \
   $(AM_CFLAGS) \
-  $(UNIFYFS_COMMON_FLAGS) \
-  $(MPI_CFLAGS)
+  $(UNIFYFS_COMMON_FLAGS)
 
 CLIENT_COMMON_LDFLAGS = \
   -version-info $(LIBUNIFYFS_LT_VERSION)
 
 CLIENT_COMMON_LIBADD = \
   $(UNIFYFS_COMMON_LIBS) \
-  $(MPI_CLDFLAGS) \
   -lm -lrt -lcrypto -lpthread
 
 if HAVE_SPATH
@@ -124,8 +122,8 @@ libunifyfs_la_SOURCES  = \
 
 if USE_PMPI_WRAPPERS
 libunifyfs_mpi_la_CPPFLAGS = $(CLIENT_COMMON_CPPFLAGS)
-libunifyfs_mpi_la_CFLAGS   = $(CLIENT_COMMON_CFLAGS)
-libunifyfs_mpi_la_LDFLAGS  = $(CLIENT_COMMON_LDFLAGS)
+libunifyfs_mpi_la_CFLAGS   = $(CLIENT_COMMON_CFLAGS) $(MPI_CFLAGS)
+libunifyfs_mpi_la_LDFLAGS  = $(CLIENT_COMMON_LDFLAGS) $(MPI_CLDFLAGS)
 libunifyfs_mpi_la_LIBADD   = libunifyfs.la
 libunifyfs_mpi_la_SOURCES  = $(PMPI_SRC_FILES)
 endif #USE_PMPI_WRAPPERS
@@ -153,8 +151,8 @@ endif #ENABLE_LD_PRELOAD
 
 if USE_PMPI_WRAPPERS
 libunifyfs_mpi_gotcha_la_CPPFLAGS = $(CLIENT_COMMON_CPPFLAGS)
-libunifyfs_mpi_gotcha_la_CFLAGS   = $(CLIENT_COMMON_CFLAGS)
-libunifyfs_mpi_gotcha_la_LDFLAGS  = $(CLIENT_COMMON_LDFLAGS)
+libunifyfs_mpi_gotcha_la_CFLAGS   = $(CLIENT_COMMON_CFLAGS) $(MPI_CFLAGS)
+libunifyfs_mpi_gotcha_la_LDFLAGS  = $(CLIENT_COMMON_LDFLAGS) $(MPI_CLDFLAGS)
 libunifyfs_mpi_gotcha_la_LIBADD   = libunifyfs_gotcha.la
 libunifyfs_mpi_gotcha_la_SOURCES  = $(PMPI_SRC_FILES)
 endif #USE_PMPI_WRAPPERS

--- a/client/unifyfs-api.pc.in
+++ b/client/unifyfs-api.pc.in
@@ -4,9 +4,8 @@ libdir=@libdir@
 includedir=@includedir@
 
 Name: UnifyFS
-Description: client library for UnifyFS unified burst buffer file system
+Description: API library for UnifyFS unified local storage file system
 Version: @LIBUNIFYFS_API_VERSION@
-Requires:
+Requires.private: margo
 Libs: -L${libdir} -lunifyfs_api
-Cflags: -I${includedir}
-
+Cflags: -I${includedir} -I${includedir}/unifyfs

--- a/client/unifyfs-static.pc.in
+++ b/client/unifyfs-static.pc.in
@@ -6,6 +6,7 @@ includedir=@includedir@
 Name: UnifyFS
 Description: client library for UnifyFS unified local storage file system
 Version: @LIBUNIFYFS_API_VERSION@
-Requires.private: margo
-Libs: -L${libdir} -lunifyfs_gotcha
+Requires: margo
+Libs: @LINK_WRAPPERS@ ${libdir}/libunifyfs.a @SPATH_LIBS@ -lcrypto -lm -lrt -lpthread -lz
 Cflags: -I${includedir} -I${includedir}/unifyfs -D__FILE_OFFSET_BITS=64
+

--- a/configure.ac
+++ b/configure.ac
@@ -380,6 +380,7 @@ AC_CONFIG_FILES([Makefile
                  client/unifyfs-static.pc
                  examples/Makefile
                  examples/src/Makefile
+                 examples/src/Makefile.examples
                  extras/Makefile
                  extras/unifyfs.conf
                  t/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -377,6 +377,7 @@ AC_CONFIG_FILES([Makefile
                  client/src/Makefile
                  client/unifyfs.pc
                  client/unifyfs-api.pc
+                 client/unifyfs-static.pc
                  examples/Makefile
                  examples/src/Makefile
                  extras/Makefile

--- a/examples/src/Makefile.am
+++ b/examples/src/Makefile.am
@@ -1,3 +1,7 @@
+makefiledir = $(datadir)/makefiles
+
+makefile_DATA = Makefile.examples
+
 testutil_headers = \
   testutil.h \
   testutil_rdwr.h
@@ -61,8 +65,9 @@ endif #HAVE_FORTRAN
 
 endif #HAVE_GOTCHA
 
-CLEANFILES = $(libexec_PROGRAMS)
+CLEANFILES = Makefile.examples $(libexec_PROGRAMS)
 
+EXTRA_DIST = Makefile.examples.in
 
 # Common compile/link flag definitions
 

--- a/examples/src/Makefile.examples.in
+++ b/examples/src/Makefile.examples.in
@@ -1,0 +1,62 @@
+UNIFYFS_INSTALL = @prefix@
+
+MPICC ?= mpicc
+
+UNIFYFS_CFG    = $(UNIFYFS_INSTALL)/bin/unifyfs-config
+UNIFYFS_PKGCFG = PKG_CONFIG_PATH=$(PKG_CONFIG_PATH):$(UNIFYFS_INSTALL)/lib/pkgconfig pkg-config
+
+GOTCHA_PROGRAMS = \
+  app-btio-gotcha \
+  app-mpiio-gotcha \
+  app-tileio-gotcha \
+  checkpoint-restart-gotcha \
+  multi-write-gotcha \
+  read-gotcha \
+  read-data-gotcha \
+  simul-gotcha \
+  transfer-gotcha \
+  write-gotcha \
+  writeread-gotcha \
+  write-transfer-gotcha
+
+STATIC_PROGRAMS += \
+  app-btio-static \
+  app-mpiio-static \
+  app-tileio-static \
+  checkpoint-restart-static \
+  multi-write-static \
+  read-static \
+  read-data-static \
+  simul-static \
+  transfer-static \
+  write-static \
+  writeread-static \
+  write-transfer-static
+
+LIBS += -lm -lrt
+
+.PHONY: default all clean gotcha static
+
+default: all
+
+all: gotcha static
+
+clean:
+	$(RM) *.o
+	$(RM) $(GOTCHA_PROGRAMS)
+	$(RM) $(STATIC_PROGRAMS)
+
+gotcha: $(GOTCHA_PROGRAMS)
+
+static: $(STATIC_PROGRAMS)
+
+testutil.o: testutil.c
+	$(MPICC) $(CPPFLAGS) $(CFLAGS) `$(UNIFYFS_PKGCFG) --cflags unifyfs-api` -c -o testutil.o testutil.c
+
+%-gotcha: %.c testutil.o
+	$(MPICC) $(CPPFLAGS) $(CFLAGS) `$(UNIFYFS_PKGCFG) --cflags unifyfs-api` -c -o $<.o $<
+	$(MPICC) -o $@ $<.o testutil.o $(LDFLAGS) `$(UNIFYFS_PKGCFG) --libs unifyfs` $(LIBS)
+
+%-static: %.c testutil.o
+	$(MPICC) $(CPPFLAGS) $(CFLAGS) `$(UNIFYFS_PKGCFG) --cflags unifyfs-static` -c -o $<.o $<
+	$(MPICC) $(LDFLAGS) `$(UNIFYFS_PKGCFG) --libs-only-L unifyfs-static` -o $@ $<.o testutil.o `$(UNIFYFS_PKGCFG) --libs-only-other --libs-only-l unifyfs-static` $(LIBS)

--- a/examples/src/app-mpiio.c
+++ b/examples/src/app-mpiio.c
@@ -12,20 +12,16 @@
  * Please read https://github.com/LLNL/UnifyFS/LICENSE for full license text.
  */
 
-#include <config.h>
 
+#include <getopt.h>
+#include <libgen.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
-#include <errno.h>
-#include <limits.h>
-#include <sys/time.h>
-#include <sys/types.h>
 #include <unistd.h>
-#include <fcntl.h>
-#include <libgen.h>
-#include <getopt.h>
+
 #include <mpi.h>
 #include <unifyfs.h>
 
@@ -189,8 +185,6 @@ static void report_result(void)
                1, MPI_DOUBLE, MPI_MAX, 0, MPI_COMM_WORLD);
 
     min_io_bw = (per_rank_mib * total_ranks) / max_io_time;
-
-    errno = 0;
 
     test_print_once(rank,
                     "\n"

--- a/examples/src/read-data.c
+++ b/examples/src/read-data.c
@@ -17,22 +17,18 @@
  * specifying filename) or non-interactively (specifying filename with offset
  * and length).
  */
-#include <config.h>
 
+#include <errno.h>
+#include <getopt.h>
+#include <libgen.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdint.h>
 #include <string.h>
-#include <errno.h>
-#include <limits.h>
-#include <sys/time.h>
-#include <sys/types.h>
-#include <unistd.h>
-#include <fcntl.h>
-#include <libgen.h>
-#include <getopt.h>
-#include <unifyfs.h>
 #include <time.h>
+#include <unistd.h>
+
+#include <unifyfs.h>
 
 #include "testutil.h"
 
@@ -115,6 +111,7 @@ static void random_offlen(uint64_t filesize, uint64_t maxoff, uint64_t maxlen,
 
 static void do_pread(int fd, size_t length, off_t offset)
 {
+    int err;
     ssize_t ret = 0;
     struct timespec ts1, ts2;
     double ts1nsec, ts2nsec;
@@ -122,11 +119,11 @@ static void do_pread(int fd, size_t length, off_t offset)
 
     alloc_buf(length);
 
-    errno = 0;
-
     clock_gettime(CLOCK_REALTIME, &ts1);
 
+    errno = 0;
     ret = pread(fd, buf, length, offset);
+    err = errno;
 
     clock_gettime(CLOCK_REALTIME, &ts2);
 
@@ -137,8 +134,8 @@ static void do_pread(int fd, size_t length, off_t offset)
     mbps = (1.0 * length / (1<<20)) / elapsed_sec;
 
     printf(" -> pread(off=%lu, len=%lu) = %zd", offset, length, ret);
-    if (errno) {
-        printf("  (err=%d, %s)\n", errno, strerror(errno));
+    if (err) {
+        printf("  (err=%d, %s)\n", err, strerror(err));
     } else {
         printf(" (%.3f sec, %.3lf MB/s)\n", elapsed_sec, mbps);
 

--- a/examples/src/transfer.c
+++ b/examples/src/transfer.c
@@ -12,23 +12,15 @@
  * Please read https://github.com/LLNL/UnifyFS/LICENSE for full license text.
  */
 
-#include <config.h>
 
+#include <getopt.h>
+#include <libgen.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <stdint.h>
 #include <string.h>
-#include <errno.h>
-#include <limits.h>
-#include <sys/time.h>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <unistd.h>
-#include <fcntl.h>
-#include <dirent.h>
-#include <libgen.h>
-#include <getopt.h>
 #include <time.h>
+
+
 #include <mpi.h>
 #include <unifyfs.h>
 
@@ -84,7 +76,6 @@ int main(int argc, char** argv)
     int ret = 0;
     int ch = 0;
     int optidx = 0;
-    struct stat sb = { 0, };
 
     size_t srclen;
     char* srcpath;

--- a/util/unifyfs/src/unifyfs-rm.c
+++ b/util/unifyfs/src/unifyfs-rm.c
@@ -803,7 +803,7 @@ static int generic_stage(char* cmd, int run_argc, unifyfs_args_t* args)
     construct_stage_argv(args, argv + run_argc);
     if (args->debug) {
         for (int i = 0; i < (argc - 1); i++) {
-            fprintf(stdout, "UNIFYFS DEBUG: stage_argv[%d] = %s\n",
+            fprintf(stdout, "UNIFYFS STAGE DEBUG: stage_argv[%d] = %s\n",
                     i, argv[i]);
             fflush(stdout);
         }
@@ -853,6 +853,14 @@ static int jsrun_launch(unifyfs_resource_t* resource,
     argv[11] = strdup(n_cores);
     argv[12] = strdup("-a1");
     construct_server_argv(args, argv + jsrun_argc);
+
+    if (args->debug) {
+        for (int i = 0; i < (argc - 1); i++) {
+            fprintf(stdout, "UNIFYFS LAUNCH DEBUG: jsrun argv[%d] = %s\n",
+                    i, argv[i]);
+            fflush(stdout);
+        }
+    }
 
     execvp(argv[0], argv);
     perror("failed to execvp() jsrun to launch unifyfsd");
@@ -956,6 +964,14 @@ static int mpirun_launch(unifyfs_resource_t* resource,
     argv[4] = strdup("ppr:1:node");
     construct_server_argv(args, argv + mpirun_argc);
 
+    if (args->debug) {
+        for (int i = 0; i < (argc - 1); i++) {
+            fprintf(stdout, "UNIFYFS LAUNCH DEBUG: mpirun argv[%d] = %s\n",
+                    i, argv[i]);
+            fflush(stdout);
+        }
+    }
+
     execvp(argv[0], argv);
     perror("failed to execvp() mpirun to launch unifyfsd");
     return -errno;
@@ -1049,11 +1065,19 @@ static int srun_launch(unifyfs_resource_t* resource,
     argv = calloc(argc, sizeof(char*));
     argv[0] = strdup("srun");
     argv[1] = strdup("--exact");
-    argv[2] = strdup("--overcommit");
+    argv[2] = strdup("--overlap");
     argv[3] = strdup(n_nodes);
     argv[4] = strdup("--ntasks-per-node=1");
     argv[5] = strdup(n_cores);
     construct_server_argv(args, argv + srun_argc);
+
+    if (args->debug) {
+        for (int i = 0; i < (argc - 1); i++) {
+            fprintf(stdout, "UNIFYFS LAUNCH DEBUG: srun argv[%d] = %s\n",
+                    i, argv[i]);
+            fflush(stdout);
+        }
+    }
 
     execvp(argv[0], argv);
     perror("failed to execvp() srun to launch unifyfsd");


### PR DESCRIPTION
### Description

A handful of minor fixes over v1.0 to overcome build and run issues on OLCF Crusher/Frontier:
* Use SLURM `srun --overlap` to run `unifyfsd` on same CPU/socket as an application
* Only link the MPI UnifyFS client libraries against MPI

Also includes a couple of improvements to help users build with Unify:
* Updated `pkg-config` support to properly handle our margo dependency, and added a new `unifyfs-static.pc` for builds that want to use linker wrapping
* A new standalone `Makefile.examples` that can be used to build the example programs from an installed Unify (using the improved pkg-config support). This works around an issue where our MPI wrapper support is broken when linked using the standard build's libtool-based method and Cray PE.

### How Has This Been Tested?

Tested using Unify examples on Crusher with up to 32 processes-per-node.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
