### PR TITLE
Add tests for stat(), lstat() and fstat()

### DIFF
--- a/client/src/unifyfs-sysio.c
+++ b/client/src/unifyfs-sysio.c
@@ -808,6 +808,11 @@ int UNIFYFS_WRAP(fstat)(int fd, struct stat* buf)
     /* check whether we should intercept this file descriptor */
     if (unifyfs_intercept_fd(&fd)) {
         int fid = unifyfs_get_fid_from_fd(fd);
+        /* check if the file is still active (e.g., not closed)*/
+        if (fid == -1) {
+            errno = EBADF;
+            return -1;
+        }
         const char* path = unifyfs_path_from_fid(posix_client, fid);
         int ret = __stat(path, buf);
         return ret;
@@ -892,6 +897,11 @@ int UNIFYFS_WRAP(__fxstat)(int vers, int fd, struct stat* buf)
         }
 
         int fid = unifyfs_get_fid_from_fd(fd);
+        /* check if the file is still active (e.g., not closed) */
+        if (fid == -1) {
+            errno = EBADF;
+            return -1;
+        }
         const char* path = unifyfs_path_from_fid(posix_client, fid);
         int ret = __stat(path, buf);
         return ret;

--- a/t/Makefile.am
+++ b/t/Makefile.am
@@ -134,7 +134,8 @@ test_sysio_sources = \
   sys/write-read-hole.c \
   sys/truncate.c \
   sys/unlink.c \
-  sys/chdir.c
+  sys/chdir.c \
+  sys/stat.c
 
 sys_sysio_gotcha_t_CPPFLAGS = $(test_cppflags)
 sys_sysio_gotcha_t_LDADD    = $(test_gotcha_ldadd)

--- a/t/sharness.d/00-test-env.sh
+++ b/t/sharness.d/00-test-env.sh
@@ -25,8 +25,7 @@ export UNIFYFS_TEST_RUN_SCRIPT=$UNIFYFS_BUILD_DIR/t/test_run_env.sh
 if test -n "$(which jsrun 2>/dev/null)"; then
     JOB_RUN_COMMAND="jsrun -r1 -n1"
 elif test -n "$(which srun 2>/dev/null)"; then
-    #JOB_RUN_COMMAND="srun -n1 -N1 --overlap"
-    JOB_RUN_COMMAND="mpiexec -n 1"
+    JOB_RUN_COMMAND="srun -n1 -N1 --overlap"
 elif test -n "$(which mpirun 2>/dev/null)"; then
     JOB_RUN_COMMAND="mpirun -np 1"
     if [ $UID -eq 0 ]; then

--- a/t/sharness.d/00-test-env.sh
+++ b/t/sharness.d/00-test-env.sh
@@ -25,7 +25,8 @@ export UNIFYFS_TEST_RUN_SCRIPT=$UNIFYFS_BUILD_DIR/t/test_run_env.sh
 if test -n "$(which jsrun 2>/dev/null)"; then
     JOB_RUN_COMMAND="jsrun -r1 -n1"
 elif test -n "$(which srun 2>/dev/null)"; then
-    JOB_RUN_COMMAND="srun -n1 -N1"
+    #JOB_RUN_COMMAND="srun -n1 -N1 --overlap"
+    JOB_RUN_COMMAND="mpiexec -n 1"
 elif test -n "$(which mpirun 2>/dev/null)"; then
     JOB_RUN_COMMAND="mpirun -np 1"
     if [ $UID -eq 0 ]; then

--- a/t/sys/stat.c
+++ b/t/sys/stat.c
@@ -110,7 +110,7 @@ int stat_test(char* unifyfs_root)
     errno = 0;
     rc = fstat(fd, &sb);
     err = errno;
-    ok(rc == -1 && err == ENOENT,
+    ok(rc == -1 && err == EBADF,
        "%s:%d fstat() after unlink fails (errno=%d): %s",
        __FILE__, __LINE__, err, strerror(err));
 

--- a/t/sys/stat.c
+++ b/t/sys/stat.c
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2019, Lawrence Livermore National Security, LLC.
+ * Produced at the Lawrence Livermore National Laboratory.
+ *
+ * Copyright 2018, UT-Battelle, LLC.
+ *
+ * LLNL-CODE-741539
+ * All rights reserved.
+ *
+ * This is the license for UnifyFS.
+ * For details, see https://github.com/LLNL/UnifyFS.
+ * Please read https://github.com/LLNL/UnifyFS/LICENSE for full license text.
+ */
+
+ /*
+  * Test stat, lstat, fstat, __xstat, __lxstst, __fxstat
+  */
+#include <fcntl.h>
+#include <string.h>
+#include <errno.h>
+#include <linux/limits.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include "t/lib/tap.h"
+#include "t/lib/testutil.h"
+
+int stat_test(char* unifyfs_root)
+{
+    diag("Starting UNIFYFS_WRAP(stat) tests");
+
+    char path[64];
+    char dir_path[64];
+    int err, fd, rc;
+    struct stat sb = {0};
+
+    testutil_rand_path(path, sizeof(path), unifyfs_root);
+    testutil_rand_path(dir_path, sizeof(dir_path), unifyfs_root);
+
+    errno = 0;
+    rc = stat(path, &sb);
+    err = errno;
+    ok(rc == -1 && err == ENOENT,
+       "%s:%d stat() non-existent file fails (errno=%d): %s",
+       __FILE__, __LINE__, err, strerror(err));
+
+    errno = 0;
+    rc = lstat(path, &sb);
+    err = errno;
+    ok(rc == -1 && err == ENOENT,
+       "%s:%d lstat() non-existent file fails (errno=%d): %s",
+       __FILE__, __LINE__, err, strerror(err));
+
+    errno = 0;
+    fd = creat(path, 0222);
+    err = errno;
+    ok(fd != -1 && err == 0, "%s:%d creat(%s) (fd=%d): %s",
+       __FILE__, __LINE__, path, fd, strerror(err));
+
+    errno = 0;
+    rc = fsync(fd);
+    err = errno;
+    ok(rc == 0 && err == 0, "%s:%d fsync(): %s",
+       __FILE__, __LINE__, strerror(err));
+
+    errno = 0;
+    rc = close(fd);
+    err = errno;
+    ok(rc == 0 && err == 0, "%s:%d close(): %s",
+       __FILE__, __LINE__, strerror(err));
+
+    errno = 0;
+    rc = stat(path, &sb);
+    err = errno;
+    ok(rc == 0 && err == 0, "%s:%d stat(): %s",
+       __FILE__, __LINE__, strerror(err));
+
+    errno = 0;
+    rc = lstat(path, &sb);
+    err = errno;
+    ok(rc == 0 && err == 0, "%s:%d lstat(): %s",
+       __FILE__, __LINE__, strerror(err));
+
+    /*
+    errno = 0;
+    rc = fstat(fd, &sb);
+    err = errno;
+    ok(rc == 0 && err == 0, "%s:%d fstat(): %s",
+       __FILE__, __LINE__, strerror(err));
+    */
+
+    errno = 0;
+    rc = unlink(path);
+    err = errno;
+    ok(rc == 0 && err == 0,
+       "%s:%d unlink() empty file: %s",
+       __FILE__, __LINE__, strerror(err));
+
+    errno = 0;
+    rc = stat(path, &sb);
+    err = errno;
+    ok(rc == -1 && err == ENOENT,
+       "%s:%d stat() after unlink fails (errno=%d): %s",
+       __FILE__, __LINE__, err, strerror(err));
+
+    errno = 0;
+    rc = lstat(path, &sb);
+    err = errno;
+    ok(rc == -1 && err == ENOENT,
+       "%s:%d lstat() after unlink fails (errno=%d): %s",
+       __FILE__, __LINE__, err, strerror(err));
+
+    /*
+    errno = 0;
+    rc = fstat(fd, &sb);
+    err = errno;
+    ok(rc == -1 && err == ENOENT,
+       "%s:%d fstat() after unlink fails (errno=%d): %s",
+       __FILE__, __LINE__, err, strerror(err));
+    */
+
+    diag("Finished UNIFYFS_WRAP(stat) tests");
+
+    return 0;
+}

--- a/t/sys/stat.c
+++ b/t/sys/stat.c
@@ -83,8 +83,9 @@ int stat_test(char* unifyfs_root)
     errno = 0;
     rc = fstat(fd, &sb);
     err = errno;
-    ok(rc == 0 && err == 0, "%s:%d fstat(): %s",
-       __FILE__, __LINE__, strerror(err));
+    ok(rc == -1 && err == EBADF,
+       "%s:%d fstat() after close fails (errno=%d): %s",
+       __FILE__, __LINE__, err, strerror(err));
 
     errno = 0;
     rc = unlink(path);

--- a/t/sys/stat.c
+++ b/t/sys/stat.c
@@ -13,7 +13,7 @@
  */
 
  /*
-  * Test stat, lstat, fstat, __xstat, __lxstst, __fxstat
+  * Test stat, lstat, and fstat
   */
 #include <fcntl.h>
 #include <string.h>
@@ -80,13 +80,11 @@ int stat_test(char* unifyfs_root)
     ok(rc == 0 && err == 0, "%s:%d lstat(): %s",
        __FILE__, __LINE__, strerror(err));
 
-    /*
     errno = 0;
     rc = fstat(fd, &sb);
     err = errno;
     ok(rc == 0 && err == 0, "%s:%d fstat(): %s",
        __FILE__, __LINE__, strerror(err));
-    */
 
     errno = 0;
     rc = unlink(path);
@@ -109,14 +107,12 @@ int stat_test(char* unifyfs_root)
        "%s:%d lstat() after unlink fails (errno=%d): %s",
        __FILE__, __LINE__, err, strerror(err));
 
-    /*
     errno = 0;
     rc = fstat(fd, &sb);
     err = errno;
     ok(rc == -1 && err == ENOENT,
        "%s:%d fstat() after unlink fails (errno=%d): %s",
        __FILE__, __LINE__, err, strerror(err));
-    */
 
     diag("Finished UNIFYFS_WRAP(stat) tests");
 

--- a/t/sys/sysio_suite.c
+++ b/t/sys/sysio_suite.c
@@ -107,6 +107,8 @@ int main(int argc, char* argv[])
 
     chdir_test(unifyfs_root);
 
+    stat_test(unifyfs_root);
+
     rc = unifyfs_unmount();
     ok(rc == 0, "unifyfs_unmount(%s) (rc=%d)", unifyfs_root, rc);
 

--- a/t/sys/sysio_suite.h
+++ b/t/sys/sysio_suite.h
@@ -74,4 +74,7 @@ int unlink_test(char* unifyfs_root);
 
 int chdir_test(char* unifyfs_root);
 
+/* Test for UNIFYFS_WRAP(stat, lstat, fstat) */
+int stat_test(char* unifyfs_root);
+
 #endif /* SYSIO_SUITE_H */

--- a/t/sys/unlink.c
+++ b/t/sys/unlink.c
@@ -156,7 +156,7 @@ static int unlink_after_sync_laminate_test(char* unifyfs_root)
 
 int unlink_test(char* unifyfs_root)
 {
-    diag("Finished UNIFYFS_WRAP(unlink) tests");
+    diag("Starting UNIFYFS_WRAP(unlink) tests");
 
     char path[64];
     char dir_path[64];


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Add tests for stat(), lstat() and fstat(). The new test actually identified an issue in the current fstat() implementation.
The current implementation does not check properly if the input file descriptor is a valid one.
For example, open --> close --> fstat would cause a seg fault instead of returning an error on the client side. This has been fixed.

Also fixed a typo in the unlink test. 

### Motivation and Context
Currently missing test for stat family calls, including stat(), lstat(), fstat(), _xstat(), _lxstat(), _fxstat() and their 64-bit version calls.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commit messages are properly formatted.
