### PR TITLE
Use New MD5 API Function

### DIFF
--- a/common/src/unifyfs_meta.c
+++ b/common/src/unifyfs_meta.c
@@ -12,9 +12,10 @@
  * Please read https://github.com/LLNL/UnifyFS/LICENSE for full license text.
  */
 
+#include <assert.h>
 #include <endian.h>
+#include <openssl/evp.h>
 #include <string.h>
-#include <openssl/md5.h>
 
 #include "unifyfs_meta.h"
 
@@ -39,9 +40,13 @@ uint64_t compute_path_md5(const char* path)
 {
     unsigned long len;
     unsigned char digested[16] = {0};
+    unsigned int digestSize;
+    /* digestSize is set by EVP_Digest().  For MD5 digests, it should always
+     * be 16. */
 
     len = strlen(path);
-    MD5((const unsigned char*) path, len, digested);
+    EVP_Digest(path, len, digested, &digestSize, EVP_md5(), NULL);
+    assert(digestSize == 16);
 
     /* construct uint64_t hash from first 8 digest bytes */
     uint64_t* digest_value = (uint64_t*) digested;

--- a/m4/openssl.m4
+++ b/m4/openssl.m4
@@ -13,6 +13,20 @@ AC_DEFUN([UNIFYFS_AC_OPENSSL], [
      couldn't find a suitable openssl-devel
    ]))])
 
+
+
+
+  AC_CHECK_LIB([crypto], [EVP_Digest],
+    [
+      AM_CONDITIONAL([HAVE_OPENSSL_EVP], [true])
+    ],
+    [
+      AC_MSG_ERROR([couldn't find a sufficiently new OpenSSL installation])
+    ],
+    []
+  )
+
+
   # restore flags
   CFLAGS=$OPENSSL_OLD_CFLAGS
   CXXFLAGS=$OPENSSL_OLD_CXXFLAGS


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Change the OpenSSL MD5 API function from the deprecated `MD5` to the new `EVP_Digest`.  Also added a check for `EVP_Digest` to the configure script.  This PR fixes issue #723.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As of OpenSSL v3, the `MD5` function is deprecated and generates a warning at compile time if it's used.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Ran existing unit tests on an Ubuntu 22.04 system.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
