### PR TITLE
Add C and Fortran wrappers for MPI_Init_thread

### DIFF
--- a/client/src/pmpi_wrappers.c
+++ b/client/src/pmpi_wrappers.c
@@ -21,7 +21,7 @@
 #include "unifyfs.h"
 #include "unifyfs_rc.h"
 
-int unifyfs_mpi_init(int* argc, char*** argv)
+int unifyfs_mpi_init(int* argc, char*** argv, int required, int* provided)
 {
     int rc, ret;
     int rank;
@@ -29,7 +29,7 @@ int unifyfs_mpi_init(int* argc, char*** argv)
 
     //fprintf(stderr, "DEBUG: %s - before PMPI_Init()\n", __func__);
 
-    ret = PMPI_Init(argc, argv);
+    ret = PMPI_Init_thread(argc, argv, required, provided);
 
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
     MPI_Comm_size(MPI_COMM_WORLD, &world_sz);
@@ -53,14 +53,32 @@ int unifyfs_mpi_init(int* argc, char*** argv)
 
 int MPI_Init(int* argc, char*** argv)
 {
-    return unifyfs_mpi_init(argc, argv);
+    int provided;
+    return unifyfs_mpi_init(argc, argv, MPI_THREAD_SINGLE, &provided);
 }
 
 void mpi_init_(MPI_Fint* ierr)
 {
     int argc = 0;
     char** argv = NULL;
-    int rc = unifyfs_mpi_init(&argc, &argv);
+    int provided;
+    int rc = unifyfs_mpi_init(&argc, &argv, MPI_THREAD_SINGLE, &provided);
+
+    if (NULL != ierr) {
+        *ierr = (MPI_Fint)rc;
+    }
+}
+
+int MPI_Init_thread(int* argc, char*** argv, int required, int* provided)
+{
+    return unifyfs_mpi_init(argc, argv, required, provided);
+}
+
+void mpi_init_thread_(int required, int* provided, MPI_Fint* ierr)
+{
+    int argc = 0;
+    char** argv = NULL;
+    int rc = unifyfs_mpi_init(&argc, &argv, required, provided);
 
     if (NULL != ierr) {
         *ierr = (MPI_Fint)rc;

--- a/client/src/pmpi_wrappers.h
+++ b/client/src/pmpi_wrappers.h
@@ -18,9 +18,11 @@
 #include <mpi.h>
 
 /* MPI_Init PMPI wrapper */
-int unifyfs_mpi_init(int* argc, char*** argv);
+int unifyfs_mpi_init(int* argc, char*** argv, int required, int* provided);
 int MPI_Init(int* argc, char*** argv);
+int MPI_Init_thread(int* argc, char*** argv, int required, int* provided);
 void mpi_init_(MPI_Fint* ierr);
+void mpi_init_thread_(int required, int* provided, MPI_Fint* ierr);
 
 /* MPI_Finalize PMPI wrapper */
 int unifyfs_mpi_finalize(void);


### PR DESCRIPTION
### Description
Add C and Fortran wrappers for MPI_Init_thread. Some applications, such as GAMESS and FLASH, use multi-threaded MPI.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)