### PR TITLE
test: fopen existing and truncate on open

### DIFF
--- a/t/std/fopen-fclose.c
+++ b/t/std/fopen-fclose.c
@@ -117,15 +117,15 @@ int fopen_fclose_test(char* unifyfs_root)
        __FILE__, __LINE__, path, strerror(err));
     end_todo;
 
-#if 0
     /* Verify close succeeds. */
+    skip(fd == NULL, 1, "fopen(w) fails with EEXIST on existing files.");
     errno = 0;
     rc = fclose(fd);
     err = errno;
     ok(rc == 0 && err == 0,
        "%s:%d fclose existing file: %s",
        __FILE__, __LINE__, strerror(err));
-#endif
+    end_skip;
 
     return 0;
 }

--- a/t/std/fopen-fclose.c
+++ b/t/std/fopen-fclose.c
@@ -108,13 +108,16 @@ int fopen_fclose_test(char* unifyfs_root)
     diag("Finished UNIFYFS_WRAP(fopen/fclose) tests");
 
     /* Verify we can open an existing file for writing */
+    todo("fopen(w) fails with EEXIST on existing files.");
     errno = 0;
     fd = fopen(path, "w");
     err = errno;
     ok(fd != NULL && err == 0,
        "%s:%d fopen existing file %s w/ mode w: %s",
        __FILE__, __LINE__, path, strerror(err));
+    end_todo;
 
+#if 0
     /* Verify close succeeds. */
     errno = 0;
     rc = fclose(fd);
@@ -122,6 +125,7 @@ int fopen_fclose_test(char* unifyfs_root)
     ok(rc == 0 && err == 0,
        "%s:%d fclose existing file: %s",
        __FILE__, __LINE__, strerror(err));
+#endif
 
     return 0;
 }

--- a/t/std/fopen-fclose.c
+++ b/t/std/fopen-fclose.c
@@ -107,5 +107,21 @@ int fopen_fclose_test(char* unifyfs_root)
 
     diag("Finished UNIFYFS_WRAP(fopen/fclose) tests");
 
+    /* Verify we can open an existing file for writing */
+    errno = 0;
+    fd = fopen(path, "w");
+    err = errno;
+    ok(fd != NULL && err == 0,
+       "%s:%d fopen existing file %s w/ mode w: %s",
+       __FILE__, __LINE__, path, strerror(err));
+
+    /* Verify close succeeds. */
+    errno = 0;
+    rc = fclose(fd);
+    err = errno;
+    ok(rc == 0 && err == 0,
+       "%s:%d fclose existing file: %s",
+       __FILE__, __LINE__, strerror(err));
+
     return 0;
 }

--- a/t/std/size.c
+++ b/t/std/size.c
@@ -176,6 +176,7 @@ int truncate_on_open(char* unifyfs_root)
 
     errno = 0;
 
+    todo("fopen(w) fails with EEXIST on existing file.");
     testutil_rand_path(path, sizeof(path), unifyfs_root);
 
     /* Write "hello world" to a file */
@@ -201,6 +202,7 @@ int truncate_on_open(char* unifyfs_root)
     testutil_get_size(path, &global);
     ok(global == 0, "%s:%d global size after fopen(%s, \"w\") = %d: %s",
        __FILE__, __LINE__, path, global, strerror(errno));
+    end_todo;
 
     diag("Finished truncate on fopen tests");
 

--- a/t/std/size.c
+++ b/t/std/size.c
@@ -176,7 +176,6 @@ int truncate_on_open(char* unifyfs_root)
 
     errno = 0;
 
-    todo("fopen(w) fails with EEXIST on existing file.");
     testutil_rand_path(path, sizeof(path), unifyfs_root);
 
     /* Write "hello world" to a file */
@@ -193,16 +192,19 @@ int truncate_on_open(char* unifyfs_root)
        __FILE__, __LINE__, global, strerror(errno));
 
     /* Opening an existing file for writing with fopen should truncate file */
+    todo("fopen(w) fails with EEXIST on existing file.");
     fp = fopen(path, "w");
     ok(fp != NULL, "%s:%d fopen(%s): %s",
        __FILE__, __LINE__, path, strerror(errno));
+    end_todo;
+    skip(fp == NULL, 2, "enable when fopen(w) EEXIST is fixed.");
     ok(fclose(fp) == 0, "%s:%d fclose(): %s",
        __FILE__, __LINE__, strerror(errno));
 
     testutil_get_size(path, &global);
     ok(global == 0, "%s:%d global size after fopen(%s, \"w\") = %d: %s",
        __FILE__, __LINE__, path, global, strerror(errno));
-    end_todo;
+    end_skip;
 
     diag("Finished truncate on fopen tests");
 

--- a/t/std/size.c
+++ b/t/std/size.c
@@ -165,3 +165,44 @@ int size_test(char* unifyfs_root)
 
     return 0;
 }
+
+int truncate_on_open(char* unifyfs_root)
+{
+    diag("Starting truncate on fopen tests");
+
+    char path[64];
+    FILE* fp = NULL;
+    size_t global;
+
+    errno = 0;
+
+    testutil_rand_path(path, sizeof(path), unifyfs_root);
+
+    /* Write "hello world" to a file */
+    fp = fopen(path, "w");
+    ok(fp != NULL, "%s:%d fopen(%s): %s",
+       __FILE__, __LINE__, path, strerror(errno));
+    ok(fwrite("hello world", 12, 1, fp) == 1,
+       "%s:%d fwrite(\"hello world\": %s", __FILE__, __LINE__, strerror(errno));
+    ok(fclose(fp) == 0, "%s:%d fclose(): %s",
+       __FILE__, __LINE__, strerror(errno));
+
+    testutil_get_size(path, &global);
+    ok(global == 12, "%s:%d global size after fwrite(\"hello world\") = %d: %s",
+       __FILE__, __LINE__, global, strerror(errno));
+
+    /* Opening an existing file for writing with fopen should truncate file */
+    fp = fopen(path, "w");
+    ok(fp != NULL, "%s:%d fopen(%s): %s",
+       __FILE__, __LINE__, path, strerror(errno));
+    ok(fclose(fp) == 0, "%s:%d fclose(): %s",
+       __FILE__, __LINE__, strerror(errno));
+
+    testutil_get_size(path, &global);
+    ok(global == 0, "%s:%d global size after fopen(%s, \"w\") = %d: %s",
+       __FILE__, __LINE__, path, global, strerror(errno));
+
+    diag("Finished truncate on fopen tests");
+
+    return 0;
+}

--- a/t/std/stdio_suite.c
+++ b/t/std/stdio_suite.c
@@ -78,6 +78,7 @@ int main(int argc, char* argv[])
     fflush_test(unifyfs_root);
 
     size_test(unifyfs_root);
+    truncate_on_open(unifyfs_root);
 
     rc = unifyfs_unmount();
     ok(rc == 0, "unifyfs_unmount(%s) (rc=%d)", unifyfs_root, rc);

--- a/t/std/stdio_suite.h
+++ b/t/std/stdio_suite.h
@@ -45,4 +45,7 @@ int fflush_test(char* unifyfs_root);
 /* Tests for UNIFYFS_WRAP(size) */
 int size_test(char* unifyfs_root);
 
+/* Tests for UNIFYFS_WRAP(fopen) truncate */
+int truncate_on_open(char* unifyfs_root);
+
 #endif /* STDIO_SUITE_H */

--- a/t/sys/sysio_suite.c
+++ b/t/sys/sysio_suite.c
@@ -101,6 +101,7 @@ int main(int argc, char* argv[])
     truncate_empty_read(unifyfs_root, 2020);
     truncate_ftrunc_before_sync(unifyfs_root);
     truncate_trunc_before_sync(unifyfs_root);
+    truncate_twice(unifyfs_root);
 
     unlink_test(unifyfs_root);
 

--- a/t/sys/sysio_suite.h
+++ b/t/sys/sysio_suite.h
@@ -67,6 +67,7 @@ int truncate_pattern_size(char* unifyfs_root, int pos);
 int truncate_empty_read(char* unifyfs_root, int pos);
 int truncate_ftrunc_before_sync(char* unifyfs_root);
 int truncate_trunc_before_sync(char* unifyfs_root);
+int truncate_twice(char* unifyfs_root);
 
 /* Test for UNIFYFS_WRAP(unlink) */
 int unlink_test(char* unifyfs_root);


### PR DESCRIPTION
This adds a few test cases related to fixes in https://github.com/LLNL/UnifyFS/pull/746

1) Check that an existing file is truncated with ``open()`` in write mode and ``O_TRUNC``.
2) Check that ``fopen(file, "w")`` succeeds on an existing file.
3) Check that ``fopen(file, "w")`` truncates an existing file to 0 bytes.