### PR TITLE
Docs: Update to use yaml file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,35 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+formats:
+  - pdf
+  - epub
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+  jobs:
+    post_checkout:
+      # Cancel building pull requests when there aren't changed in the docs directory or YAML file.
+      - |
+        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && git diff --quiet origin/dev -- docs/ .readthedocs.yaml;
+        then
+          exit 183;
+        fi
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: true
+
+# We recommend specifying your dependencies to enable reproducible builds:
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#   install:
+#   - requirements: docs/requirements.txt

--- a/docs/build.rst
+++ b/docs/build.rst
@@ -223,6 +223,7 @@ after ``./autogen.sh`` has been run.
 ----------
 
 .. _configure-options-label:
+
 -----------------
 Configure Options
 -----------------

--- a/docs/wrappers.rst
+++ b/docs/wrappers.rst
@@ -100,7 +100,7 @@ unifyfs_list.txt
 The unifyfs_list.txt_ file specifies the set of wrappers in UnifyFS. Most but
 not all such wrappers are supported. The command to build unifyfs list:
 
-.. code-block::
+.. code-block:: Bash
 
     grep UNIFYFS_WRAP ../src/\*.c > unifyfs_list.txt
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
Read the Docs has moved to a yaml file format that is needed to continue building our docs in the future. This adds that file.

This enables `fail_on_warning` to check for rst syntax errors when building. Builds for pull requests has also been enabled to add a status check to open pull requests. PR builds will be skipped if there are no changes to the docs. These features can easily be disabled if they don't work as desired.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Read the Docs will stop building any documentation not using this format in the near future.

### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
<!--- If your change is a performance enhancement, please provide benchmarks here. -->
Docs were build in a test repo.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [x] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
