### PR TITLE
Broadcast RPC Infrastructure Changes

### DIFF
--- a/server/src/unifyfs_group_rpc.c
+++ b/server/src/unifyfs_group_rpc.c
@@ -304,8 +304,6 @@ static coll_request* collective_create(server_rpc_e req_type,
                 if (rc != UNIFYFS_SUCCESS) {
                     LOGERR("failed to get child request handle");
                     *chdl = HG_HANDLE_NULL;
-                // TODO: We don't return here.  Why not? Can we really
-                // continue working without a child request handle>
                 }
             }
         }

--- a/server/src/unifyfs_group_rpc.c
+++ b/server/src/unifyfs_group_rpc.c
@@ -247,11 +247,34 @@ static coll_request* collective_create(server_rpc_e req_type,
         coll_req->app_id        = -1;
         coll_req->client_id     = -1;
         coll_req->client_req_id = -1;
+        coll_req->auto_cleanup  =  1;
+        /* Default behavior is for bcast_progress_rpc() to automatically
+         * call collective_cleanup() on the instance.  In cases where such
+         * behavior is incorrect - such as when results need to be returned
+         * from the collective's children - this variable can be changed
+         * before calling bcast_progress_rpc(). */
 
-        int rc = unifyfs_tree_init(glb_pmi_rank, glb_pmi_size, tree_root_rank,
+
+        int rc = ABT_mutex_create(&coll_req->child_resp_valid_mut);
+        if (ABT_SUCCESS != rc) {
+            LOGERR("ABT_mutex_create failed");
+            free(coll_req);
+            return NULL;
+        }
+        rc = ABT_cond_create(&coll_req->child_resp_valid);
+        if (ABT_SUCCESS != rc) {
+            LOGERR("ABT_cond_create failed");
+            ABT_mutex_free(&coll_req->child_resp_valid_mut);
+            free(coll_req);
+            return NULL;
+        }
+
+        rc = unifyfs_tree_init(glb_pmi_rank, glb_pmi_size, tree_root_rank,
                                    UNIFYFS_BCAST_K_ARY, &(coll_req->tree));
         if (rc) {
             LOGERR("unifyfs_tree_init() failed");
+            ABT_mutex_free(&coll_req->child_resp_valid_mut);
+            ABT_cond_free(&coll_req->child_resp_valid);
             free(coll_req);
             return NULL;
         }
@@ -262,6 +285,11 @@ static coll_request* collective_create(server_rpc_e req_type,
             if ((NULL == coll_req->child_hdls) ||
                 (NULL == coll_req->child_reqs)) {
                 LOGERR("allocation of children state failed");
+                free(coll_req->child_hdls);
+                free(coll_req->child_reqs);
+                /* Note: calling free() on NULL is explicitly allowed */
+                ABT_mutex_free(&coll_req->child_resp_valid_mut);
+                ABT_cond_free(&coll_req->child_resp_valid);
                 free(coll_req);
                 return NULL;
             }
@@ -276,6 +304,8 @@ static coll_request* collective_create(server_rpc_e req_type,
                 if (rc != UNIFYFS_SUCCESS) {
                     LOGERR("failed to get child request handle");
                     *chdl = HG_HANDLE_NULL;
+                // TODO: We don't return here.  Why not? Can we really
+                // continue working without a child request handle>
                 }
             }
         }
@@ -337,6 +367,10 @@ void collective_cleanup(coll_request* coll_req)
     if (HG_BULK_NULL != coll_req->bulk_forward) {
         margo_bulk_free(coll_req->bulk_forward);
     }
+
+    /* Release the Argobots mutex and condition variable */
+    ABT_cond_free(&coll_req->child_resp_valid);
+    ABT_mutex_free(&coll_req->child_resp_valid_mut);
 
     /* free allocated memory */
     if (NULL != coll_req->input) {
@@ -449,8 +483,11 @@ int collective_finish(coll_request* coll_req)
         ret = rc;
     }
 
-    if (NULL != coll_req->output) {
-        /* send output back to caller */
+    /* If there's output data AND there's a caller to send it back to,
+     * then send the output back to the caller.  If we're at the root
+     * of the tree, though, there might be output data, but no place
+     * to send it. */
+    if ((NULL != coll_req->output) && (NULL != coll_req->resp_hdl)) {
         hg_return_t hret = margo_respond(coll_req->resp_hdl, coll_req->output);
         if (hret != HG_SUCCESS) {
             LOGERR("margo_respond() failed - %s", HG_Error_to_string(hret));
@@ -459,6 +496,17 @@ int collective_finish(coll_request* coll_req)
         LOGDBG("BCAST_RPC: collective(%p, op=%d) responded",
                coll_req, (int)(coll_req->req_type));
     }
+
+    /* Signal the condition variable in case there are other threads
+     * waiting for the child responses */
+    ABT_mutex_lock(coll_req->child_resp_valid_mut);
+    ABT_cond_signal(coll_req->child_resp_valid);
+    /* There should only be a single thread waiting on the CV, so we don't
+     * need to use ABT_cond_broadcast() */
+    ABT_mutex_unlock(coll_req->child_resp_valid_mut);
+    /* Locking the mutex before signaling is required in order to ensure
+     * that the waiting thread has had a chance to actually call
+     * ABT_cond_wait() before this thread signals the CV. */
 
     return ret;
 }
@@ -535,7 +583,7 @@ static void bcast_progress_rpc(hg_handle_t handle)
         LOGERR("margo_respond() failed - %s", HG_Error_to_string(hret));
     }
 
-    if (NULL != coll) {
+    if ((NULL != coll) && (coll->auto_cleanup)) {
         collective_cleanup(coll);
     }
 

--- a/server/src/unifyfs_group_rpc.h
+++ b/server/src/unifyfs_group_rpc.h
@@ -40,6 +40,20 @@ typedef struct coll_request {
     margo_request  progress_req;
     margo_request* child_reqs;
     hg_handle_t*   child_hdls;
+
+    int            auto_cleanup;  /* if true, bcast_progress_rpc() will
+                                   * call collective_cleanup() on this
+                                   * struct.  This is the default behavior. */
+    ABT_cond       child_resp_valid; /* bcast_progress_rpc() will signal this
+                                      * condition variable when all the child
+                                      * responses have been processed.
+                                      * Intended to provide a mechanism for the
+                                      * server that originated a bcast RPC to
+                                      * wait for all the results to come
+                                      * back. */
+    ABT_mutex      child_resp_valid_mut;
+    /* The mutex associated with the above condition variable. */
+
 } coll_request;
 
 /* set collective output return value to local result value */


### PR DESCRIPTION
This PR makes some basic changes to the `coll_request` struct and its associated functions to allow us to return data from broadcast RPC's. 

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Specific changes to the struct:
1) Adds variable to optionally disable the automatic cleanup of the coll_request struct once the RPC has been completed so that the calling thread has a chance to actually read the returned data
2) Add a condition variable and associated mutex that the progress thread can signal to indicate that the all the child responses have been received.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In order to properly implement an "ls" utility, the server that is local to the 'ls' client needs to fetch file metadata from all the other servers.  This is best handled by a broadcast RPC that all the other servers can respond to.  However, this is the first broadcast RPC that requires recipients to reply with data and current implementation of the `coll_request` and its associated functions don't support this use case.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Existing unit tests pass.  (This doesn't test the new functionality, but it does at least offer some evidence that the changes haven't broken anything.)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [x] All commit messages are properly formatted.
