### PR TITLE
unlink: optional sleep after calling client-to-server unlink rpc

### DIFF
--- a/client/src/unifyfs_api.c
+++ b/client/src/unifyfs_api.c
@@ -183,6 +183,18 @@ unifyfs_rc unifyfs_initialize(const char* mountpoint,
     client->max_write_index_entries =
         client->write_index_size / sizeof(unifyfs_index_t);
 
+    /* Number of microsecs to sleep after calling client-to-server unlink rpc.
+     * This is a work around (hack) to try to give the unlink operation time
+     * to complete before the client returns from calling its unlink wrapper. */
+    client->unlink_usecs = 0;
+    cfgval = client_cfg->client_unlink_usecs;
+    if (cfgval != NULL) {
+        rc = configurator_int_val(cfgval, &l);
+        if (rc == 0) {
+            client->unlink_usecs = (int)l;
+        }
+    }
+
     /* Timeout to wait on rpc calls to server, in milliseconds */
     double timeout_msecs = UNIFYFS_MARGO_CLIENT_SERVER_TIMEOUT_MSEC;
     cfgval = client_cfg->margo_client_timeout;

--- a/client/src/unifyfs_api_internal.h
+++ b/client/src/unifyfs_api_internal.h
@@ -78,6 +78,8 @@ typedef struct unifyfs_client {
     size_t write_index_size;         /* size of metadata log */
     size_t max_write_index_entries;  /* max metadata log entries */
 
+    size_t unlink_usecs;             /* micrcosecs to sleep after unlink */
+
     /* tracks current working directory within namespace */
     char* cwd;
 

--- a/client/src/unifyfs_fid.c
+++ b/client/src/unifyfs_fid.c
@@ -12,6 +12,9 @@
  * Please read https://github.com/LLNL/UnifyFS/LICENSE for full license text.
  */
 
+#include <unistd.h>
+#include <stdlib.h>
+
 #include "unifyfs_fid.h"
 #include "margo_client.h"
 
@@ -653,6 +656,13 @@ int unifyfs_fid_unlink(unifyfs_client* client,
     rc = invoke_client_unlink_rpc(client, gfid);
     if (rc != UNIFYFS_SUCCESS) {
         return rc;
+    }
+
+    /* since we can't block until unlink is finished, sleep instead */
+    char* value = getenv("UNIFYFS_UNLINK_USECS");
+    if (value != NULL) {
+        int usecs = atoi(value);
+        usleep(usecs);
     }
 
     return UNIFYFS_SUCCESS;

--- a/client/src/unifyfs_fid.c
+++ b/client/src/unifyfs_fid.c
@@ -12,8 +12,8 @@
  * Please read https://github.com/LLNL/UnifyFS/LICENSE for full license text.
  */
 
+/* for usleep */
 #include <unistd.h>
-#include <stdlib.h>
 
 #include "unifyfs_fid.h"
 #include "margo_client.h"
@@ -659,10 +659,8 @@ int unifyfs_fid_unlink(unifyfs_client* client,
     }
 
     /* since we can't block until unlink is finished, sleep instead */
-    char* value = getenv("UNIFYFS_UNLINK_USECS");
-    if (value != NULL) {
-        int usecs = atoi(value);
-        usleep(usecs);
+    if (client->unlink_usecs > 0) {
+        usleep(client->unlink_usecs);
     }
 
     return UNIFYFS_SUCCESS;

--- a/common/src/unifyfs_configurator.h
+++ b/common/src/unifyfs_configurator.h
@@ -74,9 +74,10 @@
     UNIFYFS_CFG(client, node_local_extents, BOOL, off, \
         "use node-local extents to service node-local reads", NULL) \
     UNIFYFS_CFG(client, max_files, INT, UNIFYFS_CLIENT_MAX_FILES, "client max file count", NULL) \
+    UNIFYFS_CFG(client, super_magic, BOOL, on, "return UnifyFS super magic from statfs, TMPFS otherwise", NULL) \
+    UNIFYFS_CFG(client, unlink_usecs, INT, 0, "number of microsecs to sleep after initiating unlink rpc", NULL) \
     UNIFYFS_CFG(client, write_index_size, INT, UNIFYFS_CLIENT_WRITE_INDEX_SIZE, "write metadata index buffer size", NULL) \
     UNIFYFS_CFG(client, write_sync, BOOL, off, "sync every write to server", NULL) \
-    UNIFYFS_CFG(client, super_magic, BOOL, on, "return UnifyFS super magic from statfs, TMPFS otherwise", NULL) \
     UNIFYFS_CFG_CLI(log, verbosity, INT, 0, "log verbosity level", NULL, 'v', "specify logging verbosity level") \
     UNIFYFS_CFG_CLI(log, file, STRING, unifyfsd.log, "log file name", NULL, 'l', "specify log file name") \
     UNIFYFS_CFG_CLI(log, dir, STRING, LOGDIR, "log file directory", configurator_directory_check, 'L', "specify full path to directory to contain log file") \

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -74,6 +74,7 @@ a given section and key.
    max_files           INT     maximum number of open files per client process (default: 128)
    node_local_extents  BOOL    service reads from node local data for laminated files (default: off)
    super_magic         BOOL    whether to return UNIFYFS (on) or TMPFS (off) statfs magic (default: on)
+   unlink_usecs        INT     number of microseconds to sleep after initiating unlink rpc (default: 0)
    write_index_size    INT     maximum size (B) of memory buffer for storing write log metadata
    write_sync          BOOL    sync data to server after every write (default: off)
    ==================  ======  =================================================================


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In testing PnetCDF, some tests fail when creating a file after deleting a file by the same name (see https://github.com/LLNL/UnifyFS/issues/744).  As a work around, this adds an optional sleep immediately after a client calls the client-to-server unlink rpc to give the unlink operation more time to complete before the client returns from its call to ``unlink()``.

To enable this option, one can set a new config parameter:

```
export UNIFYFS_CLIENT_UNLINK_USECS=1000000
```

For the first test case that was failing, which was a serial program (single-process MPI job), a value of 1000000 (1 second) was sufficient.  Higher sleep times may be required for parallel jobs.

This is a hack, but it helps for now.

A better fix would be to implement a mode where the ``unlink()`` wrapper blocks at the calling client until all servers have indicated that the unlink operation has completed.  That may require a round trip between each server with each of its clients, since each client has to do some work to support unlink.  That change will be a more substantial effort, and so it is saved for future work.  Once added, this particular work around could be removed.

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
