### PR TITLE
Fortram mpi wrappers have wrong parameter types

### DIFF
--- a/client/src/pmpi_wrappers.c
+++ b/client/src/pmpi_wrappers.c
@@ -74,11 +74,11 @@ int MPI_Init_thread(int* argc, char*** argv, int required, int* provided)
     return unifyfs_mpi_init(argc, argv, required, provided);
 }
 
-void mpi_init_thread_(int required, int* provided, MPI_Fint* ierr)
+void mpi_init_thread_(MPI_Fint* required, MPI_Fint* provided, MPI_Fint* ierr)
 {
     int argc = 0;
     char** argv = NULL;
-    int rc = unifyfs_mpi_init(&argc, &argv, required, provided);
+    int rc = unifyfs_mpi_init(&argc, &argv, *((int*)required), provided);
 
     if (NULL != ierr) {
         *ierr = (MPI_Fint)rc;

--- a/client/src/pmpi_wrappers.h
+++ b/client/src/pmpi_wrappers.h
@@ -22,7 +22,7 @@ int unifyfs_mpi_init(int* argc, char*** argv, int required, int* provided);
 int MPI_Init(int* argc, char*** argv);
 int MPI_Init_thread(int* argc, char*** argv, int required, int* provided);
 void mpi_init_(MPI_Fint* ierr);
-void mpi_init_thread_(int required, int* provided, MPI_Fint* ierr);
+void mpi_init_thread_(MPI_Fint* required, MPI_Fint* provided, MPI_Fint* ierr);
 
 /* MPI_Finalize PMPI wrapper */
 int unifyfs_mpi_finalize(void);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
There's a strange error when running a FLASH5 simulation on Summit:
```bash
*** The MPI_Init_thread() function was called before MPI_INIT was invoked.
*** This is disallowed by the MPI standard.
*** Your MPI job will now abort.
```

The actual issue is not calling MPI_Init_thread before MPI_Init, but caused by the invalid `required` parameter value.
(strange how this irrelevant error message showed up).

### Fix
The previous MPI_Init_thread wrapper has a wrong parameter type for required. Instead of `int required`, it should be `MPI_Fint* required`.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)
