### PR TITLE
Update mochi-margo dependency to 0.13.1

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: [ ubuntu-latest ]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 2
 
@@ -39,11 +39,11 @@ jobs:
     steps:
     - name: Push checkout
       if: github.event_name == 'push'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: PR checkout
       if: github.event_name == 'pull_request'
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         ref: ${{ github.event.pull_request.head.sha }}
 
@@ -61,6 +61,8 @@ jobs:
 
     - name: Install Spack
       uses: kzscisoft/install-spack@v1
+      with:
+        version: develop
 
     - name: Set up packages.yaml
       run: |
@@ -80,11 +82,6 @@ jobs:
             externals:
             - spec: "automake@1.16.1"
               prefix: /usr
-          cmake:
-            buildable: False
-            externals:
-            - spec: "cmake@3.22.1"
-              prefix: /usr
           libtool:
             buildable: False
             externals:
@@ -99,6 +96,11 @@ jobs:
             buildable: False
             externals:
             - spec: "openmpi@4.0.3"
+              prefix: /usr
+          openssl:
+            buildable: False
+            externals:
+            - spec: "openssl@1.1.1f"
               prefix: /usr
           pkg-config:
             buildable: False
@@ -118,6 +120,9 @@ jobs:
         else
           spack config add "packages:all:compiler:[gcc@10.3.0]"
         fi
+        spack external find
+        spack config add modules:prefix_inspections:lib64:[LD_LIBRARY_PATH]
+        spack config add modules:prefix_inspections:lib:[LD_LIBRARY_PATH]
 
     - name: Install UnifyFS dependencies
       run: |
@@ -129,6 +134,7 @@ jobs:
 
     - name: Configure and Build
       run: |
+        export PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig
         source $GITHUB_WORKSPACE/.spack/share/spack/setup-env.sh
         spack load gotcha && spack load argobots && spack load mercury && spack load mochi-margo && spack load spath
         ./autogen.sh

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -121,8 +121,8 @@ jobs:
 
     - name: Install UnifyFS dependencies
       run: |
-        spack install gotcha@develop
-        spack install mochi-margo@0.9.6 ^mercury~boostsys ^libfabric@1.12.1 fabrics=rxm,sockets,tcp
+        spack install gotcha@1.0.4
+        spack install mochi-margo@0.13.1 ^mercury~boostsys ^libfabric@1.13.2 fabrics=rxm,sockets,tcp
         spack install spath~mpi
         echo "GOTCHA_INSTALL=$(spack location -i gotcha)" >> $GITHUB_ENV
         echo "SPATH_INSTALL=$(spack location -i spath)" >> $GITHUB_ENV

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -49,15 +49,15 @@ while [ $# -ge 1 ]; do
 done
 
 if [ $use_old_margo -eq 1 ]; then
-    argobots_version="v1.0"
-    libfabric_version="v1.9.1"
-    mercury_version="v1.0.1"
-    margo_version="v0.4.3"
+    argobots_version="v1.1"
+    libfabric_version="v1.13.2"
+    mercury_version="v2.1.0"
+    margo_version="v0.9.6"
 else
     argobots_version="v1.1"
-    libfabric_version="v1.12.1"
-    mercury_version="v2.0.1"
-    margo_version="v0.9.6"
+    libfabric_version="v1.13.2"
+    mercury_version="v2.2.0"
+    margo_version="v0.13.1"
     repos+=(https://github.com/json-c/json-c.git)
 fi
 

--- a/client/src/margo_client.c
+++ b/client/src/margo_client.c
@@ -1025,7 +1025,6 @@ static void unifyfs_mread_req_data_rpc(hg_handle_t handle)
 {
     int ret = UNIFYFS_SUCCESS;
 
-
     /* get input params */
     unifyfs_mread_req_data_in_t in;
     hg_return_t hret = margo_get_input(handle, &in);
@@ -1065,7 +1064,8 @@ static void unifyfs_mread_req_data_rpc(hg_handle_t handle)
                     /* get margo/mercury info to set up bulk transfer */
                     const struct hg_info* hgi = margo_get_info(handle);
                     assert(hgi);
-                    margo_instance_id mid = margo_hg_handle_get_instance(handle);
+                    margo_instance_id mid =
+                        margo_hg_handle_get_instance(handle);
                     assert(mid != MARGO_INSTANCE_NULL);
 
                     /* register user buffer for bulk access */

--- a/client/src/margo_client.c
+++ b/client/src/margo_client.c
@@ -1065,7 +1065,7 @@ static void unifyfs_mread_req_data_rpc(hg_handle_t handle)
                     /* get margo/mercury info to set up bulk transfer */
                     const struct hg_info* hgi = margo_get_info(handle);
                     assert(hgi);
-                    margo_instance_id mid = margo_hg_info_get_instance(hgi);
+                    margo_instance_id mid = margo_hg_handle_get_instance(handle);
                     assert(mid != MARGO_INSTANCE_NULL);
 
                     /* register user buffer for bulk access */

--- a/common/src/Makefile.mk
+++ b/common/src/Makefile.mk
@@ -48,7 +48,7 @@ UNIFYFS_COMMON_BASE_FLAGS = \
   $(MARGO_CFLAGS)
 
 UNIFYFS_COMMON_BASE_LIBS = \
-  $(MARGO_LDFLAGS) $(MARGO_LIBS) \
+  $(MARGO_LDFLAGS) $(MARGO_LIBS) -lmercury_util \
   -lm -lrt -lcrypto -lpthread
 
 UNIFYFS_COMMON_OPT_FLAGS =

--- a/common/src/unifyfs_rpc_util.c
+++ b/common/src/unifyfs_rpc_util.c
@@ -147,7 +147,7 @@ void* pull_margo_bulk_buffer(hg_handle_t rpc_hdl,
     /* get mercury info to set up bulk transfer */
     const struct hg_info* hgi = margo_get_info(rpc_hdl);
     assert(hgi);
-    margo_instance_id mid = margo_hg_info_get_instance(hgi);
+    margo_instance_id mid = margo_hg_handle_get_instance(rpc_hdl);
     assert(mid != MARGO_INSTANCE_NULL);
 
     /* register local target buffer for bulk access */

--- a/docs/build.rst
+++ b/docs/build.rst
@@ -26,7 +26,7 @@ If you use a clone of the Spack develop branch, be sure to pull the latest chang
     versions in the Mochi Suite, SDS Repo, and ``mochi-thallium`` Spack
     packages. It is likely that a different version of ``mochi-margo`` will need
     to be specified in the install command of UnifyFS (E.g.: ``spack install
-    unifyfs ^mochi-margo@0.9.6``).
+    unifyfs ^mochi-margo@0.13.1``).
 
 .. _build-label:
 
@@ -106,7 +106,7 @@ the UnifyFS dependencies can then be installed.
 .. code-block:: Bash
 
     $ spack install gotcha
-    $ spack install mochi-margo@0.9.6 ^libfabric fabrics=rxm,sockets,tcp
+    $ spack install mochi-margo@0.13.1 ^libfabric fabrics=rxm,sockets,tcp
     $ spack install spath~mpi
 
 .. tip::

--- a/docs/dependencies.rst
+++ b/docs/dependencies.rst
@@ -10,10 +10,10 @@ Required
 
 - `GOTCHA <https://github.com/LLNL/GOTCHA/releases>`_ version 1.0.4 (or later)
 
-- `Margo <https://github.com/mochi-hpc/mochi-margo/releases>`_ version 0.9.6 and its dependencies:
+- `Margo <https://github.com/mochi-hpc/mochi-margo/releases>`_ version 0.13.1 and its dependencies:
 
   - `Argobots <https://github.com/pmodels/argobots/releases>`_ version 1.1 (or later)
-  - `Mercury <https://github.com/mercury-hpc/mercury/releases>`_ version 2.0.1 to 2.1
+  - `Mercury <https://github.com/mercury-hpc/mercury/releases>`_ version 2.2.0 (or later)
 
     - `libfabric <https://github.com/ofiwg/libfabric>`_ (avoid versions 1.13 and 1.13.1) or `bmi <https://github.com/radix-io/bmi/>`_
 
@@ -26,7 +26,7 @@ Required
     Margo uses pkg-config to ensure it compiles and links correctly with all of
     its dependencies' libraries. When building manually, you'll need to set the
     ``PKG_CONFIG_PATH`` environment variable to include the paths of the
-    directories containing the ``.pc`` files for Mercury, Argobots, and Margo.
+    directories containing the ``.pc`` files for Margo, Mercury, Argobots, and OpenSSL.
 
 --------
 Optional

--- a/server/src/margo_server.c
+++ b/server/src/margo_server.c
@@ -406,7 +406,6 @@ int margo_server_rpc_init(void)
     }
     if (NULL != mercury_log_level) {
         HG_Set_log_level(mercury_log_level);
-        NA_Set_log_level(mercury_log_level);
     }
     if (NULL != unifyfs_log_stream) {
         hg_log_set_stream_debug(unifyfs_log_stream);

--- a/server/src/unifyfs_service_manager.c
+++ b/server/src/unifyfs_service_manager.c
@@ -906,9 +906,7 @@ static int process_find_extents_rpc(server_rpc_req_t* req)
     hg_bulk_t bulk_resp_handle = HG_BULK_NULL;
     if (ret == UNIFYFS_SUCCESS) {
         if (num_chunks > 0) {
-            const struct hg_info* hgi = margo_get_info(req->handle);
-            assert(hgi);
-            margo_instance_id mid = margo_hg_info_get_instance(hgi);
+            margo_instance_id mid = margo_hg_handle_get_instance(req->handle);
             assert(mid != MARGO_INSTANCE_NULL);
 
             void* buf = (void*) chunk_locs;


### PR DESCRIPTION
### Description

Updates to support using the latest version of mochi-margo, v0.13.1.
Probably also enables building with other versions of mochi-margo back to v0.10, but I did not test those versions.

### Motivation and Context

Gets us the latest and greatest features/fixes for mochi-margo, mercury, and argobots.

### How Has This Been Tested?

Verified I can build and run on both OLCF Summit and Crusher/Frontier. On these systems, spack ended up choosing mercury/2.2.0 and argobots/1.1 as the versions to use for margo's deps.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
