### PR TITLE
rework server bootstrap completion

### DIFF
--- a/client/src/margo_client.c
+++ b/client/src/margo_client.c
@@ -224,14 +224,14 @@ static hg_handle_t create_handle(hg_id_t id)
     return handle;
 }
 
-static int forward_to_server(
-    hg_handle_t hdl,
-    void* input_ptr,
-    double timeout_msec)
+static int forward_to_server(hg_handle_t hdl,
+                             void* input_ptr,
+                             double timeout_msec)
 {
     hg_return_t hret = margo_forward_timed(hdl, input_ptr, timeout_msec);
     if (hret != HG_SUCCESS) {
         LOGERR("margo_forward_timed() failed - %s", HG_Error_to_string(hret));
+        //margo_state_dump(client_rpc_context->mid, "-", 0, NULL);
         return UNIFYFS_ERROR_MARGO;
     }
     return UNIFYFS_SUCCESS;

--- a/common/src/unifyfs_server_rpcs.h
+++ b/common/src/unifyfs_server_rpcs.h
@@ -42,9 +42,9 @@ typedef enum {
     UNIFYFS_SERVER_RPC_LAMINATE,
     UNIFYFS_SERVER_RPC_METAGET,
     UNIFYFS_SERVER_RPC_METASET,
-    UNIFYFS_SERVER_RPC_PID_REPORT,
     UNIFYFS_SERVER_RPC_TRANSFER,
     UNIFYFS_SERVER_RPC_TRUNCATE,
+    UNIFYFS_SERVER_BCAST_RPC_BOOTSTRAP,
     UNIFYFS_SERVER_BCAST_RPC_EXTENTS,
     UNIFYFS_SERVER_BCAST_RPC_FILEATTR,
     UNIFYFS_SERVER_BCAST_RPC_LAMINATE,
@@ -185,6 +185,13 @@ MERCURY_GEN_PROC(bcast_progress_in_t,
 MERCURY_GEN_PROC(bcast_progress_out_t,
                  ((int32_t)(ret)))
 DECLARE_MARGO_RPC_HANDLER(bcast_progress_rpc)
+
+/* Broadcast 'bootstrap complete' to all servers */
+MERCURY_GEN_PROC(bootstrap_complete_bcast_in_t,
+                 ((int32_t)(root)))
+MERCURY_GEN_PROC(bootstrap_complete_bcast_out_t,
+                 ((int32_t)(ret)))
+DECLARE_MARGO_RPC_HANDLER(bootstrap_complete_bcast_rpc)
 
 /* Broadcast file extents to all servers */
 MERCURY_GEN_PROC(extent_bcast_in_t,

--- a/server/src/margo_server.c
+++ b/server/src/margo_server.c
@@ -155,6 +155,12 @@ static void register_server_server_rpcs(margo_instance_id mid)
                        bcast_progress_in_t, bcast_progress_out_t,
                        bcast_progress_rpc);
 
+    unifyfsd_rpc_context->rpcs.bootstrap_complete_bcast_id =
+        MARGO_REGISTER(mid, "bootstrap_complete_bcast_rpc",
+                       bootstrap_complete_bcast_in_t,
+                       bootstrap_complete_bcast_out_t,
+                       bootstrap_complete_bcast_rpc);
+
     unifyfsd_rpc_context->rpcs.chunk_read_request_id =
         MARGO_REGISTER(mid, "chunk_read_request_rpc",
                        chunk_read_request_in_t, chunk_read_request_out_t,
@@ -534,7 +540,7 @@ int margo_connect_servers(void)
 
     /* allocate array of structs to record address for each server */
     server_infos = (server_info_t*) calloc(glb_num_servers,
-        sizeof(server_info_t));
+                                           sizeof(server_info_t));
     if (NULL == server_infos) {
         LOGERR("failed to allocate server_info array");
         return ENOMEM;

--- a/server/src/margo_server.h
+++ b/server/src/margo_server.h
@@ -32,6 +32,7 @@
 typedef struct ServerRpcIds {
     /* server-server rpcs */
     hg_id_t bcast_progress_id;
+    hg_id_t bootstrap_complete_bcast_id;
     hg_id_t chunk_read_request_id;
     hg_id_t chunk_read_response_id;
     hg_id_t extent_add_id;

--- a/server/src/unifyfs_global.h
+++ b/server/src/unifyfs_global.h
@@ -208,8 +208,12 @@ bool check_pending_metaget(int gfid);
 unifyfs_rc clear_pending_metaget(int gfid);
 
 
-/* publish the pids of all servers to a shared file */
-int unifyfs_publish_server_pids(void);
+
+/* notify local server main thread that bootstrap is complete */
+int unifyfs_signal_bootstrap_complete(void);
+
+/* participate in collective server bootstrap completion process */
+int unifyfs_complete_bootstrap(void);
 
 /* report the pid for a server with given rank */
 int unifyfs_report_server_pid(int rank, int pid);

--- a/server/src/unifyfs_p2p_rpc.h
+++ b/server/src/unifyfs_p2p_rpc.h
@@ -35,8 +35,8 @@ typedef struct {
 
 /* helper method to initialize peer request rpc handle */
 int init_p2p_request_handle(hg_id_t request_hgid,
-                           int peer_rank,
-                           p2p_request* req);
+                            int peer_rank,
+                            p2p_request* req);
 
 /* helper method to forward peer rpc request */
 int forward_p2p_request(void* input_ptr,

--- a/server/src/unifyfs_server.c
+++ b/server/src/unifyfs_server.c
@@ -478,10 +478,10 @@ int main(int argc, char* argv[])
     /* initialize our tree that maps a gfid to its extent tree */
     unifyfs_inode_tree_init(global_inode_tree);
 
-    LOGDBG("publishing server pid");
-    rc = unifyfs_publish_server_pids();
+    LOGDBG("waiting for server bootstrapping to complete");
+    rc = unifyfs_complete_bootstrap();
     if (rc != 0) {
-        LOGERR("failed to publish server pid file: %s",
+        LOGERR("failed to complete server bootstrapping: %s",
                unifyfs_rc_enum_description(rc));
         exit(1);
     }

--- a/server/src/unifyfs_server_pid.c
+++ b/server/src/unifyfs_server_pid.c
@@ -26,30 +26,17 @@
 
 extern unifyfs_cfg_t server_cfg;
 
-static int n_servers_reported; // = 0
+static volatile int n_servers_reported; // = 0
+static volatile int bootstrap_completed; // = 0
 static int* server_pids; // = NULL
-static pthread_cond_t server_pid_cond = PTHREAD_COND_INITIALIZER;
-static pthread_mutex_t server_pid_mutex = PTHREAD_MUTEX_INITIALIZER;
-static struct timespec server_pid_timeout;
+static ABT_cond server_bootstrap_cond = ABT_COND_NULL;
+static ABT_mutex server_bootstrap_mutex = ABT_MUTEX_NULL;
+static struct timespec server_bootstrap_timeout;
 
-static int alloc_server_pids(void)
-{
-    int ret = 0;
-    pthread_mutex_lock(&server_pid_mutex);
-    if (NULL == server_pids) {
-        server_pids = (int*) calloc(glb_pmi_size, sizeof(int));
-        if (NULL == server_pids) {
-            LOGERR("failed to allocate memory (%s)", strerror(errno));
-            ret = ENOMEM;
-        }
-    }
-    pthread_mutex_unlock(&server_pid_mutex);
-    return ret;
-}
 
-static inline int set_pidfile_timeout(void)
+static inline int set_bootstrap_timeout(void)
 {
-    int ret = 0;
+    int ret = UNIFYFS_SUCCESS;
     long timeout_sec = 0;
 
     if (server_cfg.server_init_timeout) {
@@ -61,16 +48,82 @@ static inline int set_pidfile_timeout(void)
         }
     }
 
-    clock_gettime(CLOCK_REALTIME, &server_pid_timeout);
-    server_pid_timeout.tv_sec += timeout_sec;
+    clock_gettime(CLOCK_REALTIME, &server_bootstrap_timeout);
+    server_bootstrap_timeout.tv_sec += timeout_sec;
 
-    return 0;
+    return ret;
+}
+
+static void free_bootstrap_state(void)
+{
+    if (ABT_MUTEX_NULL != server_bootstrap_mutex) {
+        ABT_mutex_lock(server_bootstrap_mutex);
+        if (ABT_COND_NULL != server_bootstrap_cond) {
+            ABT_cond_free(&server_bootstrap_cond);
+            server_bootstrap_cond = ABT_COND_NULL;
+        }
+        ABT_mutex_unlock(server_bootstrap_mutex);
+        ABT_mutex_free(&server_bootstrap_mutex);
+        server_bootstrap_mutex = ABT_MUTEX_NULL;
+    }
+
+    if (NULL != server_pids) {
+        free(server_pids);
+        server_pids = NULL;
+    }
+}
+
+static int initialize_bootstrap_state(void)
+{
+    int rc;
+    int ret = UNIFYFS_SUCCESS;
+
+    if (ABT_MUTEX_NULL == server_bootstrap_mutex) {
+        rc = ABT_mutex_create(&server_bootstrap_mutex);
+        if (ABT_SUCCESS != rc) {
+            LOGERR("ABT_mutex_create failed");
+            return UNIFYFS_ERROR_MARGO;
+        }
+    }
+
+    ABT_mutex_lock(server_bootstrap_mutex);
+    if (ABT_COND_NULL == server_bootstrap_cond) {
+        rc = ABT_cond_create(&server_bootstrap_cond);
+        if (ABT_SUCCESS != rc) {
+            LOGERR("ABT_cond_create failed");
+            ret = UNIFYFS_ERROR_MARGO;
+        }
+    }
+
+    if (UNIFYFS_SUCCESS == ret) {
+        ret = set_bootstrap_timeout();
+    }
+
+    if ((UNIFYFS_SUCCESS == ret) && (0 == glb_pmi_rank)) {
+        if (NULL == server_pids) {
+            server_pids = (int*) calloc(glb_pmi_size, sizeof(int));
+            if (NULL == server_pids) {
+                LOGERR("failed to allocate memory for pid array (%s)",
+                    strerror(errno));
+                ret = ENOMEM;
+            }
+        }
+    }
+
+    ABT_mutex_unlock(server_bootstrap_mutex);
+
+    if (ret != UNIFYFS_SUCCESS) {
+        LOGERR("failed to initialize bootstrap state!");
+        free_bootstrap_state();
+    }
+
+    return ret;
 }
 
 static int create_server_pid_file(void)
 {
     int i = 0;
-    int ret = 0;
+    int ret = UNIFYFS_SUCCESS;
     char filename[UNIFYFS_MAX_FILENAME] = { 0, };
     FILE* fp = NULL;
 
@@ -99,80 +152,117 @@ static int create_server_pid_file(void)
 
 int unifyfs_report_server_pid(int rank, int pid)
 {
-    assert(rank < glb_pmi_size);
+    assert((glb_pmi_rank == 0) && (rank < glb_pmi_size));
 
-    int ret = alloc_server_pids();
-    if (ret) {
-        LOGERR("failed to allocate pid array");
-        return ret;
+    /* NOTE: need this here in case we receive a pid report rpc before we
+     *       have initialized state in unifyfs_complete_bootstrap() */
+    int rc = initialize_bootstrap_state();
+    if (rc) {
+        LOGERR("failed to initialize bootstrap state");
+        return rc;
     }
 
-    pthread_mutex_lock(&server_pid_mutex);
+    ABT_mutex_lock(server_bootstrap_mutex);
     n_servers_reported++;
     server_pids[rank] = pid;
-    pthread_cond_signal(&server_pid_cond);
-    pthread_mutex_unlock(&server_pid_mutex);
+    ABT_cond_signal(server_bootstrap_cond);
+    ABT_mutex_unlock(server_bootstrap_mutex);
 
     return UNIFYFS_SUCCESS;
 }
 
-int unifyfs_publish_server_pids(void)
+int unifyfs_signal_bootstrap_complete(void)
+{
+    assert(glb_pmi_rank != 0);
+
+    ABT_mutex_lock(server_bootstrap_mutex);
+    bootstrap_completed = 1;
+    ABT_cond_signal(server_bootstrap_cond);
+    ABT_mutex_unlock(server_bootstrap_mutex);
+
+    return UNIFYFS_SUCCESS;
+}
+
+static int wait_for_bootstrap_condition(void)
+{
+    int ret = UNIFYFS_SUCCESS;
+    int rc = ABT_cond_timedwait(server_bootstrap_cond, server_bootstrap_mutex,
+                                &server_bootstrap_timeout);
+    if (ABT_ERR_COND_TIMEDOUT == rc) {
+        LOGERR("server initialization timeout");
+        ret = UNIFYFS_ERROR_TIMEOUT;
+    } else if (rc) {
+        LOGERR("failed to wait on condition (err=%d)", rc);
+        ret = UNIFYFS_ERROR_MARGO;
+    }
+    return ret;
+}
+
+int unifyfs_complete_bootstrap(void)
 {
     int ret = UNIFYFS_SUCCESS;
 
+    int rc = initialize_bootstrap_state();
+    if (UNIFYFS_SUCCESS != rc) {
+        LOGERR("ABT_mutex_create failed");
+        return UNIFYFS_ERROR_MARGO;
+    }
+
     if (glb_pmi_rank > 0) {
-        /* publish my pid to server 0 */
+        /* publish my pid to server rank 0 */
+        LOGDBG("server[%d] - reporting pid", glb_pmi_rank);
         ret = unifyfs_invoke_server_pid_rpc();
         if (ret) {
             LOGERR("failed to invoke pid rpc (%s)", strerror(ret));
+        } else {
+             /* wait for "bootstrap-complete" broadcast from server rank 0 */
+            ABT_mutex_lock(server_bootstrap_mutex);
+            while (!bootstrap_completed) {
+                ret = wait_for_bootstrap_condition();
+                if (UNIFYFS_ERROR_TIMEOUT == ret) {
+                    break;
+                }
+            }
+            ABT_mutex_unlock(server_bootstrap_mutex);
+            if (bootstrap_completed) {
+                LOGDBG("server[%d] - bootstrap completed", glb_pmi_rank);
+            }
         }
-    } else { /* rank 0 acts as coordinator */
-        ret = alloc_server_pids();
-        if (ret) {
-            return ret;
-        }
-
-        ret = set_pidfile_timeout();
-        if (ret) {
-            return ret;
-        }
-
-        pthread_mutex_lock(&server_pid_mutex);
-        server_pids[0] = server_pid;
-        n_servers_reported++;
+    } else { /* server rank 0 acts as coordinator */
 
         /* keep checking count of reported servers until all have reported
          * or we hit the timeout */
+        ABT_mutex_lock(server_bootstrap_mutex);
+        server_pids[0] = server_pid;
+        n_servers_reported++;
         while (n_servers_reported < glb_pmi_size) {
-            ret = pthread_cond_timedwait(&server_pid_cond,
-                                         &server_pid_mutex,
-                                         &server_pid_timeout);
-            if (ETIMEDOUT == ret) {
-                LOGERR("server initialization timeout");
-                break;
-            } else if (ret) {
-                LOGERR("failed to wait on condition (err=%d, %s)",
-                       errno, strerror(errno));
+            ret = wait_for_bootstrap_condition();
+            if (UNIFYFS_ERROR_TIMEOUT == ret) {
                 break;
             }
         }
+        ABT_mutex_unlock(server_bootstrap_mutex);
 
         if (n_servers_reported == glb_pmi_size) {
-            ret = create_server_pid_file();
+            bootstrap_completed = 1;
+            LOGDBG("server[%d] - bootstrap completed", glb_pmi_rank);
+            ret = unifyfs_invoke_broadcast_bootstrap_complete();
             if (UNIFYFS_SUCCESS == ret) {
                 LOGDBG("servers ready to accept client connections");
+                ret = create_server_pid_file();
+                if (UNIFYFS_SUCCESS != ret) {
+                    LOGERR("pid file creation failed!");
+                }
+            } else {
+                LOGERR("bootstrap broadcast failed!");
             }
         } else {
             LOGERR("%d of %d servers reported their pids",
                    n_servers_reported, glb_pmi_size);
         }
-
-        free(server_pids);
-        server_pids = NULL;
-
-        pthread_mutex_unlock(&server_pid_mutex);
     }
+
+    free_bootstrap_state();
 
     return ret;
 }
-


### PR DESCRIPTION
### Description

* replace server pids pthread mutex/cond with ABT versions
* add `margo_state_dump()` on client-server or server-server failures (currently commented out)
* add a 'bootstrap complete' broadcast rpc after rank 0 sees all servers have reported
* fix function declaration for `unifyfs_invoke_broadcast_extents()`

### Motivation and Context

Flash-X on OLCF Summit was consistently failing to bootstrap at 12 nodes. Some of the servers were ready for client connections while others were still in the bootstrap phase.

Previously, servers assumed a successful "server bootstrap" phase when they received a response to the RPC used to report their pid to rank 0. These changes ensure that every server reaches consensus on bootstrap completion before we generate the unifyfs_server.pids file that is used by the command-line utility to report success in a user job.

### How Has This Been Tested?

Tested on OLCF Summit. Getting to a working config required use of margo 0.13.1, mercury 2.2, argobots 1.1, and libfabric 1.14.1

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Performance enhancement (non-breaking change which improves efficiency)
- [ ] Code cleanup (non-breaking change which makes code smaller or more readable)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Testing (addition of new tests or update to current tests)
- [ ] Documentation (a change to man pages or other documentation)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the UnifyFS code style requirements.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commit messages are properly formatted.
