### PR TITLE
Add resource manager support for Flux

### DIFF
--- a/common/src/rm_enumerator.h
+++ b/common/src/rm_enumerator.h
@@ -33,6 +33,7 @@
     ENUMITEM(SLURM, "SchedMD SLURM")                                    \
     ENUMITEM(LSF, "IBM Spectrum LSF")                                   \
     ENUMITEM(LSF_CSM, "IBM Spectrum LSF with Cluster System Management") \
+    ENUMITEM(FLUX, "Flux")                                              \
 
 #ifdef __cplusplus
 extern "C" {

--- a/util/unifyfs/src/unifyfs-rm.c
+++ b/util/unifyfs/src/unifyfs-rm.c
@@ -617,6 +617,102 @@ static int slurm_read_resource(unifyfs_resource_t* resource)
     return ret;
 }
 
+/**
+ *
+ * @brief Get list of nodes using Flux resource
+ *
+ * @param resource  The job resource record to be filled
+ *
+ * @return 0 on success, negative errno otherwise
+ */
+static int flux_read_resource(unifyfs_resource_t* resource)
+{
+    size_t n_nodes = 0;
+    char  num_nodes_str[10] = {0};
+    char  nodelist_str[1024] = {0};
+    char* ret = NULL;
+    FILE* pipe_fp = NULL;
+    char** nodes = NULL;
+    int node_idx = 0;
+
+    // get num nodes using flux resource command
+    pipe_fp = popen("flux resource list --states=free -no {nnodes}", "r");
+    ret = fgets(num_nodes_str, sizeof(num_nodes_str), pipe_fp);
+    if (ret == NULL) {
+        pclose(pipe_fp);
+        return -EINVAL;
+    }
+    n_nodes = (size_t) strtoul(num_nodes_str, NULL, sizeof(num_nodes_str));
+    pclose(pipe_fp);
+
+    nodes = calloc(sizeof(char*), n_nodes);
+    if (nodes == NULL) {
+        return -ENOMEM;
+    }
+
+    // get node list using flux resource command
+    // the returned list is in a condensed format
+    // e.g., tioga[18-19,21,32]
+    // TODO: is it safe to assume flux resource only
+    // returns a single line?
+    pipe_fp = popen("flux resource list --states=free -no {nodelist}", "r");
+    ret = fgets(nodelist_str, sizeof(nodelist_str), pipe_fp);
+    if (ret == NULL) {
+        pclose(pipe_fp);
+        return -EINVAL;
+    }
+    pclose(pipe_fp);
+
+    // remove the trailing ']'
+    nodelist_str[strlen(nodelist_str)-1] = 0;
+    // get the node ids, i.e., the list in []
+    char* node_ids = strstr(nodelist_str, "[");
+    if (node_ids) {
+        char* host = calloc(1, (node_ids-nodelist_str)+2);
+        strncpy(host, nodelist_str, (node_ids-nodelist_str));
+
+        // separate by ","
+        char* end_str;
+        char* token = strtok_r(node_ids+1, ",", &end_str);
+        while (token) {
+            // case 1: contiguous node range
+            //         e.g., 3-5, lo=3, hi=5
+            // case 2: a single node, then lo=hi
+            int lo, hi;
+            if (strstr(token, "-")) {
+                char* end_str2;
+                char* lo_str = strtok_r(token, "-", &end_str2);
+                char* hi_str = strtok_r(NULL, "-", &end_str2);
+                lo = atoi(lo_str);
+                hi = atoi(hi_str);
+            } else {
+                lo = atoi(token);
+                hi = lo;
+            }
+
+            for (int i = lo; i <= hi; i++) {
+                char nodename[30] = {0};
+                sprintf(nodename, "%s%d", host, i);
+                if (node_idx >= n_nodes) {
+                    return -EINVAL;
+                }
+                nodes[node_idx++] = strdup(nodename);
+            }
+            token = strtok_r(NULL, ",", &end_str);
+        }
+    } else {
+        // no '[' in the string, meaning it has a single node
+        if (n_nodes != 1) {
+            return -EINVAL;
+        }
+        nodes[0] = strdup(nodelist_str);
+    }
+
+    resource->n_nodes = n_nodes;
+    resource->nodes = nodes;
+    return 0;
+}
+
 // construct_server_argv():
 // This function is called in two ways.
 // Call it once with server_argv==NULL and it
@@ -1144,6 +1240,107 @@ static int srun_stage(unifyfs_resource_t* resource,
 }
 
 /**
+ * @brief Launch servers using Flux
+ *
+ * @param resource The job resource record
+ * @param args     The command-line options
+ *
+ * @return
+ */
+static int flux_launch(unifyfs_resource_t* resource,
+                       unifyfs_args_t* args)
+{
+    size_t argc, flux_argc, server_argc;
+    char** argv = NULL;
+    char n_nodes[16];
+    char n_tasks[16];
+    char n_cores[8];
+
+    snprintf(n_nodes, sizeof(n_nodes), "-N%zu", resource->n_nodes);
+    // without -n, --ntasks, Flux will schedule the server job
+    // to use all nodes exclusively
+    snprintf(n_tasks, sizeof(n_tasks), "-n%zu", resource->n_nodes);
+    snprintf(n_cores, sizeof(n_cores), "-c%d", resource->n_cores_per_server);
+
+    // full command: srun <srun args> <server args>
+    flux_argc = 5;
+    server_argc = construct_server_argv(args, NULL);
+
+    // setup full command argv
+    argc = 1 + flux_argc + server_argc;
+    argv = calloc(argc, sizeof(char*));
+    argv[0] = strdup("flux");
+    argv[1] = strdup("run");
+    argv[2] = strdup(n_nodes);
+    argv[3] = strdup(n_tasks);
+    argv[4] = strdup(n_cores);
+    construct_server_argv(args, argv + flux_argc);
+
+    if (args->debug) {
+        for (int i = 0; i < (argc - 1); i++) {
+            fprintf(stdout, "UNIFYFS LAUNCH DEBUG: flux argv[%d] = %s\n",
+                    i, argv[i]);
+            fflush(stdout);
+        }
+    }
+
+    execvp(argv[0], argv);
+    perror("failed to execvp() flux to launch unifyfsd");
+    return -errno;
+}
+
+/**
+ * @brief Terminate servers using Flux
+ *
+ * @param resource The job resource record
+ * @param args     The command-line options
+ *
+ * @return
+ */
+static int flux_terminate(unifyfs_resource_t* resource,
+                          unifyfs_args_t* args)
+{
+    size_t argc, flux_argc;
+    char** argv = NULL;
+
+    // full command: flux <flux args> pkill name:unifyfsd
+    flux_argc = 3;
+    argc = 1 + flux_argc;
+    argv = calloc(argc, sizeof(char*));
+    argv[0] = strdup("flux");
+    argv[1] = strdup("pkill");
+    argv[2] = strdup("name:unifyfsd");
+
+    execvp(argv[0], argv);
+    perror("failed to execvp() flux to pkill unifyfsd");
+    return -errno;
+}
+
+/**
+ * @brief Launch unifyfs-stage using flux run
+ *
+ * @param resource The job resource record
+ * @param args     The command-line options
+ *
+ * @return
+ */
+static int flux_stage(unifyfs_resource_t* resource,
+                      unifyfs_args_t* args)
+{
+    size_t flux_argc = 5;
+    char cmd[200];
+
+    // full command: flux run <flux args> <server args>
+    snprintf(cmd, sizeof(cmd), "flux run -N%zu -n%zu -c1",
+             resource->n_nodes, resource->n_nodes);
+
+    generic_stage(cmd, flux_argc, args);
+
+    perror("failed to execvp() flux to launch unifyfsd");
+    return -errno;
+}
+
+/**
  * @brief Launch servers using custom script
  *
  * @param resource The job resource record
@@ -1249,6 +1446,13 @@ static _ucr_resource_manager_t resource_managers[] = {
         .terminate = &jsrun_terminate,
         .stage = &jsrun_stage,
     },
+    {
+        .type = "flux",
+        .read_resource = &flux_read_resource,
+        .launch = &flux_launch,
+        .terminate = &flux_terminate,
+        .stage = &flux_stage,
+    },
 };
 
 int unifyfs_detect_resources(unifyfs_resource_t* resource)
@@ -1257,6 +1461,11 @@ int unifyfs_detect_resources(unifyfs_resource_t* resource)
         resource->rm = UNIFYFS_RM_PBS;
     } else if (getenv("SLURM_JOBID") != NULL) {
         resource->rm = UNIFYFS_RM_SLURM;
+    } else if (getenv("FLUX_EXEC_PATH") != NULL) {
+        // TODO: need to use a better environment
+        // variable or maybe a better way to decide
+        // whether to use flux scheduler.
+        resource->rm = UNIFYFS_RM_FLUX;
     } else if (getenv("LSB_JOBID") != NULL) {
         if (getenv("CSM_ALLOCATION_ID") != NULL) {
             resource->rm = UNIFYFS_RM_LSF_CSM;

--- a/util/unifyfs/src/unifyfs-rm.c
+++ b/util/unifyfs/src/unifyfs-rm.c
@@ -663,11 +663,11 @@ static int flux_read_resource(unifyfs_resource_t* resource)
     }
     pclose(pipe_fp);
 
-    // remove the trailing ']'
-    nodelist_str[strlen(nodelist_str)-1] = 0;
     // get the node ids, i.e., the list in []
     char* node_ids = strstr(nodelist_str, "[");
     if (node_ids) {
+        // remove the trailing "]\n"
+        nodelist_str[strlen(nodelist_str)-2] = 0;
         char* host = calloc(1, (node_ids-nodelist_str)+2);
         strncpy(host, nodelist_str, (node_ids-nodelist_str));
 


### PR DESCRIPTION
### Description

Tioga uses Flux to schedule jobs and has limited support for srun. Also Tioga does not have the `scontrol` command, which we use to retrieve the allocated node list.

This PR includes native support for Flux. It uses `flux run` to run clients and servers and uses `flux resource` to retrieve the number of nodes and the node list.
PS: `flux resource` returns a condensed node list, e.g., tioga[3-10, 12, 14]. The existing `parse_hostfile()` function can't handle this format, I added some code to parse it manually.

### How Has This Been Tested?

Tested on Tioga with 1, 2, 4 nodes. Also tested `unifyfs-ls`, `unifyfs-stage` and stage-in/out features.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.

### TODO

Unlike slurm where `SLURM_JOBID` can be used to determine a slurm allocation, flux only sets environment variables such as `FLUX_JOB_ID` for each `flux run` job (a flux job is similar to a slurm step). At the time of executing `unifyfs` (batch level), those variables have not been set yet.

A short flux script example: 
```bash
#!/bin/bash
# flux: -N4 -n256 -t 5m
# flux: --job-name="UnifyFS"
# flux: --queue="pdebug"

export UNIFYFS_LOGIO_SPILL_DIR=/tmp
export UNIFYFS_LOG_DIR=`pwd`
export UNIFYFS_LOG_VERBOSITY=3
export UNIFYFS_MOUNTPOINT=/unifyfs

# Here FLUX_JOB_ID are FLUX_JOB_NNODES are not set

unifyfs start -d --stage-in=`pwd`/manifest-in.txt --share-dir=`pwd`
flux run -n128 -N4 -c1 $UNIFYFS_DIR/libexec/write-static -m /unifyfs -f myTestFile
flux run -n128 -N4 -c1 $UNIFYFS_DIR/libexec/write-gotcha -f workflowTestFile
flux run -n128 -N4 -c1 $UNIFYFS_DIR/libexec/read-gotcha  -f workflowTestFile
flux run -n16 -N4 -c1 unifyfs-stage --parallel --status-file=/tmp/stage-out-status.txt `pwd`/manifest-out.txt 
unifyfs-ls 
unifyfs terminate --cleanup

```

***As a result, currently I use `FLUX_EXEC_PATH` to determine if the system has flux scheduler. I feel this is not optimal but I couldn't figure out a better way.***
