### PR TITLE
fix next_page_align unused function compiler error

### DIFF
--- a/client/src/unifyfs.c
+++ b/client/src/unifyfs.c
@@ -202,20 +202,6 @@ static size_t get_superblock_size(unifyfs_client* client)
     return sb_size;
 }
 
-static inline
-char* next_page_align(char* ptr)
-{
-    size_t pgsz = get_page_size();
-    intptr_t orig = (intptr_t) ptr;
-    intptr_t aligned = orig;
-    intptr_t offset = orig % pgsz;
-    if (offset) {
-        aligned += (pgsz - offset);
-    }
-    LOGDBG("orig=0x%p, next-page-aligned=0x%p", ptr, (char*)aligned);
-    return (char*) aligned;
-}
-
 /* initialize our global pointers into the given superblock */
 static void init_superblock_pointers(unifyfs_client* client,
                                      void* superblock)


### PR DESCRIPTION

### Motivation and Context
Cray CCE 14.0.2 (clang-based) treats this as an error, not a warning.

See also #708 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
