### PR TITLE
fix: remove potential double free

### DIFF
--- a/server/src/unifyfs_group_rpc.c
+++ b/server/src/unifyfs_group_rpc.c
@@ -262,7 +262,6 @@ static int merge_metaget_all_bcast_outputs(
         LOGERR("margo_bulk_create() failed - %s", HG_Error_to_string(hret));
         p_out->file_meta = parent_old_bulk;
         free(parent_attr_list);
-        free(child_attr_list);
         return UNIFYFS_ERROR_MARGO;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Building with a newer gcc detected this potential variable use after a ``free()``.

We don't need this ``free()`` call at line 265 during error handling since the memory has already been freed just after the ``memcpy()`` at line 247.

https://github.com/LLNL/UnifyFS/blob/ffe0a965e0ba286b839ff622153eb9ee901f6819/server/src/unifyfs_group_rpc.c#L245-L267

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commit messages are properly formatted.
