### PR TITLE
Do not assume file must exist after an open call

### DIFF
--- a/client/src/unifyfs_fid.c
+++ b/client/src/unifyfs_fid.c
@@ -553,15 +553,15 @@ int unifyfs_fid_open(
         }
     }
 
-    /* File should exist at this point,
-     * update our cache with its metadata. */
+    /* Update our cache with its metadata. */
     ret = unifyfs_fid_fetch(client, path);
     if (ret != UNIFYFS_SUCCESS) {
-        /* Failed to get metadata for a file that should exist.
-         * Perhaps it was since deleted.  We could try to create
-         * it again and loop through these steps, but for now
-         * consider this situation to be an error. */
-        LOGERR("Failed to get metadata on existing file %s", path);
+        /* Failed to get metadata.
+         * Perhaps it was opened without O_CREAT or it
+         * was since deleted.  For the latter, we could
+         * try to create it again and loop through these
+         * steps. */
+        LOGDBG("Failed to get metadata on file %s", path);
         return ret;
     }
 


### PR DESCRIPTION
Fix for issue https://github.com/LLNL/UnifyFS/issues/776 :

`unifyfs_fid_open` function assumes the file must exist after the open call, it throughs an error if it's not.
This is not true because a file may be opened without O_CREAT.
Fix: changed LOGERR to LOGDBG and modified some related comments. 


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

