### PR TITLE
docs: split ROMIO and HDF5 limits into distinct sections

### DIFF
--- a/docs/limitations.rst
+++ b/docs/limitations.rst
@@ -140,8 +140,8 @@ When using ROMIO, an application having appropriate
 "sync-barrier-sync" constructs as required by the
 MPI standard will run correctly on UnifyFS.
 
-ROMIO Synchronizing Flush
-"""""""""""""""""""""""""
+ROMIO Synchronizing Flush Hint
+""""""""""""""""""""""""""""""
 
 Although ``MPI_File_sync()`` is an MPI collective,
 it is not required to be synchronizing.
@@ -160,8 +160,8 @@ the full sync-barrier-sync construct.
 This hint was added starting with the ROMIO version
 available in the MPICH v4.0 release.
 
-ROMIO Data Visibility
-"""""""""""""""""""""
+ROMIO Data Visibility Hint
+""""""""""""""""""""""""""
 
 Starting with the ROMIO version available in the MPICH v4.1 release,
 a read-only hint was added to inform the caller as to whether

--- a/docs/limitations.rst
+++ b/docs/limitations.rst
@@ -77,7 +77,6 @@ A common approach is for the application to execute a
 .. _sync-barrier-sync-label:
 
 .. code-block:: c
-    :caption: Sync-barrier-sync Construct
 
     MPI_File_sync() //flush newly written bytes from MPI library to file system
     MPI_Barrier()   //ensure all ranks have finished the previous sync

--- a/docs/limitations.rst
+++ b/docs/limitations.rst
@@ -266,6 +266,13 @@ For example::
     MPI_Barrier(...)
     H5Fflush(...)
 
+.. Note::
+
+    If ``MPI_File_sync()`` is a synchronizing collective, as with
+    when enabling the ``romio_synchronizing_flush`` MPI-I/O hint,
+    then a single call to ``H5Fflush()`` suffices to accomplish
+    the sync-barrier-sync construct.
+
 HDF5 FILE_SYNC
 """"""""""""""
 

--- a/docs/limitations.rst
+++ b/docs/limitations.rst
@@ -76,7 +76,7 @@ A common approach is for the application to execute a
 
 .. _sync-barrier-sync-label:
 
-.. code-block:: C
+.. code-block:: c
     :caption: Sync-barrier-sync Construct
 
     MPI_File_sync() //flush newly written bytes from MPI library to file system

--- a/docs/limitations.rst
+++ b/docs/limitations.rst
@@ -36,12 +36,8 @@ with ``close()`` or ``fclose()``.
 UnifyFS can be configured to behave more “POSIX like” by
 flushing newly written data to the server after every write operation.
 To do this, one can set ``UNIFYFS_CLIENT_WRITE_SYNC=ON``.
-
-.. Note::
-
-    ``UNIFYFS_CLIENT_WRITE_SYNC=ON`` can cause a significant
-    decrease in write performance as the amount of file sync operations
-    that are performed will be far more than necessary.
+``UNIFYFS_CLIENT_WRITE_SYNC=ON`` can decrease write performance
+as the number of file sync operations may be more than necessary.
 
 File Locking
 ************
@@ -124,7 +120,7 @@ all ``MPI_File_sync()`` calls required by the MPI standard.
 
     It may be labor intensive to identify and correct all places
     within an application where file synchronization calls are required.
-    The :doc:`VerifyIO <verifyio>` tool can assist with this effort.
+    The :doc:`VerifyIO <verifyio>` tool can assist developers in this effort.
 
 .. TODO: Mention use/need of ``romio_visibility_immediate`` hint once available.
 .. https://github.com/pmodels/mpich/issues/5902
@@ -163,6 +159,20 @@ the full sync-barrier-sync construct.
 
 This hint was added starting with the ROMIO version
 available in the MPICH v4.0 release.
+
+ROMIO Data Visibility
+"""""""""""""""""""""
+
+Starting with the ROMIO version available in the MPICH v4.1 release,
+a read-only hint was added to inform the caller as to whether
+it is necessary to call ``MPI_File_sync`` to manage data consistency.
+
+One can query the ``MPI_Info`` associated with a file.
+If this hint is defined and if its value is ``true``,
+then the underlying file system does not require the sync-barrier-sync
+construct in order for a process to read data written by another process.
+If the value is ``false`` or if the hint is not defined in the ``MPI_Info``
+object, then the sync-barrier-sync constrct is required.
 
 File Locking
 ************
@@ -259,18 +269,18 @@ For example::
 HDF5 FILE_SYNC
 """"""""""""""
 
-HDF5 provides a configuration option that internally calls ``MPI_File_sync()``
+Starting with the HDF5 v1.13.2 release,
+HDF can be configured to call ``MPI_File_sync()``
 after every collective HDF write operation.
-Set the environment variable ``HDF5_DO_MPI_FILE_SYNC=1`` to enable this option.
-This environment variable is available starting with the HDF v1.13.2 release.
+This configuration is enabled automatically if MPI-I/O
+defines the ``romio_visibility_immediate`` hint as ``false``.
+One can enable this option by setting the
+environment variable ``HDF5_DO_MPI_FILE_SYNC=1``.
 
 .. Note::
 
-    This causes a significant decrease in write performance as the amount
-    of file sync operations performed will likely be more than necessary.
-    Similar to but potentially more efficient than the ``WRITE_SYNC``
-    workaround as less overall file syncs may be performed in comparison,
-    but still likely more than needed.
+    Enabling this option can decrease write performance
+    since it may induce more file sync operations than necessary.
 
 .. explicit external hyperlink targets
 

--- a/docs/limitations.rst
+++ b/docs/limitations.rst
@@ -77,6 +77,7 @@ A common approach is for the application to execute a
 .. _sync-barrier-sync-label:
 
 .. code-block:: c
+    :caption: Sync-barrier-sync Construct
 
     MPI_File_sync() //flush newly written bytes from MPI library to file system
     MPI_Barrier()   //ensure all ranks have finished the previous sync

--- a/docs/limitations.rst
+++ b/docs/limitations.rst
@@ -151,9 +151,6 @@ standard and execute a full sync-barrier-sync construct when possible.
 There exists potential optimizations such that
 future implementations of UnifyFS may require the full sequence of calls.
 
-.. TODO: Mention use/need of ``romio_visibility_immediate`` hint once available.
-.. https://github.com/pmodels/mpich/issues/5902
-
 ---------------------------
 ROMIO Limitations
 ---------------------------
@@ -193,15 +190,21 @@ ROMIO Data Visibility Hint
 """"""""""""""""""""""""""
 
 Starting with the ROMIO version available in the MPICH v4.1 release,
-a read-only hint was added to inform the caller as to whether
-it is necessary to call ``MPI_File_sync`` to manage data consistency.
+the read-only hint ``romio_visibility_immediate`` was added to inform
+the caller as to whether it is necessary to call ``MPI_File_sync``
+to manage data consistency.
+
+.. https://github.com/pmodels/mpich/issues/5902
 
 One can query the ``MPI_Info`` associated with a file.
 If this hint is defined and if its value is ``true``,
 then the underlying file system does not require the sync-barrier-sync
 construct in order for a process to read data written by another process.
-If the value is ``false`` or if the hint is not defined in the ``MPI_Info``
-object, then the sync-barrier-sync construct is required.
+Newly written data is visible to other processes as soon as the writer
+process returns from its write call.
+If the value of the hint is ``false``, or if the hint is not defined
+in the ``MPI_Info`` object, then a sync-barrier-sync construct is
+required.
 
 When using UnifyFS, an application must call ``MPI_File_sync()``
 in all situations where the MPI standard requires it.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This updates our "limitations and workarounds" documentation to separate ROMIO and HDF5 into their own subsections.  This also describes how to set ROMIO hints in more detail, and it clarifies some language about ``MPI_File_sync``.

Good chance that I messed up the RST syntax along the way, since I haven't rendered the page to visualize the formatting.

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
