### PR TITLE
CI: have PRs use most recent head branch

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,7 +2,7 @@ name: UnifyFS Build and Test
 
 on:
   pull_request:
-    branches: [ dev ]
+    branches: [ main, dev ]
   push:
 
 jobs:
@@ -37,7 +37,15 @@ jobs:
       CXX: g++-${{ matrix.gcc }}
 
     steps:
-    - uses: actions/checkout@v2
+    - name: Push checkout
+      if: github.event_name == 'push'
+      uses: actions/checkout@v2
+
+    - name: PR checkout
+      if: github.event_name == 'pull_request'
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
 
     - name: Set up GCC
       uses: egor-tensin/setup-gcc@v1


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
By default, GitHub Actions workflows compare the head branch and merge branch as they looked at the time the PR was created. This is an attempt to use the most recent head branch when a pull request workflow is run/rerun in the future.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] ~~I have added tests to cover my changes.~~
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
