### PR TITLE
Fix warning about too small buffer in write() call

### DIFF
--- a/t/sys/write-read.c
+++ b/t/sys/write-read.c
@@ -360,8 +360,11 @@ int write_pre_existing_file_test(char* unifyfs_root)
 {
     diag("Starting write-to-pre-existing-file tests");
 
+#define TEST_LEN 300
+#define TEST_LEN_SHORT 100
+/* TEST_LEN_SHORT must be less than TEST_LEN */
     char path[64];
-    char buf[300] = {0};
+    char buf[TEST_LEN] = {0};
     int fd = -1;
     int err, rc;
     size_t global;
@@ -374,13 +377,13 @@ int write_pre_existing_file_test(char* unifyfs_root)
     ok(fd != -1 && err == 0, "%s:%d open(%s) (fd=%d): %s",
        __FILE__, __LINE__, path, fd, strerror(err));
 
-    /* Write 300 bytes to a file */
+    /* Write TEST_LEN bytes to a file */
     errno = 0;
-    rc = (int) write(fd, "a", 300);
+    rc = (int) write(fd, buf, TEST_LEN);
     err = errno;
-    ok(rc == 300 && err == 0,
-       "%s:%d write() a 300 byte file: %s",
-       __FILE__, __LINE__, strerror(err));
+    ok(rc == TEST_LEN && err == 0,
+       "%s:%d write() a %d byte file: %s",
+       __FILE__, __LINE__, TEST_LEN, strerror(err));
 
     errno = 0;
     rc = close(fd);
@@ -388,10 +391,10 @@ int write_pre_existing_file_test(char* unifyfs_root)
     ok(rc == 0 && err == 0, "%s:%d close() worked: %s",
        __FILE__, __LINE__, strerror(err));
 
-    /* Check global size is 300 */
+    /* Check global size is correct */
     testutil_get_size(path, &global);
-    ok(global == 300, "%s:%d global size of 300 byte file is %zu: %s",
-       __FILE__, __LINE__, global, strerror(err));
+    ok(global == TEST_LEN, "%s:%d global size of %d byte file is %zu: %s",
+       __FILE__, __LINE__, TEST_LEN, global, strerror(err));
 
     /* Reopen the same file */
     errno = 0;
@@ -400,13 +403,13 @@ int write_pre_existing_file_test(char* unifyfs_root)
     ok(fd != -1 && err == 0, "%s:%d open(%s) (fd=%d): %s",
        __FILE__, __LINE__, path, fd, strerror(err));
 
-    /* Overwrite the first 100 bytes of same file */
+    /* Overwrite the first part of same file */
     errno = 0;
-    rc = (int) write(fd, buf, 100);
+    rc = (int) write(fd, buf, TEST_LEN_SHORT);
     err = errno;
-    ok(rc == 100 && err == 0,
-       "%s:%d overwrite first 100 bytes of same file: %s",
-       __FILE__, __LINE__, strerror(err));
+    ok(rc == TEST_LEN_SHORT && err == 0,
+       "%s:%d overwrite first %d bytes of same file: %s",
+       __FILE__, __LINE__, TEST_LEN_SHORT, strerror(err));
 
     errno = 0;
     rc = close(fd);
@@ -414,10 +417,10 @@ int write_pre_existing_file_test(char* unifyfs_root)
     ok(rc == 0 && err == 0, "%s:%d close() worked: %s",
        __FILE__, __LINE__, strerror(err));
 
-    /* Check global size is 300 */
+    /* Check global size is still correct */
     testutil_get_size(path, &global);
-    ok(global == 300, "%s:%d global size of 300 byte file is %zu: %s",
-       __FILE__, __LINE__, global, strerror(err));
+    ok(global == TEST_LEN, "%s:%d global size of %d byte file is %zu: %s",
+       __FILE__, __LINE__, TEST_LEN, global, strerror(err));
 
     errno = 0;
     rc = unlink(path);


### PR DESCRIPTION
Fix a warning about a write() call having too small a buffer for the number of bytes it was supposed to write.

Also replaced a pair of literal numbers that were used repeatedly with #defines.

Resolves issue #782

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Simple bug fix:  use the already existing buffer as the source for a `write()` call instead of the too short string literal.

This change adds `#defines` for the test length and for a shorter test length and uses them instead of the integer literals `300` and `100` that are sprinkled throughout the function.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Newer versions of GCC (starting with at least v11.3.0 and possibly earlier) issue a warning because of this bug.  Since the default for UnifyFS is to compile with `-Werror`, that warning aborts the build.  See issue #782.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Re-compile and note that the warning goes away.
Re-run the unit tests and make sure the changed test still passes and all the printed messages look correct.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [x ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
- [x ] All commit messages are properly formatted.
